### PR TITLE
feat(flatpak): add selectable Torch extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,9 @@ download, installation, verification, signature, and publication instructions.
 - Upgraded the desktop backend to Python 3.14 and refreshed its dependency graph.
 - Made the ONNX implementation the sole Advanced Chords runtime while preserving its engine ID,
   default selection, package aliases, and pinned model; removed Crema, TensorFlow, and Keras.
-- Made default Flatpak packages resolve official CPU-only PyTorch 2.13.0 and torchaudio 2.11.0,
-  while retaining the explicit legacy NVIDIA CUDA 12.6 package path and adding size evidence.
+- Kept the Flatpak application CPU-only and split NVIDIA and legacy NVIDIA Torch stacks into
+  matching, marker-validated Core/Runtime extensions with independent size and hash evidence;
+  Flatpak builds can select CPU alone or either accelerator pair.
 
 ## [1.3.0] - 2026-08-28
 

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ pnpm sync:backend:legacy-nvidia -- --no-crema
 pnpm sync:backend:default -- --no-crema
 ```
 
-Both backend sync helpers recreate `apps/backend/.venv` from scratch to avoid stale mixed CUDA stacks when switching profiles. `uv` still reuses its shared cache, so after the first install, switching is usually much faster than a cold download. It is intended for cards like the GTX 1050 Ti. macOS, CI, and the default Linux setup remain unchanged.
+Both backend sync helpers recreate `apps/backend/.venv` from scratch to avoid stale mixed CUDA stacks when switching profiles. `uv` still reuses its shared cache, so after the first install, switching is usually much faster than a cold download. The legacy profile targets older NVIDIA GPU architectures. macOS, CI, and the default Linux setup remain unchanged.
 
 When the legacy marker is active, use the root `pnpm` scripts for backend work. They preserve the local Torch
 override; running raw `uv run` inside `apps/backend` can resync the default Torch stack and leave CUDA libraries mixed.
@@ -264,8 +264,10 @@ For faster Flatpak testing, skip the single-file bundle step:
 pnpm package:linux:flatpak -- --no-bundle
 ```
 
-macOS packaging writes a `.app` bundle and DMG. Flatpak packaging writes either a local `.flatpak`
-bundle or, with `--no-bundle`, a local repository install flow. Source distribution is the source
+macOS packaging writes a `.app` bundle and DMG. Flatpak packaging writes a CPU `.flatpak` plus
+matching NVIDIA and legacy NVIDIA Core/Runtime bundles or, with `--no-bundle`, a local repository
+install flow. Pass `--cpu`, `--nvidia`, or `--legacy-nvidia` to limit a Flatpak build; accelerator
+selections always include the CPU app, while no profile flags build all profiles. Source distribution is the source
 checkout/archive; the package commands do not create a separate source tarball.
 
 macOS packages require host `ffmpeg` / `ffprobe`; Flatpak routes backend lookups to sandbox wrappers at `/app/bin/ffmpeg` and `/app/bin/ffprobe`. TuneForge does not bundle FFmpeg. See [Packaging](./docs/PACKAGING.md) for output paths, package flags, local repo install commands, data-directory behavior, and size expectations.

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -48,13 +48,13 @@ This file is the source of truth for dependency and model-weight distribution po
 
 - **License:** BSD-3-Clause
 - **Source:** <https://github.com/pytorch/pytorch>
-- **Notes:** The default Linux Flatpak resolves official CPU-only PyTorch 2.13.0 and torchaudio 2.11.0 wheels for Python 3.14 x86_64 manylinux. The `--legacy-nvidia` Linux package option retains the NVIDIA CUDA 12.6 wheel closure for older supported NVIDIA GPUs. Its local verifier confirms wheel and CUDA-runtime versions, not GPU inference on every driver/hardware combination.
+- **Notes:** The Linux Flatpak application resolves the official CPU Torch base. Optional NVIDIA and legacy NVIDIA Core/Runtime extension pairs redistribute separate locked acceleration and compatibility closures. Marker and dependency checks do not prove inference on every driver/hardware combination.
 
 ### NVIDIA CUDA runtime wheels
 
 - **License:** NVIDIA Software License Agreement and related NVIDIA component terms; see each wheel's bundled license metadata.
-- **Source:** <https://download.pytorch.org/whl/cu126/> and NVIDIA CUDA component packages on PyPI.
-- **Notes:** Only the `--legacy-nvidia` Linux package option redistributes the CUDA 12.6 runtime wheel set pulled by PyTorch 2.13.0+cu126 and torchaudio 2.11.0+cu126, including cuBLAS, cuDNN, cuFFT, cuSOLVER, cuSPARSE, NCCL, NVRTC, NVTX, and related runtime libraries. Default Flatpaks reject CUDA, NVIDIA, and Triton packages from their generated Python closure.
+- **Source:** <https://download.pytorch.org/whl/> and NVIDIA CUDA component packages on PyPI.
+- **Notes:** The `com.tuneforge.desktop.Torch.Stack.Nvidia` and `com.tuneforge.desktop.Torch.Stack.LegacyNvidia` profiles each use a Core extension for their Torch-family binaries and a matching Runtime extension for the locked CUDA/NVIDIA closure, including cuBLAS, cuDNN, cuFFT, cuSOLVER, cuSPARSE, NCCL, NVRTC, NVTX, and related runtime libraries. The CPU application rejects CUDA, NVIDIA, and Triton packages.
 
 ### librosa
 

--- a/apps/backend/README.md
+++ b/apps/backend/README.md
@@ -143,7 +143,7 @@ The preload is stored at `$TORCH_HOME/hub/checkpoints/beat_this-small0.ckpt` whe
 
 ### Linux legacy NVIDIA profile
 
-If you are on Linux `x86_64` and the default PyTorch build does not support your NVIDIA GPU architecture (for example, Pascal cards like the GTX 1050 Ti), start from the standard sync above and then locally override `torch` / `torchaudio` with the older CUDA 12.6 wheels:
+If you are on Linux `x86_64` and the default PyTorch build does not support your NVIDIA GPU architecture, start from the standard sync above and then locally override `torch` / `torchaudio` with the older CUDA 12.6 wheels:
 
 ```sh
 uv pip install \

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -2,6 +2,7 @@ use std::{process::Child, sync::Mutex};
 
 #[cfg(not(target_os = "android"))]
 use std::{
+    collections::HashMap,
     env,
     ffi::OsString,
     fs,
@@ -14,6 +15,9 @@ use std::{
 };
 
 use tauri::{AppHandle, Manager, State};
+
+#[cfg(not(target_os = "android"))]
+use serde::{Deserialize, Serialize};
 
 mod file_dialog_scope;
 mod mobile_backend;
@@ -139,10 +143,143 @@ fn python_executable(python_root: &Path) -> PathBuf {
 }
 
 #[cfg(not(target_os = "android"))]
+#[derive(Debug, Deserialize, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+struct TorchExtensionProfile {
+    schema_version: u8,
+    contract: String,
+    profile: String,
+    role: String,
+    ref_id: String,
+    python_abi: String,
+    torch_version: String,
+    torchaudio_version: String,
+    triton_version: String,
+    cuda_family: String,
+    pair_id: String,
+}
+
+#[cfg(not(target_os = "android"))]
+const TORCH_EXTENSION_POLICY_JSON: &str = r#"{
+  "schema_version": 2,
+  "contract": "profile-pair-v1",
+  "python_abi": "cp314",
+  "profiles": {
+    "Nvidia": {
+      "ref_prefix": "com.tuneforge.desktop.Torch.Stack.Nvidia",
+      "torch_version": "2.13.0",
+      "torchaudio_version": "2.11.0",
+      "triton_version": "3.7.1",
+      "cuda_family": "13",
+      "pair_id": "5655bca4c785fdcc9390b2c3ed9c58b6a69eeee3b383d2aaf3f7903bbec3abc2"
+    },
+    "LegacyNvidia": {
+      "ref_prefix": "com.tuneforge.desktop.Torch.Stack.LegacyNvidia",
+      "torch_version": "2.13.0+cu126",
+      "torchaudio_version": "2.11.0+cu126",
+      "triton_version": "3.7.1",
+      "cuda_family": "12.6",
+      "pair_id": "112a80543c933ef4903aca2c0afcca91f21012c9e4ee1164222b08f118eba4f2"
+    }
+  }
+}"#;
+
+#[cfg(not(target_os = "android"))]
+#[derive(Deserialize)]
+struct TorchExtensionPolicy {
+    schema_version: u8,
+    contract: String,
+    python_abi: String,
+    profiles: HashMap<String, TorchExtensionPolicyProfile>,
+}
+
+#[cfg(not(target_os = "android"))]
+#[derive(Deserialize)]
+struct TorchExtensionPolicyProfile {
+    ref_prefix: String,
+    torch_version: String,
+    torchaudio_version: String,
+    triton_version: String,
+    cuda_family: String,
+    pair_id: String,
+}
+
+#[cfg(not(target_os = "android"))]
+fn expected_torch_extension_profile(name: &str, role: &str) -> TorchExtensionProfile {
+    let policy = serde_json::from_str::<TorchExtensionPolicy>(TORCH_EXTENSION_POLICY_JSON)
+        .expect("valid embedded Torch extension policy");
+    let profile = policy
+        .profiles
+        .get(name)
+        .expect("fixed Torch extension name");
+    let ref_role = match role {
+        "core" => "Core",
+        "runtime" => "Runtime",
+        _ => unreachable!("fixed Torch extension role"),
+    };
+    TorchExtensionProfile {
+        schema_version: policy.schema_version,
+        contract: policy.contract.clone(),
+        profile: name.to_string(),
+        role: role.to_string(),
+        ref_id: format!("{}.{ref_role}", profile.ref_prefix),
+        python_abi: policy.python_abi.clone(),
+        torch_version: profile.torch_version.clone(),
+        torchaudio_version: profile.torchaudio_version.clone(),
+        triton_version: profile.triton_version.clone(),
+        cuda_family: profile.cuda_family.clone(),
+        pair_id: profile.pair_id.clone(),
+    }
+}
+
+#[cfg(not(target_os = "android"))]
+fn valid_torch_extension_site_packages(root: &Path, name: &str) -> Option<PathBuf> {
+    let site_packages = root.join("site-packages");
+    let core = root.join("Core");
+    let runtime = root.join("Runtime");
+    if !root.is_dir()
+        || !site_packages.is_dir()
+        || !core.join("site-packages").is_dir()
+        || !runtime.join("site-packages").is_dir()
+    {
+        return None;
+    }
+    let core_profile =
+        serde_json::from_slice::<TorchExtensionProfile>(&fs::read(core.join("profile.json")).ok()?)
+            .ok()?;
+    let runtime_profile = serde_json::from_slice::<TorchExtensionProfile>(
+        &fs::read(runtime.join("profile.json")).ok()?,
+    )
+    .ok()?;
+    (core_profile == expected_torch_extension_profile(name, "core")
+        && runtime_profile == expected_torch_extension_profile(name, "runtime"))
+    .then_some(site_packages)
+}
+
+#[cfg(not(target_os = "android"))]
+fn select_torch_extension_site_packages(nvidia_root: &Path, legacy_root: &Path) -> Option<PathBuf> {
+    valid_torch_extension_site_packages(nvidia_root, "Nvidia")
+        .or_else(|| valid_torch_extension_site_packages(legacy_root, "LegacyNvidia"))
+}
+
+#[cfg(not(target_os = "android"))]
+fn mounted_torch_extension_site_packages() -> Option<PathBuf> {
+    let root = Path::new("/app/lib/tuneforge/backend/torch-extensions");
+    select_torch_extension_site_packages(&root.join("Nvidia"), &root.join("LegacyNvidia"))
+}
+
+#[cfg(not(target_os = "android"))]
 fn build_python_path(backend_root: &Path) -> Result<String, Box<dyn std::error::Error>> {
     let site_packages = backend_root.join("site-packages");
     let backend_source = backend_root.join("src");
-    let joined = env::join_paths([site_packages, backend_source])?;
+    let mut paths = Vec::new();
+    if cfg!(target_os = "linux") {
+        if let Some(extension) = mounted_torch_extension_site_packages() {
+            paths.push(extension);
+        }
+    }
+    paths.extend([site_packages, backend_source]);
+    let joined = env::join_paths(paths)?;
     Ok(joined.to_string_lossy().into_owned())
 }
 
@@ -508,6 +645,174 @@ mod tests {
         let paths = append_unique_paths(vec![first.clone()], [second.clone(), first.clone()]);
 
         assert_eq!(paths, vec![first, second]);
+    }
+
+    fn torch_extension_fixture(root: &Path, name: &str, valid: bool) -> PathBuf {
+        let extension = root.join(name);
+        fs::create_dir_all(extension.join("site-packages")).expect("create extension fixture");
+        for role in ["core", "runtime"] {
+            let role_dir = extension.join(if role == "core" { "Core" } else { "Runtime" });
+            fs::create_dir_all(role_dir.join("site-packages"))
+                .expect("create extension role fixture");
+            let profile = if valid {
+                serde_json::to_vec(&expected_torch_extension_profile(name, role))
+                    .expect("serialize profile")
+            } else {
+                br#"{"schema_version":0}"#.to_vec()
+            };
+            fs::write(role_dir.join("profile.json"), profile).expect("write extension marker");
+        }
+        extension
+    }
+
+    fn torch_test_root(name: &str) -> PathBuf {
+        let root = env::temp_dir().join(format!("tuneforge-torch-{name}-{}", std::process::id()));
+        let _ = fs::remove_dir_all(&root);
+        fs::create_dir_all(&root).expect("create torch test root");
+        root
+    }
+
+    #[test]
+    fn torch_extension_markers_match_literal_profile_role_contracts() {
+        for (profile, role, ref_id, pair_id) in [
+            (
+                "Nvidia",
+                "core",
+                "com.tuneforge.desktop.Torch.Stack.Nvidia.Core",
+                "5655bca4c785fdcc9390b2c3ed9c58b6a69eeee3b383d2aaf3f7903bbec3abc2",
+            ),
+            (
+                "Nvidia",
+                "runtime",
+                "com.tuneforge.desktop.Torch.Stack.Nvidia.Runtime",
+                "5655bca4c785fdcc9390b2c3ed9c58b6a69eeee3b383d2aaf3f7903bbec3abc2",
+            ),
+            (
+                "LegacyNvidia",
+                "core",
+                "com.tuneforge.desktop.Torch.Stack.LegacyNvidia.Core",
+                "112a80543c933ef4903aca2c0afcca91f21012c9e4ee1164222b08f118eba4f2",
+            ),
+            (
+                "LegacyNvidia",
+                "runtime",
+                "com.tuneforge.desktop.Torch.Stack.LegacyNvidia.Runtime",
+                "112a80543c933ef4903aca2c0afcca91f21012c9e4ee1164222b08f118eba4f2",
+            ),
+        ] {
+            let marker = expected_torch_extension_profile(profile, role);
+            assert_eq!(marker.schema_version, 2);
+            assert_eq!(marker.contract, "profile-pair-v1");
+            assert_eq!(marker.profile, profile);
+            assert_eq!(marker.role, role);
+            assert_eq!(marker.ref_id, ref_id);
+            assert_eq!(marker.pair_id, pair_id);
+        }
+    }
+
+    #[test]
+    fn torch_extension_selection_uses_cpu_without_extensions() {
+        let root = torch_test_root("none");
+        assert_eq!(
+            select_torch_extension_site_packages(&root.join("nvidia"), &root.join("legacy")),
+            None
+        );
+        fs::remove_dir_all(root).expect("remove fixture");
+    }
+
+    #[test]
+    fn torch_extension_selection_accepts_nvidia_only() {
+        let root = torch_test_root("nvidia");
+        let nvidia = torch_extension_fixture(&root, "Nvidia", true);
+        assert_eq!(
+            select_torch_extension_site_packages(&nvidia, &root.join("legacy")),
+            Some(nvidia.join("site-packages"))
+        );
+        fs::remove_dir_all(root).expect("remove fixture");
+    }
+
+    #[test]
+    fn torch_extension_selection_rejects_partial_profile() {
+        for missing_role in ["Core", "Runtime"] {
+            let root = torch_test_root(&format!("partial-{missing_role}"));
+            let nvidia = torch_extension_fixture(&root, "Nvidia", true);
+            fs::remove_dir_all(nvidia.join(missing_role)).expect("remove role fixture");
+            assert_eq!(
+                select_torch_extension_site_packages(&nvidia, &root.join("legacy")),
+                None
+            );
+            fs::remove_dir_all(root).expect("remove fixture");
+        }
+    }
+
+    #[test]
+    fn torch_extension_selection_accepts_legacy_only() {
+        let root = torch_test_root("legacy");
+        let legacy = torch_extension_fixture(&root, "LegacyNvidia", true);
+        assert_eq!(
+            select_torch_extension_site_packages(&root.join("nvidia"), &legacy),
+            Some(legacy.join("site-packages"))
+        );
+        fs::remove_dir_all(root).expect("remove fixture");
+    }
+
+    #[test]
+    fn torch_extension_selection_prefers_nvidia_when_both_are_valid() {
+        let root = torch_test_root("both");
+        let nvidia = torch_extension_fixture(&root, "Nvidia", true);
+        let legacy = torch_extension_fixture(&root, "LegacyNvidia", true);
+        assert_eq!(
+            select_torch_extension_site_packages(&nvidia, &legacy),
+            Some(nvidia.join("site-packages"))
+        );
+        fs::remove_dir_all(root).expect("remove fixture");
+    }
+
+    #[test]
+    fn torch_extension_selection_rejects_mismatched_pair() {
+        let root = torch_test_root("mismatched");
+        let nvidia = torch_extension_fixture(&root, "Nvidia", true);
+        let mut mismatched = expected_torch_extension_profile("Nvidia", "runtime");
+        mismatched.pair_id = "b".repeat(64);
+        fs::write(
+            nvidia.join("Runtime").join("profile.json"),
+            serde_json::to_vec(&mismatched).expect("serialize mismatched marker"),
+        )
+        .expect("write mismatched marker");
+        assert_eq!(
+            select_torch_extension_site_packages(&nvidia, &root.join("legacy")),
+            None
+        );
+        fs::remove_dir_all(root).expect("remove fixture");
+    }
+
+    #[test]
+    fn torch_extension_selection_rejects_cross_profile_pair() {
+        let root = torch_test_root("cross-profile");
+        let nvidia = torch_extension_fixture(&root, "Nvidia", true);
+        fs::write(
+            nvidia.join("Runtime").join("profile.json"),
+            serde_json::to_vec(&expected_torch_extension_profile("LegacyNvidia", "runtime"))
+                .expect("serialize cross-profile marker"),
+        )
+        .expect("write cross-profile marker");
+        assert_eq!(
+            select_torch_extension_site_packages(&nvidia, &root.join("legacy")),
+            None
+        );
+        fs::remove_dir_all(root).expect("remove fixture");
+    }
+
+    #[test]
+    fn torch_extension_selection_falls_through_malformed_nvidia_marker() {
+        let root = torch_test_root("malformed");
+        let nvidia = torch_extension_fixture(&root, "Nvidia", false);
+        let legacy = torch_extension_fixture(&root, "LegacyNvidia", true);
+        assert_eq!(
+            select_torch_extension_site_packages(&nvidia, &legacy),
+            Some(legacy.join("site-packages"))
+        );
+        fs::remove_dir_all(root).expect("remove fixture");
     }
 
     #[test]

--- a/docs/PACKAGING.md
+++ b/docs/PACKAGING.md
@@ -7,7 +7,8 @@ See [Third-party notices](../THIRD_PARTY_NOTICES.md) for the dependency and mode
 ## Release Artifact Truth
 
 - macOS packaging creates a local `.app` bundle and DMG. The app is unsigned and not notarized.
-- Linux Flatpak packaging creates either a single-file `.flatpak` bundle or, with `--no-bundle`, a local Flatpak repository install flow.
+- Linux Flatpak packaging creates the CPU app plus the selected optional Core/Runtime extension
+  pairs or, with `--no-bundle`, exports those same selected refs to a local Flatpak repository.
 - Source distribution is the repository checkout or source archive from version control. These package commands do not create a separate source tarball.
 - Packaging, model-bundle review, ONNX Advanced Chords, beat-this, CUDA/MPS/legacy NVIDIA GPU behavior, and install smoke checks are manual or special coverage unless a CI workflow explicitly runs them.
 - Release/default package commands do not use `--model-bundle`. Publishable model-bundled artifacts require an explicit review of the selected weights and package distribution evidence.
@@ -206,7 +207,10 @@ For faster local iteration, skip the single-file bundle step:
 pnpm package:linux:flatpak -- --no-bundle
 ```
 
-The Flatpak build generates local dependency source manifests, builds inside the SDK sandbox, and installs the backend under `/app/lib/tuneforge/backend`. It bundles `pactl` for microphone volume control but does not bundle FFmpeg.
+The Flatpak build generates local dependency source manifests, builds inside the SDK sandbox, and
+installs the CPU-only backend under `/app/lib/tuneforge/backend`. The same manifest exports optional
+NVIDIA and legacy NVIDIA Torch extensions from one repository. It bundles `pactl` for microphone
+volume control but does not bundle FFmpeg.
 
 ### Flatpak Build Caches and Evidence
 
@@ -229,8 +233,9 @@ refs can intentionally differ. `TUNEFORGE_FRONTEND_GIT_REF` overrides only the f
 
 Every successful build writes the ignored, sanitized
 `packaging/flatpak/generated/cache-report.json`. Override it with
-`FLATPAK_CACHE_REPORT_PATH`. It records cache integrity and usage, timings, and a deterministic
-installed-payload digest without exposing host cache paths.
+`FLATPAK_CACHE_REPORT_PATH`. It records cache integrity and usage, timings, a deterministic
+installed-payload digest, and the exact CPU, NVIDIA, and legacy NVIDIA repository commits
+without exposing host cache paths.
 
 Use a Linux x86_64 Flatpak host and never-before-used evidence roots for a cold/warm comparison:
 
@@ -259,7 +264,7 @@ Chordia dependency stacks by default. Feature flags are independent:
 ```sh
 pnpm package:linux -- --no-crema --no-beat-this --no-lv-chordia
 pnpm package:linux -- --no-advanced-chords --no-advanced-beats
-pnpm package:linux -- --legacy-nvidia --model-bundle
+pnpm package:linux -- --model-bundle
 pnpm package:linux -- --crema-onnx
 pnpm package:linux -- --crema-onnx --model-bundle
 ```
@@ -268,13 +273,22 @@ pnpm package:linux -- --crema-onnx --model-bundle
 - `--no-crema`, `--no-advanced-chords`, `--no-crema-onnx`, and `--no-advanced-chords-onnx` exclude it. Mixing enable and disable selectors is an error.
 - `--no-beat-this` / `--no-advanced-beats` exclude the Advanced Beat Analysis dependency stack.
 - `--lv-chordia` / `--no-lv-chordia` include or exclude LV Chordia and its five checkpoints.
-- `--legacy-nvidia` swaps in PyTorch 2.13.0 and torchaudio 2.11.0 CUDA 12.6 wheels and
-  grants broader GPU device access. LV Chordia remains included unless `--no-lv-chordia` is
-  passed.
 - `--model-bundle` includes required Demucs and Whisper weights, plus beat-this `small0` when beat-this dependencies are included. Advanced Chords model/state files are always included when that engine is enabled.
 - `--sandbox-data` keeps app data under Flatpak-private `/var/data/tuneforge` instead of the host XDG data directory.
+- With no profile flags, Flatpak packaging builds CPU, NVIDIA, and legacy NVIDIA. `--cpu` builds
+  only the CPU app; `--nvidia` or `--legacy-nvidia` builds the CPU app and that accelerator pair.
+  The profile flags may be combined in any order, and repeated flags have no effect.
 
-Like macOS packages, plain Flatpak packages rely on normal Demucs, Whisper, and beat-this caches unless `--model-bundle` is explicitly passed. The default Flatpak resolves official CPU-only PyTorch and torchaudio wheels for its Linux x86_64 Python runtime; its generated closure rejects CUDA, NVIDIA, and Triton packages. `--legacy-nvidia` retains the legacy CUDA closure for older supported NVIDIA GPUs. Advanced Chords always includes and seeds the exact pinned ONNX model and runtime-state files. Packages omit the Crema Python package, TensorFlow, Keras, and their HDF5 closure but retain LV Chordia's separately declared `h5py` dependency.
+Like macOS packages, plain Flatpak packages rely on normal Demucs, Whisper, and beat-this caches
+unless `--model-bundle` is explicitly passed. The application contains the official CPU Torch base;
+its generated closure rejects CUDA, NVIDIA, and Triton. Each NVIDIA profile is split across
+matching `Core` and `Runtime` refs beneath
+`com.tuneforge.desktop.Torch.Stack`. Core contains the profile-specific Torch binaries; Runtime
+contains its CUDA/NVIDIA closure. This generic profile-pair layout can also represent other GPU
+families without making Core binaries portable across backends. The launcher validates both immutable
+markers before starting Python, prefers NVIDIA over legacy NVIDIA, and prepends only the selected
+profile's merged `site-packages`; an incomplete, mismatched, or stale pair falls back to the CPU base.
+Advanced Chords always includes and seeds the exact pinned ONNX model and runtime-state files.
 When beat-this is excluded, desktop actions explicitly select Built-in Beat Analysis. An Advanced
 Beat Analysis request that ultimately fails during first-use download, load, runtime, or timing
 analysis fails the job rather than switching engines; explicit Built-in Beat Analysis requests do
@@ -289,18 +303,41 @@ library.
 
 ## Flatpak Local Repo Installs
 
-When `--no-bundle` is used, packaging exports a local Flatpak repository and prints the exact install commands. The local remote is `tuneforge-local` and the repository is `packaging/flatpak/repo`:
+When `--no-bundle` is used, packaging exports a local Flatpak repository and prints the exact
+commands for the selected profiles. The local remote is `tuneforge-local` and the repository is
+`packaging/flatpak/repo`:
 
 ```sh
 flatpak remote-add --user --if-not-exists --no-gpg-verify tuneforge-local packaging/flatpak/repo
 flatpak install --user --reinstall tuneforge-local com.tuneforge.desktop
+flatpak install --user --reinstall tuneforge-local com.tuneforge.desktop.Torch.Stack.Nvidia.Core com.tuneforge.desktop.Torch.Stack.Nvidia.Runtime
 ```
 
-Without `--no-bundle`, the Flatpak bundle is written under `packaging/flatpak/` as `Tuneforge_<version>_x86_64.flatpak`.
+Install the legacy NVIDIA pair by replacing `Nvidia` with `LegacyNvidia`. Install the CPU application
+first, then one or both complete accelerator pairs. When both pairs are installed, NVIDIA takes
+precedence over legacy NVIDIA.
+
+Without profile flags or `--no-bundle`, packaging writes five independent bundles under
+`packaging/flatpak/`:
+
+- `Tuneforge_<version>_x86_64.flatpak`;
+- `Tuneforge_<version>_Torch_Nvidia_Core_x86_64.flatpak`;
+- `Tuneforge_<version>_Torch_Nvidia_Runtime_x86_64.flatpak`;
+- `Tuneforge_<version>_Torch_LegacyNvidia_Core_x86_64.flatpak`;
+- `Tuneforge_<version>_Torch_LegacyNvidia_Runtime_x86_64.flatpak`.
+
+Selective builds write only the CPU bundle and the two bundles for each selected accelerator. The
+ignored `packaging/flatpak/generated/SHA256SUMS` contains exactly the artifacts from that run.
+Every run removes stale known default bundles and checksums before building. Each bundle
+must remain strictly below 2 GiB. The bundle step runs at most two independent bundle jobs
+concurrently; the Flatpak ref build remains sequential.
 
 ## Size Expectations
 
-Linux Flatpak bundles are large because they include Torch, beat-this, and the LV Chordia runtime. ONNX Advanced Chords is materially smaller than the removed TensorFlow stack. Report LV Chordia source/runtime bytes separately from its fixed 28,730,939 checkpoint bytes. `--legacy-nvidia` adds CUDA 12.6 runtime wheels, and `--model-bundle` adds other reviewed model weights.
+Linux Flatpak bundles are large because they include Torch, beat-this, and the LV Chordia runtime.
+Each NVIDIA profile's Torch Core and CUDA/NVIDIA Runtime live in separate optional extension bundles,
+so all four components are gated independently from the CPU application. `--model-bundle` adds other
+reviewed model weights.
 
 Every Flatpak build writes an ignored structured size report at
 `packaging/flatpak/generated/size-report.json` (override with `FLATPAK_SIZE_REPORT_PATH`). It uses

--- a/packaging/flatpak/com.tuneforge.desktop.yml
+++ b/packaging/flatpak/com.tuneforge.desktop.yml
@@ -7,6 +7,45 @@ sdk-extensions:
   - org.freedesktop.Sdk.Extension.llvm20
   - org.freedesktop.Sdk.Extension.rust-stable
 command: tuneforge
+add-extensions:
+  com.tuneforge.desktop.Torch.Stack.Nvidia:
+    directory: lib/tuneforge/backend/torch-extensions/Nvidia
+    version: stable
+    subdirectories: true
+    merge-dirs: site-packages
+    no-autodownload: true
+    autodelete: true
+  com.tuneforge.desktop.Torch.Stack.Nvidia.Core:
+    directory: lib/tuneforge/backend/torch-extensions/Nvidia/Core
+    version: stable
+    bundle: true
+    no-autodownload: true
+    autodelete: true
+  com.tuneforge.desktop.Torch.Stack.Nvidia.Runtime:
+    directory: lib/tuneforge/backend/torch-extensions/Nvidia/Runtime
+    version: stable
+    bundle: true
+    no-autodownload: true
+    autodelete: true
+  com.tuneforge.desktop.Torch.Stack.LegacyNvidia:
+    directory: lib/tuneforge/backend/torch-extensions/LegacyNvidia
+    version: stable
+    subdirectories: true
+    merge-dirs: site-packages
+    no-autodownload: true
+    autodelete: true
+  com.tuneforge.desktop.Torch.Stack.LegacyNvidia.Core:
+    directory: lib/tuneforge/backend/torch-extensions/LegacyNvidia/Core
+    version: stable
+    bundle: true
+    no-autodownload: true
+    autodelete: true
+  com.tuneforge.desktop.Torch.Stack.LegacyNvidia.Runtime:
+    directory: lib/tuneforge/backend/torch-extensions/LegacyNvidia/Runtime
+    version: stable
+    bundle: true
+    no-autodownload: true
+    autodelete: true
 finish-args:
   - --socket=wayland
   - --socket=fallback-x11
@@ -40,6 +79,8 @@ cleanup:
   - /bin/sccache
   - "*.a"
   - "*.la"
+cleanup-commands:
+  - mkdir -p ${FLATPAK_DEST}/lib/tuneforge/backend/torch-extensions/Nvidia ${FLATPAK_DEST}/lib/tuneforge/backend/torch-extensions/LegacyNvidia
 
 modules:
   - name: pnpm
@@ -213,6 +254,90 @@ modules:
       - rm -rf /run/build/python-runtime-deps/.pip-tmp
       - find /app/lib/tuneforge/backend/site-packages -type d -name __pycache__ -prune -exec rm -rf {} +
       - find /app/lib/tuneforge/backend/site-packages -type f -name '*.pyc' -delete
+
+  - name: nvidia-torch-core-extension
+    buildsystem: simple
+    build-options:
+      env:
+        LD_LIBRARY_PATH: /app/lib/tuneforge/backend/python/lib
+        TMPDIR: /run/build/nvidia-torch-core-extension/.pip-tmp
+    sources:
+      - generated/python-nvidia-torch-core-sources.json
+      - type: file
+        path: generated/python-nvidia-torch-core-requirements.txt
+      - type: file
+        path: generated/nvidia-torch-core-profile.json
+    build-commands:
+      - install -dm755 /app/lib/tuneforge/backend/torch-extensions/Nvidia/Core/site-packages
+      - install -dm700 /run/build/nvidia-torch-core-extension/.pip-tmp
+      - /app/lib/tuneforge/backend/python/bin/python3.14 -m pip install --no-index --no-deps --find-links=python-sources --target=/app/lib/tuneforge/backend/torch-extensions/Nvidia/Core/site-packages -r python-nvidia-torch-core-requirements.txt
+      - install -Dm644 nvidia-torch-core-profile.json /app/lib/tuneforge/backend/torch-extensions/Nvidia/Core/profile.json
+      - rm -rf /run/build/nvidia-torch-core-extension/.pip-tmp
+      - find /app/lib/tuneforge/backend/torch-extensions/Nvidia/Core/site-packages -type d -name __pycache__ -prune -exec rm -rf {} +
+      - find /app/lib/tuneforge/backend/torch-extensions/Nvidia/Core/site-packages -type f -name '*.pyc' -delete
+
+  - name: nvidia-torch-runtime-extension
+    buildsystem: simple
+    build-options:
+      env:
+        LD_LIBRARY_PATH: /app/lib/tuneforge/backend/python/lib
+        TMPDIR: /run/build/nvidia-torch-runtime-extension/.pip-tmp
+    sources:
+      - generated/python-nvidia-torch-runtime-sources.json
+      - type: file
+        path: generated/python-nvidia-torch-runtime-requirements.txt
+      - type: file
+        path: generated/nvidia-torch-runtime-profile.json
+    build-commands:
+      - install -dm755 /app/lib/tuneforge/backend/torch-extensions/Nvidia/Runtime/site-packages
+      - install -dm700 /run/build/nvidia-torch-runtime-extension/.pip-tmp
+      - /app/lib/tuneforge/backend/python/bin/python3.14 -m pip install --no-index --no-deps --find-links=python-sources --target=/app/lib/tuneforge/backend/torch-extensions/Nvidia/Runtime/site-packages -r python-nvidia-torch-runtime-requirements.txt
+      - install -Dm644 nvidia-torch-runtime-profile.json /app/lib/tuneforge/backend/torch-extensions/Nvidia/Runtime/profile.json
+      - rm -rf /run/build/nvidia-torch-runtime-extension/.pip-tmp
+      - find /app/lib/tuneforge/backend/torch-extensions/Nvidia/Runtime/site-packages -type d -name __pycache__ -prune -exec rm -rf {} +
+      - find /app/lib/tuneforge/backend/torch-extensions/Nvidia/Runtime/site-packages -type f -name '*.pyc' -delete
+
+  - name: legacy-nvidia-torch-core-extension
+    buildsystem: simple
+    build-options:
+      env:
+        LD_LIBRARY_PATH: /app/lib/tuneforge/backend/python/lib
+        TMPDIR: /run/build/legacy-nvidia-torch-core-extension/.pip-tmp
+    sources:
+      - generated/python-legacy-torch-core-sources.json
+      - type: file
+        path: generated/python-legacy-torch-core-requirements.txt
+      - type: file
+        path: generated/legacy-torch-core-profile.json
+    build-commands:
+      - install -dm755 /app/lib/tuneforge/backend/torch-extensions/LegacyNvidia/Core/site-packages
+      - install -dm700 /run/build/legacy-nvidia-torch-core-extension/.pip-tmp
+      - /app/lib/tuneforge/backend/python/bin/python3.14 -m pip install --no-index --no-deps --find-links=python-sources --target=/app/lib/tuneforge/backend/torch-extensions/LegacyNvidia/Core/site-packages -r python-legacy-torch-core-requirements.txt
+      - install -Dm644 legacy-torch-core-profile.json /app/lib/tuneforge/backend/torch-extensions/LegacyNvidia/Core/profile.json
+      - rm -rf /run/build/legacy-nvidia-torch-core-extension/.pip-tmp
+      - find /app/lib/tuneforge/backend/torch-extensions/LegacyNvidia/Core/site-packages -type d -name __pycache__ -prune -exec rm -rf {} +
+      - find /app/lib/tuneforge/backend/torch-extensions/LegacyNvidia/Core/site-packages -type f -name '*.pyc' -delete
+
+  - name: legacy-nvidia-torch-runtime-extension
+    buildsystem: simple
+    build-options:
+      env:
+        LD_LIBRARY_PATH: /app/lib/tuneforge/backend/python/lib
+        TMPDIR: /run/build/legacy-nvidia-torch-runtime-extension/.pip-tmp
+    sources:
+      - generated/python-legacy-torch-runtime-sources.json
+      - type: file
+        path: generated/python-legacy-torch-runtime-requirements.txt
+      - type: file
+        path: generated/legacy-torch-runtime-profile.json
+    build-commands:
+      - install -dm755 /app/lib/tuneforge/backend/torch-extensions/LegacyNvidia/Runtime/site-packages
+      - install -dm700 /run/build/legacy-nvidia-torch-runtime-extension/.pip-tmp
+      - /app/lib/tuneforge/backend/python/bin/python3.14 -m pip install --no-index --no-deps --find-links=python-sources --target=/app/lib/tuneforge/backend/torch-extensions/LegacyNvidia/Runtime/site-packages -r python-legacy-torch-runtime-requirements.txt
+      - install -Dm644 legacy-torch-runtime-profile.json /app/lib/tuneforge/backend/torch-extensions/LegacyNvidia/Runtime/profile.json
+      - rm -rf /run/build/legacy-nvidia-torch-runtime-extension/.pip-tmp
+      - find /app/lib/tuneforge/backend/torch-extensions/LegacyNvidia/Runtime/site-packages -type d -name __pycache__ -prune -exec rm -rf {} +
+      - find /app/lib/tuneforge/backend/torch-extensions/LegacyNvidia/Runtime/site-packages -type f -name '*.pyc' -delete
 
   - name: pulseaudio-client-tools
     buildsystem: meson

--- a/scripts/flatpak-cache.test.mjs
+++ b/scripts/flatpak-cache.test.mjs
@@ -1,22 +1,33 @@
 import assert from "node:assert/strict";
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, utimesSync, writeFileSync } from "node:fs";
+import { createHash } from "node:crypto";
+import { EventEmitter } from "node:events";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, utimesSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { spawnSync } from "node:child_process";
 import test from "node:test";
 import {
   cacheNamespace,
+  buildFlatpakBundles,
+  cleanupFlatpakBundleOutputs,
   compareCacheReports,
   digestBuildPayload,
   enforceFlatpakBundleSize,
+  flatpakArtifactSizeReport,
+  flatpakBundlePlan,
   flatpakSizeReport,
   frontendModuleInputPaths,
   isValidPnpmCacheReport,
   normalizeGeneratedModelBundleManifest,
   parseSccacheStats,
+  reconcileFlatpakOutputRefs,
   resolveCacheRoots,
   resolveFrontendGitRef,
   resolveSourceDateEpoch,
+  selectedFlatpakOutputRefs,
+  verifyFlatpakOutputRefs,
+  writeFlatpakChecksums,
+  withFreshFlatpakBundleOutputs,
 } from "./package-flatpak.mjs";
 import { parsePackageOptions } from "./package-options.mjs";
 
@@ -55,6 +66,14 @@ test("Flatpak cache namespace includes every invalidation dimension", () => {
   assert.equal(first.inputs.arch, "x86_64");
   assert.match(first.inputs.runtime, /org\.gnome\.Platform\/50/);
   assert.match(first.inputs.tools, /pnpm11\.22\.0-sccache0\.17\.0/);
+  const explicitAll = parsePackageOptions(["--legacy-nvidia", "--cpu", "--nvidia"], { platform: "linux" });
+  const noBundle = parsePackageOptions(["--no-bundle"], { platform: "linux" });
+  assert.equal(cacheNamespace(explicitAll, "1.3.0").name, first.name);
+  assert.equal(cacheNamespace(noBundle, "1.3.0").name, first.name);
+  assert.notEqual(
+    cacheNamespace(parsePackageOptions(["--cpu"], { platform: "linux" }), "1.3.0").name,
+    cacheNamespace(parsePackageOptions(["--nvidia"], { platform: "linux" }), "1.3.0").name,
+  );
 });
 
 test("Flatpak state and cache roots reject force-clean overlap and unsafe roots", () => {
@@ -133,6 +152,10 @@ test("Flatpak modules split frontend, Rust, and backend source boundaries", () =
       "tuneforge-desktop",
       "cpython-3.14",
       "python-runtime-deps",
+      "nvidia-torch-core-extension",
+      "nvidia-torch-runtime-extension",
+      "legacy-nvidia-torch-core-extension",
+      "legacy-nvidia-torch-runtime-extension",
       "pulseaudio-client-tools",
       "tuneforge-backend",
     ],
@@ -217,8 +240,15 @@ test("payload digest is metadata-complete, order-stable, and content-sensitive",
 });
 
 test("cold and warm reports compare payloads and propagate report errors", () => {
-  const cold = { namespace: "same", payload: { sha256: "abc", entryCount: 4 }, errors: [] };
-  const warm = { namespace: "same", payload: { sha256: "abc", entryCount: 4 }, errors: [] };
+  const refCommits = [
+    { id: "cpu", commitSha256: "a".repeat(64) },
+    { id: "nvidia-core", commitSha256: "b".repeat(64) },
+    { id: "nvidia-runtime", commitSha256: "c".repeat(64) },
+    { id: "legacy-nvidia-core", commitSha256: "d".repeat(64) },
+    { id: "legacy-nvidia-runtime", commitSha256: "e".repeat(64) },
+  ];
+  const cold = { namespace: "same", payload: { sha256: "abc", entryCount: 4 }, refCommits, errors: [] };
+  const warm = { namespace: "same", payload: { sha256: "abc", entryCount: 4 }, refCommits, errors: [] };
   assert.equal(compareCacheReports(cold, warm).equivalent, true);
   assert.deepEqual(
     compareCacheReports(cold, { ...warm, payload: { sha256: "def", entryCount: 4 } }).errors,
@@ -226,6 +256,59 @@ test("cold and warm reports compare payloads and propagate report errors", () =>
   );
   assert.equal(compareCacheReports(cold, { ...warm, errors: ["stats error"] }).equivalent, false);
   assert.equal(compareCacheReports(cold, { ...warm, namespace: "different" }).equivalent, false);
+  const changedNvidia = refCommits.map((entry) =>
+    entry.id === "nvidia-runtime" ? { ...entry, commitSha256: "f".repeat(64) } : entry);
+  assert.deepEqual(compareCacheReports(cold, { ...warm, refCommits: changedNvidia }).errors, [
+    "Cold and warm Flatpak output ref commits differ.",
+  ]);
+});
+
+test("Flatpak repo reconciliation removes only known refs and verifies the selected set", () => {
+  const known = selectedFlatpakOutputRefs(["cpu", "nvidia", "legacy-nvidia"]).map(({ ref }) => ref);
+  const obsolete = [
+    "runtime/com.tuneforge.desktop.Torch.Nvidia/x86_64/stable",
+    "runtime/com.tuneforge.desktop.Torch.LegacyNvidia/x86_64/stable",
+  ];
+  const unrelated = "runtime/org.example.Unrelated/x86_64/stable";
+  const deleted = [];
+  reconcileFlatpakOutputRefs({
+    repoPath: "/tmp/repo",
+    listRefs: () => [...known, ...obsolete, unrelated],
+    deleteRef: (_repo, ref) => deleted.push(ref),
+  });
+  assert.deepEqual(deleted.sort(), [...known, ...obsolete].sort());
+  assert.equal(deleted.includes(unrelated), false);
+
+  const selected = selectedFlatpakOutputRefs(["cpu", "nvidia"]);
+  const commits = verifyFlatpakOutputRefs({
+    repoPath: "/tmp/repo",
+    selectedProfiles: ["cpu", "nvidia"],
+    listRefs: () => [...selected.map(({ ref }) => ref), unrelated],
+    resolveCommit: (_repo, ref) => createHash("sha256").update(ref).digest("hex"),
+  });
+  assert.deepEqual(commits.map(({ id, ref }) => [id, ref]), [
+    ["cpu", "app/com.tuneforge.desktop/x86_64/stable"],
+    ["nvidia-core", "runtime/com.tuneforge.desktop.Torch.Stack.Nvidia.Core/x86_64/stable"],
+    ["nvidia-runtime", "runtime/com.tuneforge.desktop.Torch.Stack.Nvidia.Runtime/x86_64/stable"],
+  ]);
+  assert.ok(commits.every(({ commitSha256 }) => /^[a-f0-9]{64}$/.test(commitSha256)));
+  assert.throws(() => verifyFlatpakOutputRefs({
+    selectedProfiles: ["cpu"],
+    listRefs: () => [known[0], known[1]],
+  }), /Stale unselected Flatpak output ref/);
+  assert.throws(() => verifyFlatpakOutputRefs({
+    selectedProfiles: ["cpu", "nvidia"],
+    listRefs: () => [known[0]],
+  }), /Missing selected Flatpak output ref/);
+  assert.throws(() => verifyFlatpakOutputRefs({
+    selectedProfiles: ["cpu"],
+    listRefs: () => [known[0], obsolete[0]],
+  }), /Stale obsolete Flatpak output ref/);
+  assert.throws(() => verifyFlatpakOutputRefs({
+    selectedProfiles: ["cpu"],
+    listRefs: () => [known[0]],
+    resolveCommit: () => "not-a-digest",
+  }), /Malformed commit/);
 });
 
 test("Flatpak size report is deterministic, byte-based, and has no compliance claim without a bundle", () => {
@@ -305,4 +388,181 @@ test("Flatpak bundle size follows a symlink target and requires a regular file",
   } finally {
     rmSync(root, { recursive: true, force: true });
   }
+});
+
+test("Flatpak bundle plan emits the CPU app and exact runtime extension refs", () => {
+  const plan = flatpakBundlePlan({
+    applicationBundle: "/tmp/app.flatpak",
+    nvidiaCoreBundle: "/tmp/nvidia-core.flatpak",
+    nvidiaRuntimeBundle: "/tmp/nvidia-runtime.flatpak",
+    legacyCoreBundle: "/tmp/legacy-core.flatpak",
+    legacyRuntimeBundle: "/tmp/legacy-runtime.flatpak",
+  });
+  assert.deepEqual(plan.map(({ refId, runtime }) => [refId, runtime]), [
+    ["com.tuneforge.desktop", false],
+    ["com.tuneforge.desktop.Torch.Stack.Nvidia.Core", true],
+    ["com.tuneforge.desktop.Torch.Stack.Nvidia.Runtime", true],
+    ["com.tuneforge.desktop.Torch.Stack.LegacyNvidia.Core", true],
+    ["com.tuneforge.desktop.Torch.Stack.LegacyNvidia.Runtime", true],
+  ]);
+  const cpuOnly = flatpakBundlePlan({
+    selectedProfiles: ["cpu"],
+    applicationBundle: "/tmp/cpu-only.flatpak",
+  });
+  assert.deepEqual(cpuOnly.map(({ refId }) => refId), ["com.tuneforge.desktop"]);
+  const nvidiaOnly = flatpakBundlePlan({
+    selectedProfiles: ["cpu", "nvidia"],
+    applicationBundle: "/tmp/selected-app.flatpak",
+    nvidiaCoreBundle: "/tmp/selected-nvidia-core.flatpak",
+    nvidiaRuntimeBundle: "/tmp/selected-nvidia-runtime.flatpak",
+  });
+  assert.equal(nvidiaOnly.length, 3);
+  assert.ok(nvidiaOnly.every(({ refId }) => !refId.includes("LegacyNvidia")));
+  assert.throws(
+    () => flatpakBundlePlan({
+      applicationBundle: "/tmp/collision.flatpak",
+      nvidiaCoreBundle: "/tmp/collision.flatpak",
+    }),
+    /bundle output paths must be unique/,
+  );
+  assert.throws(
+    () => flatpakBundlePlan({
+      applicationBundle: "/tmp/one/collision.flatpak",
+      nvidiaCoreBundle: "/tmp/two/collision.flatpak",
+    }),
+    /checksum artifact basenames must be unique/,
+  );
+  let spawned = false;
+  assert.throws(
+    () => buildFlatpakBundles({
+      bundlePlan: [
+        { refId: "first", runtime: false, path: "/tmp/collision.flatpak" },
+        { refId: "second", runtime: true, path: "/tmp/collision.flatpak" },
+      ],
+      spawnProcess: () => {
+        spawned = true;
+      },
+    }),
+    /bundle output paths must be unique/,
+  );
+  assert.equal(spawned, false);
+  assert.match(packageScript, /Torch_Nvidia_x86_64\.flatpak/);
+  assert.match(packageScript, /Torch_LegacyNvidia_x86_64\.flatpak/);
+  assert.doesNotMatch(packageScript, /FLATPAK_(?:NVIDIA|LEGACY)_TORCH_BUNDLE_PATH/);
+});
+
+test("each Flatpak artifact has an independent size gate and stable checksum entry", () => {
+  const root = mkdtempSync(path.join(os.tmpdir(), "tuneforge-flatpak-artifacts-"));
+  try {
+    const artifacts = ["app.flatpak", "nvidia-core.flatpak", "nvidia-runtime.flatpak", "legacy-core.flatpak", "legacy-runtime.flatpak"].map((name, index) => {
+      const artifact = path.join(root, name);
+      writeFileSync(artifact, `artifact-${index}`);
+      const report = flatpakArtifactSizeReport(artifact);
+      assert.equal(report.compressedBundle.path, name);
+      assert.doesNotThrow(() => enforceFlatpakBundleSize(report));
+      return artifact;
+    });
+    const output = path.join(root, "SHA256SUMS");
+    const lines = writeFlatpakChecksums(artifacts, output);
+    assert.equal(lines.length, 5);
+    assert.deepEqual(lines.map((line) => line.split("  ")[1]), [
+      "app.flatpak",
+      "legacy-core.flatpak",
+      "legacy-runtime.flatpak",
+      "nvidia-core.flatpak",
+      "nvidia-runtime.flatpak",
+    ]);
+    assert.equal(readFileSync(output, "utf8"), `${lines.join("\n")}\n`);
+    const selectedLines = writeFlatpakChecksums(artifacts.slice(0, 3), output);
+    assert.equal(selectedLines.length, 3);
+    assert.deepEqual(selectedLines.map((line) => line.split("  ")[1]), [
+      "app.flatpak", "nvidia-core.flatpak", "nvidia-runtime.flatpak",
+    ]);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("no-bundle cleanup and bundle failures cannot preserve stale artifacts", async () => {
+  const root = mkdtempSync(path.join(os.tmpdir(), "tuneforge-flatpak-cleanup-"));
+  const bundlePlan = ["app.flatpak", "nvidia-core.flatpak", "nvidia-runtime.flatpak", "legacy-core.flatpak", "legacy-runtime.flatpak"].map((name) => ({
+    path: path.join(root, name),
+  }));
+  const checksumPath = path.join(root, "generated", "SHA256SUMS");
+  const obsoleteBundlePaths = [
+    path.join(root, "Tuneforge_1.4.0_Torch_Nvidia_x86_64.flatpak"),
+    path.join(root, "Tuneforge_1.4.0_Torch_LegacyNvidia_x86_64.flatpak"),
+  ];
+  const unrelatedOldOverride = path.join(root, "custom-old-nvidia-output.flatpak");
+  try {
+    mkdirSync(path.dirname(checksumPath), { recursive: true });
+    for (const { path: artifact } of bundlePlan) writeFileSync(artifact, "stale");
+    for (const artifact of obsoleteBundlePaths) writeFileSync(artifact, "obsolete");
+    writeFileSync(unrelatedOldOverride, "preserve");
+    writeFileSync(checksumPath, "stale\n");
+    cleanupFlatpakBundleOutputs({ bundlePlan, checksumPath, obsoleteBundlePaths });
+    assert.ok(bundlePlan.every(({ path: artifact }) => !existsSync(artifact)));
+    assert.ok(obsoleteBundlePaths.every((artifact) => !existsSync(artifact)));
+    assert.equal(existsSync(unrelatedOldOverride), true);
+    assert.equal(existsSync(checksumPath), false);
+
+    for (const artifact of obsoleteBundlePaths) writeFileSync(artifact, "obsolete");
+    await assert.rejects(
+      withFreshFlatpakBundleOutputs(() => {
+        writeFileSync(bundlePlan[0].path, "partial");
+        writeFileSync(checksumPath, "partial\n");
+        throw new Error("bundle failed");
+      }, { bundlePlan, checksumPath, obsoleteBundlePaths }),
+      /bundle failed/,
+    );
+    assert.ok(bundlePlan.every(({ path: artifact }) => !existsSync(artifact)));
+    assert.ok(obsoleteBundlePaths.every((artifact) => !existsSync(artifact)));
+    assert.equal(existsSync(checksumPath), false);
+
+    const protectedArtifact = bundlePlan[0].path;
+    writeFileSync(protectedArtifact, "keep-before-validation");
+    assert.throws(
+      () => cleanupFlatpakBundleOutputs({
+        bundlePlan: [{ path: protectedArtifact }, { path: protectedArtifact }],
+        checksumPath,
+        obsoleteBundlePaths: [],
+      }),
+      /bundle output paths must be unique/,
+    );
+    assert.equal(readFileSync(protectedArtifact, "utf8"), "keep-before-validation");
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("Flatpak bundle queue runs at most two jobs and terminates peers after failure", async () => {
+  const plan = Array.from({ length: 5 }, (_, index) => ({
+    refId: `ref-${index}`,
+    runtime: index > 0,
+    path: `/tmp/ref-${index}.flatpak`,
+  }));
+  let active = 0;
+  let maximum = 0;
+  const killed = [];
+  const spawnProcess = (_command, args) => {
+    const child = new EventEmitter();
+    child.kill = () => {
+      killed.push(args.at(-2));
+      queueMicrotask(() => child.emit("exit", null, "SIGTERM"));
+    };
+    active += 1;
+    maximum = Math.max(maximum, active);
+    const refId = args.at(-2);
+    queueMicrotask(() => {
+      active -= 1;
+      child.emit("exit", refId === "ref-1" ? 1 : 0, null);
+    });
+    return child;
+  };
+  await assert.rejects(
+    buildFlatpakBundles({ bundlePlan: plan, repository: "/tmp/repo", spawnProcess }),
+    /ref-1.*status 1/,
+  );
+  assert.equal(maximum, 2);
+  assert.ok(killed.length <= 1);
 });

--- a/scripts/flatpak-options.test.mjs
+++ b/scripts/flatpak-options.test.mjs
@@ -86,3 +86,34 @@ test("Advanced Chords package plan includes only pinned Crema ONNX files without
 test("Flatpak manifest allows the logind inhibition fallback", () => {
   assert.match(flatpakManifest, /^\s+- --system-talk-name=org\.freedesktop\.login1$/m);
 });
+
+test("Flatpak declares optional bundled Torch extension refs without widening devices", () => {
+  assert.match(flatpakManifest, /^app-id: com\.tuneforge\.desktop$/m);
+  const extensionSection = flatpakManifest.slice(
+    flatpakManifest.indexOf("add-extensions:"),
+    flatpakManifest.indexOf("finish-args:"),
+  );
+  assert.doesNotMatch(extensionSection, /^  com\.tuneforge\.desktop\.Torch:$/m);
+  assert.doesNotMatch(extensionSection, /^  com\.tuneforge\.desktop\.Torch\.(?:Nvidia|LegacyNvidia):$/m);
+  for (const profile of ["Nvidia", "LegacyNvidia"]) {
+    assert.match(flatpakManifest, new RegExp(`^  com\\.tuneforge\\.desktop\\.Torch\\.Stack\\.${profile}:$`, "m"));
+    assert.match(
+      flatpakManifest,
+      new RegExp(`directory: lib/tuneforge/backend/torch-extensions/${profile}`),
+    );
+    for (const role of ["Core", "Runtime"]) {
+      assert.match(
+        flatpakManifest,
+        new RegExp(`^  com\\.tuneforge\\.desktop\\.Torch\\.Stack\\.${profile}\\.${role}:$`, "m"),
+      );
+      assert.match(
+        flatpakManifest,
+        new RegExp(`directory: lib/tuneforge/backend/torch-extensions/${profile}/${role}`),
+      );
+    }
+  }
+  assert.equal((extensionSection.match(/^    bundle: true$/gm) ?? []).length, 4);
+  assert.equal((extensionSection.match(/^    merge-dirs: site-packages$/gm) ?? []).length, 2);
+  assert.match(flatpakManifest, /^  - --device=dri$/m);
+  assert.doesNotMatch(flatpakManifest, /--device=all|add-ld-path/);
+});

--- a/scripts/generate-flatpak-sources.mjs
+++ b/scripts/generate-flatpak-sources.mjs
@@ -1,5 +1,6 @@
 import { Buffer } from "node:buffer";
-import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { createHash } from "node:crypto";
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
@@ -12,6 +13,34 @@ const scriptDir = path.dirname(__filename);
 const workspaceRoot = path.resolve(scriptDir, "..");
 const flatpakRoot = path.join(workspaceRoot, "packaging", "flatpak");
 const generatedRoot = path.join(flatpakRoot, "generated");
+const obsoleteTorchStem = ["modern", "torch"].join("-");
+const obsoleteTorchExtensionOutputs = [
+  `${obsoleteTorchStem}-profile.json`,
+  ...["requirements.txt", "sources.json", "size-report.json"].map(
+    (suffix) => `python-${obsoleteTorchStem}-${suffix}`,
+  ),
+  ...["nvidia-torch", "legacy-torch"].flatMap((stem) => [
+    `${stem}-profile.json`,
+    ...["requirements.txt", "sources.json", "size-report.json"].map(
+      (suffix) => `python-${stem}-${suffix}`,
+    ),
+  ]),
+];
+const torchProfileOutputs = {
+  nvidia: ["nvidia-torch-core-profile.json", "nvidia-torch-runtime-profile.json",
+    ...["core", "runtime"].flatMap((role) => [
+      `python-nvidia-torch-${role}-requirements.txt`,
+      `python-nvidia-torch-${role}-sources.json`,
+      `python-nvidia-torch-${role}-size-report.json`,
+    ])],
+  "legacy-nvidia": ["legacy-torch-core-profile.json", "legacy-torch-runtime-profile.json",
+    "python-legacy-torch.in", "pylock.legacy-torch.toml",
+    ...["core", "runtime"].flatMap((role) => [
+      `python-legacy-torch-${role}-requirements.txt`,
+      `python-legacy-torch-${role}-sources.json`,
+      `python-legacy-torch-${role}-size-report.json`,
+    ])],
+};
 
 const cargoLockPath = path.join(workspaceRoot, "apps", "desktop", "src-tauri", "Cargo.lock");
 const pnpmLockPath = path.join(workspaceRoot, "pnpm-lock.yaml");
@@ -34,6 +63,20 @@ function writeGeneratedFile(fileName, contents) {
 
 function writeGeneratedJson(fileName, value) {
   writeGeneratedFile(fileName, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+export function removeObsoleteTorchExtensionOutputs(root = generatedRoot) {
+  for (const fileName of obsoleteTorchExtensionOutputs) {
+    rmSync(path.join(root, fileName), { force: true });
+  }
+}
+
+export function removeUnselectedTorchExtensionOutputs(selectedProfiles, root = generatedRoot) {
+  const selected = new Set(selectedProfiles);
+  for (const [profile, fileNames] of Object.entries(torchProfileOutputs)) {
+    if (selected.has(profile)) continue;
+    for (const fileName of fileNames) rmSync(path.join(root, fileName), { force: true });
+  }
 }
 
 function normalizePackageName(name) {
@@ -462,6 +505,7 @@ export function resolvePythonRuntimePackages(packages, { extras = [] } = {}) {
 
 function resolveNamedPythonPackages(packages, names) {
   const resolved = new Map();
+  const processedExtrasByPackage = new Map();
   const queue = names.map((name) => ({ name }));
   while (queue.length > 0) {
     const dependency = queue.shift();
@@ -470,11 +514,19 @@ function resolveNamedPythonPackages(packages, names) {
     }
     const pkg = findLockedPackage(packages, dependency);
     const identity = packageIdentity(pkg);
-    if (resolved.has(identity)) {
-      continue;
+    if (!resolved.has(identity)) {
+      resolved.set(identity, pkg);
+      queue.push(...pkg.dependencies);
     }
-    resolved.set(identity, pkg);
-    queue.push(...pkg.dependencies);
+    const processedExtras = processedExtrasByPackage.get(identity) ?? new Set();
+    processedExtrasByPackage.set(identity, processedExtras);
+    for (const extra of dependency.extras ?? []) {
+      if (processedExtras.has(extra)) continue;
+      processedExtras.add(extra);
+      const extraDependencies = pkg.optionalDependencies.get(extra);
+      if (!extraDependencies) throw new Error(`${pkg.name} ${pkg.version} does not define requested extra "${extra}"`);
+      queue.push(...extraDependencies);
+    }
   }
   return Array.from(resolved.values()).sort((left, right) => packageIdentity(left).localeCompare(packageIdentity(right)));
 }
@@ -583,24 +635,133 @@ export function assertDefaultCpuTorchClosure(packages) {
   }
 }
 
-function generatePythonSources() {
-  const lockedPackages = parseUvLock(readRequiredFile(uvLockPath));
-  let runtimePackages = resolvePythonRuntimePackages(lockedPackages, { extras: selectedPythonExtras });
-  runtimePackages = mergeLegacyTorchPackageSets(
-    runtimePackages,
-    packageOptions.legacyNvidia ? resolveLegacyTorchPackages() : resolveCpuTorchPackages(),
-  );
-  if (!packageOptions.legacyNvidia) assertDefaultCpuTorchClosure(runtimePackages);
-  const buildRequirementNames = ["setuptools", "wheel", ...(packageOptions.lvChordia ? ["hatchling"] : [])];
-  const buildPackages = resolveNamedPythonPackages(lockedPackages, buildRequirementNames);
-  const runtimePackageNames = new Set(runtimePackages.map((pkg) => packageIdentity(pkg)));
-  const packages = Array.from(
-    new Map([...runtimePackages, ...buildPackages].map((pkg) => [packageIdentity(pkg), pkg])).values(),
-  ).sort((left, right) => packageIdentity(left).localeCompare(packageIdentity(right)));
+export const TORCH_EXTENSION_PROFILES = Object.freeze({
+  Nvidia: Object.freeze({
+    ref_prefix: "com.tuneforge.desktop.Torch.Stack.Nvidia",
+    torch_version: "2.13.0",
+    torchaudio_version: "2.11.0",
+    triton_version: "3.7.1",
+    cuda_family: "13",
+    pair_id: "5655bca4c785fdcc9390b2c3ed9c58b6a69eeee3b383d2aaf3f7903bbec3abc2",
+  }),
+  LegacyNvidia: Object.freeze({
+    ref_prefix: "com.tuneforge.desktop.Torch.Stack.LegacyNvidia",
+    torch_version: "2.13.0+cu126",
+    torchaudio_version: "2.11.0+cu126",
+    triton_version: "3.7.1",
+    cuda_family: "12.6",
+    pair_id: "112a80543c933ef4903aca2c0afcca91f21012c9e4ee1164222b08f118eba4f2",
+  }),
+});
+
+function packageRows(packages) {
+  return packages instanceof Map ? Array.from(packages.values()) : packages;
+}
+
+function acceleratorPackageNames(packages) {
+  return packageRows(packages)
+    .map((pkg) => normalizePackageName(pkg.name))
+    .filter((name) => name.startsWith("cuda-") || name.startsWith("nvidia-"))
+    .sort();
+}
+
+function isAcceleratorPackage(pkg) {
+  const name = normalizePackageName(pkg.name);
+  return name.startsWith("cuda-") || name.startsWith("nvidia-");
+}
+
+export function partitionTorchExtensionPackages(packages) {
+  const rows = packageRows(packages);
+  const core = rows.filter((pkg) => !isAcceleratorPackage(pkg));
+  const runtime = rows.filter(isAcceleratorPackage);
+  const coreIds = new Set(core.map(packageIdentity));
+  const runtimeIds = new Set(runtime.map(packageIdentity));
+  if ([...coreIds].some((identity) => runtimeIds.has(identity))) {
+    throw new Error("Torch Core and Runtime package closures overlap");
+  }
+  const union = [...core, ...runtime].map(packageIdentity).sort();
+  const original = rows.map(packageIdentity).sort();
+  if (union.join("\n") !== original.join("\n")) {
+    throw new Error("Torch Core and Runtime package closures do not reproduce the locked profile");
+  }
+  const coreNames = new Set(core.map((pkg) => normalizePackageName(pkg.name)));
+  for (const required of ["torch", "torchaudio", "triton"]) {
+    if (!coreNames.has(required)) throw new Error(`Torch Core is missing ${required}`);
+  }
+  if (runtime.length === 0 || runtime.some((pkg) => !isAcceleratorPackage(pkg))) {
+    throw new Error("Torch Runtime must contain only CUDA/NVIDIA packages");
+  }
+  return { core, runtime };
+}
+
+export function torchExtensionPairId(profileName, packages) {
+  const rows = packageRows(packages).map((pkg) => {
+    const artifact = pkg.sha256 && pkg.fileName ? pkg : selectPythonArtifact(pkg);
+    return {
+      name: normalizePackageName(pkg.name),
+      version: pkg.version,
+      fileName: artifact.fileName,
+      sha256: artifact.sha256,
+    };
+  }).sort((left, right) =>
+    `${left.name}@${left.version}/${left.fileName}`.localeCompare(`${right.name}@${right.version}/${right.fileName}`));
+  return createHash("sha256")
+    .update(JSON.stringify({ contract: "profile-pair-v1", profile: profileName, packages: rows }))
+    .digest("hex");
+}
+
+export function assertTorchExtensionProfile(packages, profileName, expectedAcceleratorNames) {
+  const profile = TORCH_EXTENSION_PROFILES[profileName];
+  if (!profile) throw new Error(`Unknown Torch extension profile: ${profileName}`);
+  const rows = packageRows(packages);
+  const versions = new Map(rows.map((pkg) => [normalizePackageName(pkg.name), pkg.version]));
+  for (const [name, expected] of [
+    ["torch", profile.torch_version],
+    ["torchaudio", profile.torchaudio_version],
+  ]) {
+    if (versions.get(name) !== expected) {
+      throw new Error(`${profileName} requires ${name} ${expected}, found ${versions.get(name) ?? "none"}`);
+    }
+  }
+  if (profile.triton_version && versions.get("triton") !== profile.triton_version) {
+    throw new Error(`${profileName} requires triton ${profile.triton_version}`);
+  }
+  const acceleratorNames = acceleratorPackageNames(rows);
+  if (acceleratorNames.length === 0) throw new Error(`${profileName} has no CUDA/NVIDIA closure`);
+  if (expectedAcceleratorNames && acceleratorNames.join("\n") !== [...expectedAcceleratorNames].sort().join("\n")) {
+    throw new Error(`${profileName} CUDA/NVIDIA closure does not match the locked family`);
+  }
+  if (profileName === "LegacyNvidia" && acceleratorNames.some((name) => name.endsWith("-cu13"))) {
+    throw new Error("LegacyNvidia includes a CUDA 13 package");
+  }
+}
+
+export function torchExtensionMarker(profileName, role, pairId) {
+  const profile = TORCH_EXTENSION_PROFILES[profileName];
+  if (!profile) throw new Error(`Unknown Torch extension profile: ${profileName}`);
+  if (!["core", "runtime"].includes(role)) throw new Error(`Unknown Torch extension role: ${role}`);
+  if (!/^[a-f0-9]{64}$/.test(pairId)) throw new Error("Torch extension pair ID must be a SHA-256 digest");
+  const refRole = role[0].toUpperCase() + role.slice(1);
+  return {
+    schema_version: 2,
+    contract: "profile-pair-v1",
+    profile: profileName,
+    role,
+    ref_id: `${profile.ref_prefix}.${refRole}`,
+    python_abi: "cp314",
+    torch_version: profile.torch_version,
+    torchaudio_version: profile.torchaudio_version,
+    triton_version: profile.triton_version,
+    cuda_family: profile.cuda_family,
+    pair_id: pairId,
+  };
+}
+
+function writePythonPackageSet(prefix, packages) {
   const sourceByUrl = new Map();
   const artifactReport = [];
-
-  for (const pkg of packages) {
+  const rows = packageRows(packages);
+  for (const pkg of rows) {
     const artifact = selectPythonArtifact(pkg);
     sourceByUrl.set(artifact.url, {
       type: "file",
@@ -617,8 +778,70 @@ function generatePythonSources() {
       url: artifact.url,
     });
   }
+  writeGeneratedJson(`${prefix}-sources.json`, Array.from(sourceByUrl.values()).sort((a, b) => a.url.localeCompare(b.url)));
+  writeGeneratedFile(
+    `${prefix}-requirements.txt`,
+    `${rows.map((pkg) => `${pkg.name}==${pkg.version}`).sort().join("\n")}\n`,
+  );
+  writeGeneratedJson(
+    `${prefix}-size-report.json`,
+    artifactReport.sort((a, b) => (b.size ?? -1) - (a.size ?? -1) || a.name.localeCompare(b.name)),
+  );
+}
 
-  const sources = Array.from(sourceByUrl.values()).sort((left, right) => left.url.localeCompare(right.url));
+export function selectedTorchExtensionProfileSpecs(selectedProfiles, {
+  resolveNvidia,
+  resolveLegacy,
+}) {
+  const selected = new Set(selectedProfiles);
+  const specs = [];
+  if (selected.has("nvidia")) {
+    specs.push({ profileName: "Nvidia", stem: "nvidia", ...resolveNvidia() });
+  }
+  if (selected.has("legacy-nvidia")) {
+    specs.push({ profileName: "LegacyNvidia", stem: "legacy", ...resolveLegacy() });
+  }
+  return specs;
+}
+
+function generatePythonSources() {
+  const lockedPackages = parseUvLock(readRequiredFile(uvLockPath));
+  let runtimePackages = resolvePythonRuntimePackages(lockedPackages, { extras: selectedPythonExtras });
+  runtimePackages = mergeLegacyTorchPackageSets(
+    runtimePackages,
+    resolveCpuTorchPackages(),
+  );
+  assertDefaultCpuTorchClosure(runtimePackages);
+  const extensionSpecs = selectedTorchExtensionProfileSpecs(packageOptions.flatpakProfiles, {
+    resolveNvidia: () => ({
+      packages: resolveNamedPythonPackages(lockedPackages, ["torch", "torchaudio"]),
+      expectedAcceleratorNames: acceleratorPackageNames(lockedPackages),
+    }),
+    resolveLegacy: () => ({ packages: resolveLegacyTorchPackages() }),
+  });
+  let extensionPackageCount = 0;
+  for (const { profileName, stem, packages, expectedAcceleratorNames } of extensionSpecs) {
+    assertTorchExtensionProfile(packages, profileName, expectedAcceleratorNames);
+    const partition = partitionTorchExtensionPackages(packages);
+    const pairId = torchExtensionPairId(profileName, packages);
+    if (pairId !== TORCH_EXTENSION_PROFILES[profileName].pair_id) {
+      throw new Error(`${profileName} locked wheel manifest changed; update its reviewed pair ID and launcher marker`);
+    }
+    for (const role of ["core", "runtime"]) {
+      writePythonPackageSet(`python-${stem}-torch-${role}`, partition[role]);
+      writeGeneratedJson(
+        `${stem}-torch-${role}-profile.json`,
+        torchExtensionMarker(profileName, role, pairId),
+      );
+    }
+    extensionPackageCount += packageRows(packages).length;
+  }
+  const buildRequirementNames = ["setuptools", "wheel", ...(packageOptions.lvChordia ? ["hatchling"] : [])];
+  const buildPackages = resolveNamedPythonPackages(lockedPackages, buildRequirementNames);
+  const runtimePackageNames = new Set(runtimePackages.map((pkg) => packageIdentity(pkg)));
+  const packages = Array.from(
+    new Map([...runtimePackages, ...buildPackages].map((pkg) => [packageIdentity(pkg), pkg])).values(),
+  ).sort((left, right) => packageIdentity(left).localeCompare(packageIdentity(right)));
   const runtimeRequirements = packages
     .filter((pkg) => runtimePackageNames.has(packageIdentity(pkg)))
     .map((pkg) => `${pkg.name}==${pkg.version}`)
@@ -628,15 +851,11 @@ function generatePythonSources() {
     return `${pkg.name}==${pkg.version}`;
   });
 
-  writeGeneratedJson("python-sources.json", sources);
+  writePythonPackageSet("python", packages);
   writeGeneratedFile("python-build-requirements.txt", `${buildRequirements.join("\n")}\n`);
   writeGeneratedFile("python-requirements.txt", `${runtimeRequirements.join("\n")}\n`);
-  writeGeneratedJson(
-    "python-size-report.json",
-    artifactReport.sort((left, right) => (right.size ?? -1) - (left.size ?? -1) || left.name.localeCompare(right.name)),
-  );
 
-  return packages.length;
+  return packages.length + extensionPackageCount;
 }
 
 function generateModelBundleSources() {
@@ -669,6 +888,11 @@ export function cremaOnlyModelBundlePlan(plan) {
 }
 
 function main() {
+  removeObsoleteTorchExtensionOutputs();
+  removeUnselectedTorchExtensionOutputs(packageOptions.flatpakProfiles);
+  writeGeneratedJson("flatpak-profile-selection.json", {
+    profiles: packageOptions.flatpakProfiles,
+  });
   const cargoCount = generateCargoSources();
   const nodeCount = generateNodeSources();
   const pythonCount = generatePythonSources();

--- a/scripts/package-flatpak.mjs
+++ b/scripts/package-flatpak.mjs
@@ -14,10 +14,11 @@ import {
   writeFileSync,
 } from "node:fs";
 import path from "node:path";
-import { spawnSync } from "node:child_process";
+import { spawn, spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import { writeBuildInfoFile, writeResolvedBuildInfoFile } from "./build-info.mjs";
 import {
+  normalizeFlatpakProfiles,
   packageOptionsEnvironment,
   packageOptionsToGeneratorArgs,
   parsePackageOptions,
@@ -32,6 +33,20 @@ const baseManifestPath = path.join(flatpakRoot, "com.tuneforge.desktop.yml");
 const flatpakVersionInfoPath = path.join(flatpakRoot, "generated", "version.json");
 const frontendVersionInfoPath = path.join(flatpakRoot, "generated", "frontend-version.json");
 const appId = "com.tuneforge.desktop";
+const nvidiaTorchCoreRef = `${appId}.Torch.Stack.Nvidia.Core`;
+const nvidiaTorchRuntimeRef = `${appId}.Torch.Stack.Nvidia.Runtime`;
+const legacyTorchCoreRef = `${appId}.Torch.Stack.LegacyNvidia.Core`;
+const legacyTorchRuntimeRef = `${appId}.Torch.Stack.LegacyNvidia.Runtime`;
+const torchProfileArtifacts = {
+  nvidia: [
+    { id: "nvidia-core", refId: nvidiaTorchCoreRef, module: "nvidia-torch-core-extension" },
+    { id: "nvidia-runtime", refId: nvidiaTorchRuntimeRef, module: "nvidia-torch-runtime-extension" },
+  ],
+  "legacy-nvidia": [
+    { id: "legacy-nvidia-core", refId: legacyTorchCoreRef, module: "legacy-nvidia-torch-core-extension" },
+    { id: "legacy-nvidia-runtime", refId: legacyTorchRuntimeRef, module: "legacy-nvidia-torch-runtime-extension" },
+  ],
+};
 const localRepoRemote = "tuneforge-local";
 const cacheSchema = "flatpak-cache-v1";
 const sizeReportSchema = "flatpak-size-v1";
@@ -43,9 +58,37 @@ const repoDir = process.env.FLATPAK_REPO_DIR ?? path.join(flatpakRoot, "repo");
 const appVersion = JSON.parse(
   readFileSync(path.join(workspaceRoot, "apps", "desktop", "src-tauri", "tauri.conf.json"), "utf8"),
 ).version;
-const bundlePath =
-  process.env.FLATPAK_BUNDLE_PATH ??
-  path.join(flatpakRoot, `Tuneforge_${appVersion}_x86_64.flatpak`);
+const defaultBundlePath = path.join(flatpakRoot, `Tuneforge_${appVersion}_x86_64.flatpak`);
+const defaultNvidiaTorchCoreBundlePath =
+  path.join(flatpakRoot, `Tuneforge_${appVersion}_Torch_Nvidia_Core_x86_64.flatpak`);
+const defaultNvidiaTorchRuntimeBundlePath =
+  path.join(flatpakRoot, `Tuneforge_${appVersion}_Torch_Nvidia_Runtime_x86_64.flatpak`);
+const defaultLegacyTorchCoreBundlePath =
+  path.join(flatpakRoot, `Tuneforge_${appVersion}_Torch_LegacyNvidia_Core_x86_64.flatpak`);
+const defaultLegacyTorchRuntimeBundlePath =
+  path.join(flatpakRoot, `Tuneforge_${appVersion}_Torch_LegacyNvidia_Runtime_x86_64.flatpak`);
+const bundlePath = process.env.FLATPAK_BUNDLE_PATH ?? defaultBundlePath;
+const nvidiaTorchCoreBundlePath = process.env.FLATPAK_NVIDIA_TORCH_CORE_BUNDLE_PATH ??
+  defaultNvidiaTorchCoreBundlePath;
+const nvidiaTorchRuntimeBundlePath = process.env.FLATPAK_NVIDIA_TORCH_RUNTIME_BUNDLE_PATH ??
+  defaultNvidiaTorchRuntimeBundlePath;
+const legacyTorchCoreBundlePath = process.env.FLATPAK_LEGACY_TORCH_CORE_BUNDLE_PATH ??
+  defaultLegacyTorchCoreBundlePath;
+const legacyTorchRuntimeBundlePath = process.env.FLATPAK_LEGACY_TORCH_RUNTIME_BUNDLE_PATH ??
+  defaultLegacyTorchRuntimeBundlePath;
+const currentDefaultBundlePaths = [
+  defaultBundlePath,
+  defaultNvidiaTorchCoreBundlePath,
+  defaultNvidiaTorchRuntimeBundlePath,
+  defaultLegacyTorchCoreBundlePath,
+  defaultLegacyTorchRuntimeBundlePath,
+];
+const obsoleteDefaultBundlePaths = [
+  path.join(flatpakRoot, `Tuneforge_${appVersion}_Torch_Nvidia_x86_64.flatpak`),
+  path.join(flatpakRoot, `Tuneforge_${appVersion}_Torch_LegacyNvidia_x86_64.flatpak`),
+];
+const sha256SumsPath =
+  process.env.FLATPAK_SHA256SUMS_PATH ?? path.join(flatpakRoot, "generated", "SHA256SUMS");
 export const frontendModuleInputPaths = [
   "package.json", "pnpm-lock.yaml", "pnpm-workspace.yaml", "scripts/build-info.mjs",
   "packaging/flatpak/seed-pnpm-store.mjs", "apps/desktop/package.json",
@@ -90,9 +133,6 @@ function generatedManifestPath(options, cacheRoot, namespace, frontendGitRef) {
     "@@TUNEFORGE_FRONTEND_GIT_REF@@",
     frontendGitRef.replaceAll("'", "''"),
   );
-  if (options.legacyNvidia) {
-    manifest = replaceManifestFragment(manifest, "  - --device=dri\n", "  - --device=all\n");
-  }
   if (options.sandboxData) {
     manifest = replaceManifestFragment(manifest, "  - --filesystem=xdg-data/tuneforge:create\n", "");
     manifest = replaceManifestFragment(
@@ -198,7 +238,38 @@ export function manifestWithPackageOptions(manifest, options) {
         "      - mv /app/lib/tuneforge/backend/site-packages/share/lv-chordia/cache_data /app/lib/tuneforge/backend/python/share/lv-chordia/cache_data\n",
     );
   }
+  const selectedProfiles = new Set(normalizeFlatpakProfiles(options.flatpakProfiles));
+  for (const [profile, artifacts] of Object.entries(torchProfileArtifacts)) {
+    if (selectedProfiles.has(profile)) continue;
+    for (const { module, refId } of artifacts) {
+      result = removeManifestModule(result, module);
+      result = disableManifestExtensionBundle(result, refId);
+    }
+  }
   return result;
+}
+
+function removeManifestModule(contents, moduleName) {
+  const marker = `  - name: ${moduleName}\n`;
+  const start = contents.indexOf(marker);
+  if (start < 0) throw new Error(`Could not find Flatpak module: ${moduleName}`);
+  const next = contents.indexOf("\n  - name: ", start + marker.length);
+  if (next < 0) throw new Error(`Could not find module after Flatpak module: ${moduleName}`);
+  return contents.slice(0, start) + contents.slice(next + 1);
+}
+
+function disableManifestExtensionBundle(contents, refId) {
+  const marker = `  ${refId}:\n`;
+  const start = contents.indexOf(marker);
+  if (start < 0) throw new Error(`Could not find Flatpak extension declaration: ${refId}`);
+  const following = contents.slice(start + marker.length);
+  const next = following.search(/\n  \S/);
+  const end = next < 0 ? contents.length : start + marker.length + next;
+  const block = contents.slice(start, end);
+  if (!block.includes("    bundle: true\n")) {
+    throw new Error(`Could not find bundled Flatpak extension declaration: ${refId}`);
+  }
+  return contents.slice(0, start) + block.replace("    bundle: true\n", "") + contents.slice(end);
 }
 
 function replaceManifestFragment(contents, search, replacement) {
@@ -261,13 +332,15 @@ export function resolveFrontendGitRef({
 }
 
 export function cacheNamespace(options, version = appVersion) {
+  const buildOptions = { ...options, noBundle: false };
   const inputs = {
     schema: cacheSchema,
     app: `${appId}@${version}`,
     arch: "x86_64",
     runtime: "org.gnome.Platform/50",
     tools: "node26-llvm20-rust-stable-pnpm11.22.0-sccache0.17.0",
-    profile: packageOptionsEnvironment(options).TUNEFORGE_PACKAGE_OPTIONS,
+    profile: packageOptionsEnvironment(buildOptions).TUNEFORGE_PACKAGE_OPTIONS,
+    selectedProfiles: normalizeFlatpakProfiles(options.flatpakProfiles),
   };
   const digest = createHash("sha256").update(JSON.stringify(inputs)).digest("hex").slice(0, 16);
   return { name: `${cacheSchema}-${digest}`, inputs };
@@ -358,11 +431,110 @@ export function digestBuildPayload(root) {
   };
 }
 
+const knownFlatpakOutputRefs = [
+  { id: "cpu", ref: `app/${appId}/x86_64/stable` },
+  { id: "nvidia-core", ref: `runtime/${nvidiaTorchCoreRef}/x86_64/stable` },
+  { id: "nvidia-runtime", ref: `runtime/${nvidiaTorchRuntimeRef}/x86_64/stable` },
+  { id: "legacy-nvidia-core", ref: `runtime/${legacyTorchCoreRef}/x86_64/stable` },
+  { id: "legacy-nvidia-runtime", ref: `runtime/${legacyTorchRuntimeRef}/x86_64/stable` },
+];
+const obsoleteFlatpakOutputRefs = [
+  `runtime/${appId}.Torch.Nvidia/x86_64/stable`,
+  `runtime/${appId}.Torch.LegacyNvidia/x86_64/stable`,
+];
+
+export function selectedFlatpakOutputRefs(profiles) {
+  const selected = new Set(normalizeFlatpakProfiles(profiles));
+  return knownFlatpakOutputRefs.filter(({ id }) =>
+    id === "cpu" || selected.has(id.startsWith("legacy-") ? "legacy-nvidia" : "nvidia"));
+}
+
+function listOstreeRefs(repoPath) {
+  if (!existsSync(path.join(repoPath, "config"))) return [];
+  const result = spawnSync("ostree", [`--repo=${repoPath}`, "refs"], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  if (result.error?.code === "ENOENT") throw new Error("ostree is required to reconcile Flatpak output refs.");
+  if (result.status !== 0) throw new Error("Could not list Flatpak repository refs.");
+  return result.stdout.trim().split("\n").filter(Boolean);
+}
+
+function deleteOstreeRef(repoPath, ref) {
+  const result = spawnSync("ostree", [`--repo=${repoPath}`, "refs", "--delete", ref], {
+    stdio: "ignore",
+  });
+  if (result.error?.code === "ENOENT") throw new Error("ostree is required to reconcile Flatpak output refs.");
+  if (result.status !== 0) throw new Error(`Could not delete stale Flatpak output ref ${ref}`);
+}
+
+export function reconcileFlatpakOutputRefs({
+  repoPath = repoDir,
+  listRefs = listOstreeRefs,
+  deleteRef = deleteOstreeRef,
+} = {}) {
+  const present = new Set(listRefs(repoPath));
+  for (const ref of [
+    ...knownFlatpakOutputRefs.map((output) => output.ref),
+    ...obsoleteFlatpakOutputRefs,
+  ]) {
+    if (present.has(ref)) deleteRef(repoPath, ref);
+  }
+}
+
+function resolveOstreeCommit(repoPath, ref) {
+  const result = spawnSync("ostree", [`--repo=${repoPath}`, "rev-parse", ref], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  if (result.error?.code === "ENOENT") throw new Error("ostree is required to verify Flatpak output refs.");
+  if (result.status !== 0) throw new Error(`Could not resolve Flatpak output ref ${ref}`);
+  return result.stdout.trim();
+}
+
+export function verifyFlatpakOutputRefs({
+  repoPath = repoDir,
+  selectedProfiles,
+  listRefs = listOstreeRefs,
+  resolveCommit = resolveOstreeCommit,
+} = {}) {
+  const expected = selectedFlatpakOutputRefs(selectedProfiles);
+  const expectedRefs = new Set(expected.map(({ ref }) => ref));
+  const present = new Set(listRefs(repoPath));
+  for (const { ref } of expected) {
+    if (!present.has(ref)) throw new Error(`Missing selected Flatpak output ref ${ref}`);
+  }
+  for (const { ref } of knownFlatpakOutputRefs) {
+    if (!expectedRefs.has(ref) && present.has(ref)) {
+      throw new Error(`Stale unselected Flatpak output ref ${ref}`);
+    }
+  }
+  for (const ref of obsoleteFlatpakOutputRefs) {
+    if (present.has(ref)) throw new Error(`Stale obsolete Flatpak output ref ${ref}`);
+  }
+  return expected.map(({ id, ref }) => {
+    const commitSha256 = resolveCommit(repoPath, ref);
+    if (!/^[a-f0-9]{64}$/.test(commitSha256)) {
+      throw new Error(`Malformed commit for Flatpak output ref ${ref}`);
+    }
+    return { id, ref, commitSha256 };
+  });
+}
+
 export function compareCacheReports(cold, warm) {
   const errors = [...(cold.errors ?? []), ...(warm.errors ?? [])];
   if (cold.namespace !== warm.namespace) errors.push("Cold and warm cache namespaces differ.");
   if (cold.payload?.sha256 !== warm.payload?.sha256) errors.push("Cold and warm payload digests differ.");
-  return { schema: cacheSchema, equivalent: errors.length === 0, errors, cold: cold.payload, warm: warm.payload };
+  if (JSON.stringify(cold.refCommits) !== JSON.stringify(warm.refCommits)) {
+    errors.push("Cold and warm Flatpak output ref commits differ.");
+  }
+  return {
+    schema: cacheSchema,
+    equivalent: errors.length === 0,
+    errors,
+    cold: { payload: cold.payload, refCommits: cold.refCommits },
+    warm: { payload: warm.payload, refCommits: warm.refCommits },
+  };
 }
 
 function bytesToBinaryUnit(bytes) {
@@ -459,9 +631,161 @@ export function enforceFlatpakBundleSize(report) {
   }
   if (!report.compliance.targetMet) {
     process.stderr.write(
-      `Flatpak bundle ${bytesToBinaryUnit(report.compressedBundle.bytes)} is below the hard limit but misses the 1.9 GiB target; issue #490 remains incomplete.\n`,
+      `Flatpak bundle ${bytesToBinaryUnit(report.compressedBundle.bytes)} is below the hard limit but misses the 1.9 GiB target.\n`,
     );
   }
+}
+
+export function flatpakBundlePlan({
+  applicationBundle = bundlePath,
+  nvidiaCoreBundle = nvidiaTorchCoreBundlePath,
+  nvidiaRuntimeBundle = nvidiaTorchRuntimeBundlePath,
+  legacyCoreBundle = legacyTorchCoreBundlePath,
+  legacyRuntimeBundle = legacyTorchRuntimeBundlePath,
+  selectedProfiles = ["cpu", "nvidia", "legacy-nvidia"],
+} = {}) {
+  const selected = new Set(normalizeFlatpakProfiles(selectedProfiles));
+  const plan = [
+    { refId: appId, runtime: false, path: applicationBundle },
+  ];
+  if (selected.has("nvidia")) plan.push(
+    { refId: nvidiaTorchCoreRef, runtime: true, path: nvidiaCoreBundle },
+    { refId: nvidiaTorchRuntimeRef, runtime: true, path: nvidiaRuntimeBundle },
+  );
+  if (selected.has("legacy-nvidia")) plan.push(
+    { refId: legacyTorchCoreRef, runtime: true, path: legacyCoreBundle },
+    { refId: legacyTorchRuntimeRef, runtime: true, path: legacyRuntimeBundle },
+  );
+  validateFlatpakArtifactPaths(plan.map((artifact) => artifact.path));
+  return plan;
+}
+
+export function validateFlatpakArtifactPaths(artifacts) {
+  const resolved = artifacts.map((artifact) => path.resolve(artifact));
+  const duplicatePath = resolved.find((artifact, index) => resolved.indexOf(artifact) !== index);
+  if (duplicatePath) throw new Error(`Flatpak bundle output paths must be unique: ${duplicatePath}`);
+  const basenames = artifacts.map((artifact) => path.basename(artifact));
+  const duplicateBasename = basenames.find((artifact, index) => basenames.indexOf(artifact) !== index);
+  if (duplicateBasename) {
+    throw new Error(`Flatpak checksum artifact basenames must be unique: ${duplicateBasename}`);
+  }
+}
+
+export function cleanupFlatpakBundleOutputs({
+  bundlePlan = flatpakBundlePlan(),
+  checksumPath = sha256SumsPath,
+  obsoleteBundlePaths = [...currentDefaultBundlePaths, ...obsoleteDefaultBundlePaths],
+} = {}) {
+  validateFlatpakArtifactPaths(bundlePlan.map((artifact) => artifact.path));
+  for (const artifact of bundlePlan) rmSync(artifact.path, { force: true });
+  for (const artifact of obsoleteBundlePaths) rmSync(artifact, { force: true });
+  rmSync(checksumPath, { force: true });
+}
+
+export async function withFreshFlatpakBundleOutputs(operation, options = {}) {
+  cleanupFlatpakBundleOutputs(options);
+  try {
+    return await operation();
+  } catch (error) {
+    cleanupFlatpakBundleOutputs(options);
+    throw error;
+  }
+}
+
+export function buildFlatpakBundles({
+  bundlePlan = flatpakBundlePlan(),
+  repository = repoDir,
+  concurrency = 2,
+  spawnProcess = spawn,
+} = {}) {
+  validateFlatpakArtifactPaths(bundlePlan.map((artifact) => artifact.path));
+  if (!Number.isInteger(concurrency) || concurrency < 1) throw new Error("Bundle concurrency must be a positive integer");
+  return new Promise((resolve, reject) => {
+    const active = new Set();
+    let next = 0;
+    let failure;
+
+    const finish = () => {
+      if (active.size > 0) return;
+      if (failure) reject(failure);
+      else if (next === bundlePlan.length) resolve();
+    };
+    const fail = (error) => {
+      if (!failure) {
+        failure = error;
+        next = bundlePlan.length;
+        for (const child of active) child.kill("SIGTERM");
+      }
+      finish();
+    };
+    const launch = () => {
+      while (!failure && active.size < concurrency && next < bundlePlan.length) {
+        const artifact = bundlePlan[next++];
+        const args = [
+          "build-bundle",
+          ...(artifact.runtime ? ["--runtime"] : []),
+          "--arch=x86_64",
+          repository,
+          artifact.path,
+          artifact.refId,
+          "stable",
+        ];
+        const child = spawnProcess("flatpak", args, {
+          cwd: workspaceRoot,
+          stdio: "inherit",
+          env: process.env,
+        });
+        active.add(child);
+        let settled = false;
+        const settle = (error) => {
+          if (settled) return;
+          settled = true;
+          active.delete(child);
+          if (error) fail(error);
+          else {
+            launch();
+            finish();
+          }
+        };
+        child.once("error", (error) => settle(
+          error?.code === "ENOENT" ? new Error("Required command not found: flatpak") : error,
+        ));
+        child.once("exit", (status, signal) => settle(
+          status === 0
+            ? undefined
+            : new Error(`flatpak build-bundle for ${artifact.refId} failed (${signal ?? `status ${status}`})`),
+        ));
+      }
+      finish();
+    };
+    launch();
+  });
+}
+
+export function flatpakArtifactSizeReport(bundle) {
+  const compressedBundle = compressedBundleEvidence(bundle, true);
+  return {
+    schema: sizeReportSchema,
+    unit: "bytes",
+    compressedBundle,
+    compliance: {
+      hardLimitBytes: flatpakBundleHardLimitBytes,
+      hardLimitPassed: compressedBundle.bytes < flatpakBundleHardLimitBytes,
+      targetBytes: flatpakBundleTargetBytes,
+      targetMet: compressedBundle.bytes <= flatpakBundleTargetBytes,
+    },
+  };
+}
+
+export function writeFlatpakChecksums(artifacts, outputPath = sha256SumsPath) {
+  validateFlatpakArtifactPaths(artifacts);
+  const lines = artifacts
+    .map((artifact) => ({ name: path.basename(artifact), sha256: fileSha256(artifact) }))
+    .sort((left, right) => left.name.localeCompare(right.name))
+    .map(({ name, sha256 }) => `${sha256}  ${name}`);
+  mkdirSync(path.dirname(outputPath), { recursive: true });
+  writeFileSync(outputPath, `${lines.join("\n")}\n`);
+  return lines;
 }
 
 function printFlatpakSizeReport(report) {
@@ -496,7 +820,7 @@ export function isValidPnpmCacheReport(pnpm) {
   );
 }
 
-function cacheReport({ namespace, inputs, cacheRoot, timings, evidence }) {
+function cacheReport({ namespace, inputs, cacheRoot, timings, evidence, refCommits, selectedProfiles }) {
   const namespaceRoot = path.join(cacheRoot, namespace);
   const pnpmPath = path.join(namespaceRoot, "pnpm-report.json");
   const sccachePath = path.join(namespaceRoot, "sccache-stats.json");
@@ -516,14 +840,19 @@ function cacheReport({ namespace, inputs, cacheRoot, timings, evidence }) {
     pnpm: pnpm ?? { status: "module-cached" },
     sccache: sccache ?? { status: "module-cached" },
     timings,
+    selectedProfiles,
     payload: digestBuildPayload(path.join(buildDir, "files")),
+    refCommits,
     errors: [],
   };
 }
 
-function main() {
+async function main() {
   const startedAt = performance.now();
   const packageOptions = parsePackageOptions(process.argv.slice(2), { platform: "linux" });
+  const selectedProfiles = packageOptions.flatpakProfiles;
+  const bundlePlan = flatpakBundlePlan({ selectedProfiles });
+  cleanupFlatpakBundleOutputs({ bundlePlan });
   const skipBundle = packageOptions.noBundle || process.env.FLATPAK_NO_BUNDLE === "1";
   const evidence = process.env.FLATPAK_CACHE_EVIDENCE === "1";
   if (process.arch !== "x64") {
@@ -583,12 +912,16 @@ function main() {
   ];
   if (evidence) builderArgs.unshift("--disable-cache");
   const builderStartedAt = performance.now();
+  reconcileFlatpakOutputRefs();
   run("flatpak-builder", builderArgs);
+  const refCommits = verifyFlatpakOutputRefs({ selectedProfiles });
   const report = cacheReport({
     namespace: namespace.name,
     inputs: namespace.inputs,
     cacheRoot,
     evidence,
+    refCommits,
+    selectedProfiles,
     timings: {
       sourceGenerationSeconds: Number(sourceSeconds.toFixed(3)),
       builderSeconds: Number(((performance.now() - builderStartedAt) / 1_000).toFixed(3)),
@@ -608,6 +941,7 @@ function main() {
   if (skipBundle) {
     const sizeReportPath = process.env.FLATPAK_SIZE_REPORT_PATH ?? path.join(flatpakRoot, "generated", "size-report.json");
     const sizeReport = flatpakSizeReport({ includeBundle: false });
+    sizeReport.selectedProfiles = selectedProfiles;
     writeJson(sizeReportPath, sizeReport);
     printFlatpakSizeReport(sizeReport);
     process.stdout.write(`Flatpak repo exported to ${repoDir}\n`);
@@ -615,24 +949,37 @@ function main() {
       `Install with: flatpak remote-add --user --if-not-exists --no-gpg-verify ${localRepoRemote} ${repoDir}\n`,
     );
     process.stdout.write(`Then run: flatpak install --user --reinstall ${localRepoRemote} ${appId}\n`);
+    if (selectedProfiles.includes("nvidia")) process.stdout.write(
+      `Optional NVIDIA: flatpak install --user --reinstall ${localRepoRemote} ${nvidiaTorchCoreRef} ${nvidiaTorchRuntimeRef}\n`,
+    );
+    if (selectedProfiles.includes("legacy-nvidia")) process.stdout.write(
+      `Optional legacy NVIDIA: flatpak install --user --reinstall ${localRepoRemote} ${legacyTorchCoreRef} ${legacyTorchRuntimeRef}\n`,
+    );
     return;
   }
 
-  run("flatpak", ["build-bundle", "--arch=x86_64", repoDir, bundlePath, appId, "stable"]);
-  const sizeReportPath = process.env.FLATPAK_SIZE_REPORT_PATH ?? path.join(flatpakRoot, "generated", "size-report.json");
-  const sizeReport = flatpakSizeReport();
-  writeJson(sizeReportPath, sizeReport);
-  printFlatpakSizeReport(sizeReport);
-  enforceFlatpakBundleSize(sizeReport);
+  await withFreshFlatpakBundleOutputs(async () => {
+    await buildFlatpakBundles({ bundlePlan });
+    const sizeReportPath = process.env.FLATPAK_SIZE_REPORT_PATH ?? path.join(flatpakRoot, "generated", "size-report.json");
+    const sizeReport = {
+      ...flatpakSizeReport(),
+      selectedProfiles,
+      extensionBundles: bundlePlan.slice(1).map((artifact) => flatpakArtifactSizeReport(artifact.path)),
+    };
+    writeJson(sizeReportPath, sizeReport);
+    printFlatpakSizeReport(sizeReport);
+    enforceFlatpakBundleSize(sizeReport);
+    for (const report of sizeReport.extensionBundles) enforceFlatpakBundleSize(report);
+    writeFlatpakChecksums(bundlePlan.map((artifact) => artifact.path));
+  }, { bundlePlan });
 
-  process.stdout.write(`Flatpak bundle written to ${bundlePath}\n`);
+  for (const artifact of bundlePlan) process.stdout.write(`Flatpak bundle written to ${artifact.path}\n`);
+  process.stdout.write(`Flatpak checksums written to ${sha256SumsPath}\n`);
 }
 
 if (process.argv[1] && path.resolve(process.argv[1]) === __filename) {
-  try {
-    main();
-  } catch (error) {
+  main().catch((error) => {
     process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
     process.exitCode = 1;
-  }
+  });
 }

--- a/scripts/package-options.mjs
+++ b/scripts/package-options.mjs
@@ -13,29 +13,54 @@ const OPTION_ALIASES = new Map([
   ["--advanced-beats", ["beatThis", true]],
   ["--no-beat-this", ["beatThis", false]],
   ["--no-advanced-beats", ["beatThis", false]],
-  ["--legacy-nvidia", ["legacyNvidia", true]],
   ["--model-bundle", ["modelBundle", true]],
   ["--no-bundle", ["noBundle", true]],
   ["--sandbox-data", ["sandboxData", true]],
 ]);
+
+export const FLATPAK_PROFILE_IDS = Object.freeze(["cpu", "nvidia", "legacy-nvidia"]);
+const FLATPAK_PROFILE_FLAGS = new Map(FLATPAK_PROFILE_IDS.map((profile) => [`--${profile}`, profile]));
+
+export function normalizeFlatpakProfiles(profiles = FLATPAK_PROFILE_IDS) {
+  if (!Array.isArray(profiles)) {
+    throw new Error("Flatpak profiles must be an array.");
+  }
+  const selected = new Set(profiles);
+  for (const profile of selected) {
+    if (!FLATPAK_PROFILE_IDS.includes(profile)) {
+      throw new Error(`Unknown Flatpak profile: ${profile}`);
+    }
+  }
+  selected.add("cpu");
+  return FLATPAK_PROFILE_IDS.filter((profile) => selected.has(profile));
+}
 
 export function defaultPackageOptions() {
   return {
     crema: "onnx",
     lvChordia: true,
     beatThis: true,
-    legacyNvidia: false,
     modelBundle: false,
     noBundle: false,
     sandboxData: false,
+    flatpakProfiles: [...FLATPAK_PROFILE_IDS],
   };
 }
 
 export function parsePackageOptions(argv, { platform } = {}) {
   const options = defaultPackageOptions();
   const cremaSelections = new Set();
+  const profileSelections = new Set();
   for (const arg of argv) {
     if (arg === "--") {
+      continue;
+    }
+    const flatpakProfile = FLATPAK_PROFILE_FLAGS.get(arg);
+    if (flatpakProfile) {
+      if (platform === "mac") {
+        throw new Error(`${arg} is only supported for Linux Flatpak packaging.`);
+      }
+      profileSelections.add(flatpakProfile);
       continue;
     }
     const option = OPTION_ALIASES.get(arg);
@@ -50,6 +75,9 @@ export function parsePackageOptions(argv, { platform } = {}) {
       }
     }
     options[optionName] = value;
+  }
+  if (profileSelections.size > 0) {
+    options.flatpakProfiles = normalizeFlatpakProfiles([...profileSelections]);
   }
   return validatePackageOptions(options, { platform });
 }
@@ -68,9 +96,6 @@ export function validatePackageOptions(rawOptions, { platform } = {}) {
   if (!["onnx", "none"].includes(crema)) {
     throw new Error("Advanced Chords package selection must be onnx or none.");
   }
-  if (platform === "mac" && options.legacyNvidia) {
-    throw new Error("--legacy-nvidia is only supported for Linux packaging.");
-  }
   if (platform === "mac" && options.noBundle) {
     throw new Error("--no-bundle is only supported for Linux Flatpak packaging.");
   }
@@ -81,10 +106,10 @@ export function validatePackageOptions(rawOptions, { platform } = {}) {
     crema,
     lvChordia: Boolean(options.lvChordia),
     beatThis: Boolean(options.beatThis),
-    legacyNvidia: Boolean(options.legacyNvidia),
     modelBundle: Boolean(options.modelBundle),
     noBundle: Boolean(options.noBundle),
     sandboxData: Boolean(options.sandboxData),
+    flatpakProfiles: normalizeFlatpakProfiles(options.flatpakProfiles),
   };
 }
 
@@ -112,12 +137,10 @@ export function packageOptionsToGeneratorArgs(options) {
   } else {
     args.push("--no-lv-chordia");
   }
-  if (validated.legacyNvidia) {
-    args.push("--legacy-nvidia");
-  }
   if (validated.modelBundle) {
     args.push("--model-bundle");
   }
+  args.push(...validated.flatpakProfiles.map((profile) => `--${profile}`));
   return args;
 }
 

--- a/scripts/package-options.test.mjs
+++ b/scripts/package-options.test.mjs
@@ -1,17 +1,30 @@
 import assert from "node:assert/strict";
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
 import {
   assertDefaultCpuTorchClosure,
+  assertTorchExtensionProfile,
   markerMatchesFlatpakTarget,
   mergeLegacyTorchPackageSets,
   parseUvLock,
+  partitionTorchExtensionPackages,
+  removeObsoleteTorchExtensionOutputs,
+  removeUnselectedTorchExtensionOutputs,
   resolvePythonRuntimePackages,
+  selectedTorchExtensionProfileSpecs,
+  torchExtensionPairId,
+  torchExtensionMarker,
+  TORCH_EXTENSION_PROFILES,
   wheelScore,
 } from "./generate-flatpak-sources.mjs";
 import { manifestWithPackageOptions } from "./package-flatpak.mjs";
+import {
+  buildFlatpakProfileComponentInventory,
+  buildReleaseLicenseInventory,
+  formatReleaseLicenseInventory,
+} from "./release-license-inventory.mjs";
 import {
   assertCremaOnnxBundleLayout,
   assertLvChordiaBundleLayout,
@@ -20,6 +33,7 @@ import {
 } from "./prepare-bundle.mjs";
 import {
   backendSyncArgs,
+  normalizeFlatpakProfiles,
   packageOptionsEnvironment,
   packageOptionsToGeneratorArgs,
   parsePackageOptions,
@@ -27,10 +41,55 @@ import {
 
 const flatpakPipTmpDir = "/run/build/python-runtime-deps/.pip-tmp";
 
+test("Flatpak source generation removes only exact obsolete Torch extension outputs", () => {
+  const root = mkdtempSync(path.join(tmpdir(), "tuneforge-obsolete-torch-"));
+  const stem = ["modern", "torch"].join("-");
+  const obsolete = [
+    `${stem}-profile.json`,
+    ...["requirements.txt", "sources.json", "size-report.json"].map((suffix) => `python-${stem}-${suffix}`),
+  ];
+  try {
+    for (const file of [...obsolete, `python-${stem}-keep.txt`]) writeFileSync(path.join(root, file), "stale");
+    removeObsoleteTorchExtensionOutputs(root);
+    assert.ok(obsolete.every((file) => !existsSync(path.join(root, file))));
+    assert.equal(existsSync(path.join(root, `python-${stem}-keep.txt`)), true);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("Flatpak source generation removes stale unselected profiles and resolves selected profiles only", () => {
+  const root = mkdtempSync(path.join(tmpdir(), "tuneforge-selected-torch-"));
+  const stale = [
+    "python-nvidia-torch-core-requirements.txt",
+    "python-legacy-torch-runtime-sources.json",
+    "legacy-torch-core-profile.json",
+  ];
+  try {
+    for (const file of stale) writeFileSync(path.join(root, file), "stale");
+    removeUnselectedTorchExtensionOutputs(["cpu", "nvidia"], root);
+    assert.equal(existsSync(path.join(root, stale[0])), true);
+    assert.equal(existsSync(path.join(root, stale[1])), false);
+    assert.equal(existsSync(path.join(root, stale[2])), false);
+
+    let nvidiaCalls = 0;
+    let legacyCalls = 0;
+    const specs = selectedTorchExtensionProfileSpecs(["cpu", "nvidia"], {
+      resolveNvidia: () => { nvidiaCalls += 1; return { packages: ["nvidia"] }; },
+      resolveLegacy: () => { legacyCalls += 1; return { packages: ["legacy"] }; },
+    });
+    assert.deepEqual(specs.map(({ profileName }) => profileName), ["Nvidia"]);
+    assert.equal(nvidiaCalls, 1);
+    assert.equal(legacyCalls, 0);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
 function pythonRuntimeDepsModule(manifest) {
   return manifest.slice(
     manifest.indexOf("  - name: python-runtime-deps"),
-    manifest.indexOf("  - name: pulseaudio-client-tools"),
+    manifest.indexOf("  - name: nvidia-torch-core-extension"),
   );
 }
 
@@ -59,10 +118,10 @@ test("package option parser accepts feature aliases", () => {
       crema: "onnx",
       lvChordia: true,
       beatThis: true,
-      legacyNvidia: false,
       modelBundle: true,
       noBundle: false,
       sandboxData: false,
+      flatpakProfiles: ["cpu", "nvidia", "legacy-nvidia"],
     },
   );
   assert.deepEqual(
@@ -71,10 +130,10 @@ test("package option parser accepts feature aliases", () => {
       crema: "onnx",
       lvChordia: true,
       beatThis: true,
-      legacyNvidia: false,
       modelBundle: false,
       noBundle: false,
       sandboxData: false,
+      flatpakProfiles: ["cpu", "nvidia", "legacy-nvidia"],
     },
   );
 });
@@ -86,12 +145,14 @@ test("package option parser includes advanced dependencies by default", () => {
     crema: "onnx",
     lvChordia: true,
     beatThis: true,
-    legacyNvidia: false,
     modelBundle: false,
     noBundle: false,
     sandboxData: false,
+    flatpakProfiles: ["cpu", "nvidia", "legacy-nvidia"],
   });
-  assert.deepEqual(packageOptionsToGeneratorArgs(options), ["--crema", "--beat-this", "--lv-chordia"]);
+  assert.deepEqual(packageOptionsToGeneratorArgs(options), [
+    "--crema", "--beat-this", "--lv-chordia", "--cpu", "--nvidia", "--legacy-nvidia",
+  ]);
   assert.deepEqual(backendSyncArgs(options), [
     "sync",
     "--python",
@@ -122,7 +183,9 @@ test("package option parser accepts advanced dependency opt-outs", () => {
   assert.equal(options.beatThis, false);
   assert.equal(options.lvChordia, false);
   assert.equal(JSON.parse(packageOptionsEnvironment(options).TUNEFORGE_PACKAGE_OPTIONS).beatThis, false);
-  assert.deepEqual(packageOptionsToGeneratorArgs(options), ["--no-crema", "--no-beat-this", "--no-lv-chordia"]);
+  assert.deepEqual(packageOptionsToGeneratorArgs(options), [
+    "--no-crema", "--no-beat-this", "--no-lv-chordia", "--cpu", "--nvidia", "--legacy-nvidia",
+  ]);
   assert.deepEqual(backendSyncArgs(options), ["sync", "--python", "3.14", "--all-groups"]);
 });
 
@@ -134,7 +197,9 @@ test("Advanced Chords aliases select one ONNX profile and reject enable-disable 
     assert.equal(parsePackageOptions([alias], { platform: "mac" }).crema, "none");
   }
   const options = parsePackageOptions(["--crema", "--advanced-chords-onnx"], { platform: "mac" });
-  assert.deepEqual(packageOptionsToGeneratorArgs(options), ["--crema", "--beat-this", "--lv-chordia"]);
+  assert.deepEqual(packageOptionsToGeneratorArgs(options), [
+    "--crema", "--beat-this", "--lv-chordia", "--cpu", "--nvidia", "--legacy-nvidia",
+  ]);
   assert.deepEqual(backendSyncArgs(options).slice(4, 6), ["--extra", "advanced-chords"]);
   assert.throws(
     () => parsePackageOptions(["--crema", "--no-advanced-chords-onnx"], { platform: "mac" }),
@@ -186,11 +251,46 @@ test("Flatpak package options are scoped to the TuneForge module build environme
   );
   assert.doesNotMatch(optOutManifest, /site-packages\/share\/lv-chordia\/cache_data/);
   assert.doesNotMatch(optOutManifest, /python\/share\/lv-chordia\/cache_data/);
-  assert.doesNotMatch(optOutManifest, /pip install .*--no-deps/);
+  assert.doesNotMatch(pythonRuntimeDepsModule(optOutManifest), /pip install .*--no-deps/);
   assert.match(
     optOutManifest,
     /pip install --no-index --no-build-isolation .* -r python-requirements\.txt/,
   );
+});
+
+test("selective Flatpak manifests retain declarations and bundle only selected profile leaves", () => {
+  const baseManifest = readFileSync(
+    new URL("../packaging/flatpak/com.tuneforge.desktop.yml", import.meta.url),
+    "utf8",
+  );
+  for (const [args, includedModules, bundleCount] of [
+    [["--cpu"], [], 0],
+    [["--nvidia"], ["nvidia-torch-core-extension", "nvidia-torch-runtime-extension"], 2],
+    [["--legacy-nvidia"], ["legacy-nvidia-torch-core-extension", "legacy-nvidia-torch-runtime-extension"], 2],
+    [[], [
+      "nvidia-torch-core-extension", "nvidia-torch-runtime-extension",
+      "legacy-nvidia-torch-core-extension", "legacy-nvidia-torch-runtime-extension",
+    ], 4],
+  ]) {
+    const selected = manifestWithPackageOptions(
+      baseManifest,
+      parsePackageOptions(args, { platform: "linux" }),
+    );
+    for (const profile of ["Nvidia", "LegacyNvidia"]) {
+      assert.match(selected, new RegExp(`^  com\\.tuneforge\\.desktop\\.Torch\\.Stack\\.${profile}:$`, "m"));
+      for (const role of ["Core", "Runtime"]) {
+        assert.match(selected, new RegExp(`^  com\\.tuneforge\\.desktop\\.Torch\\.Stack\\.${profile}\\.${role}:$`, "m"));
+      }
+    }
+    const extensionSection = selected.slice(selected.indexOf("add-extensions:"), selected.indexOf("finish-args:"));
+    assert.equal((extensionSection.match(/^    bundle: true$/gm) ?? []).length, bundleCount);
+    for (const module of [
+      "nvidia-torch-core-extension", "nvidia-torch-runtime-extension",
+      "legacy-nvidia-torch-core-extension", "legacy-nvidia-torch-runtime-extension",
+    ]) {
+      assert.equal(selected.includes(`  - name: ${module}\n`), includedModules.includes(module));
+    }
+  }
 });
 
 test("Flatpak pip temporary files use disk-backed module storage for all Flatpak profiles", () => {
@@ -268,10 +368,31 @@ test("package option parser has no profile compatibility path", () => {
   );
 });
 
+test("package option parser selects normalized Flatpak profiles", () => {
+  const cases = [
+    [[], ["cpu", "nvidia", "legacy-nvidia"]],
+    [["--cpu"], ["cpu"]],
+    [["--nvidia"], ["cpu", "nvidia"]],
+    [["--legacy-nvidia"], ["cpu", "legacy-nvidia"]],
+    [["--legacy-nvidia", "--nvidia"], ["cpu", "nvidia", "legacy-nvidia"]],
+    [["--cpu", "--nvidia", "--cpu"], ["cpu", "nvidia"]],
+    [["--legacy-nvidia", "--cpu", "--nvidia"], ["cpu", "nvidia", "legacy-nvidia"]],
+  ];
+  for (const [args, expected] of cases) {
+    assert.deepEqual(parsePackageOptions(args, { platform: "linux" }).flatpakProfiles, expected);
+  }
+  assert.deepEqual(normalizeFlatpakProfiles(["legacy-nvidia", "cpu", "nvidia"]), [
+    "cpu", "nvidia", "legacy-nvidia",
+  ]);
+  for (const unsupported of ["--all", "--no-nvidia", "--amd", "--intel", "--nvida"]) {
+    assert.throws(() => parsePackageOptions([unsupported], { platform: "linux" }), /Unknown option/);
+  }
+});
+
 test("package option parser rejects platform-specific options", () => {
   assert.throws(
     () => parsePackageOptions(["--legacy-nvidia"], { platform: "mac" }),
-    /only supported for Linux/,
+    /only supported for Linux Flatpak/,
   );
   assert.throws(
     () => parsePackageOptions(["--no-bundle"], { platform: "mac" }),
@@ -283,34 +404,196 @@ test("package option parser rejects platform-specific options", () => {
   );
 });
 
-test("legacy nvidia includes LV Chordia by default", () => {
-  const options = parsePackageOptions(["--legacy-nvidia"], { platform: "linux" });
-
-  assert.deepEqual(
-    packageOptionsToGeneratorArgs(options),
-    ["--crema", "--beat-this", "--lv-chordia", "--legacy-nvidia"],
-  );
-  assert.deepEqual(backendSyncArgs(options), [
-    "sync",
-    "--python",
-    "3.14",
-    "--all-groups",
-    "--extra",
-    "advanced-chords",
-    "--extra",
-    "advanced-beats",
-    "--extra",
-    "lv-chordia",
-  ]);
-});
-
-test("Flatpak resolves official CPU Torch by default and preserves the legacy CUDA 12.6 resolver", () => {
+test("Flatpak resolves CPU, NVIDIA, and legacy NVIDIA Torch profiles", () => {
   const generator = readFileSync(new URL("./generate-flatpak-sources.mjs", import.meta.url), "utf8");
 
   assert.match(generator, /"torch==2\.13\.0\\ntorchaudio==2\.11\.0\\n"/);
   assert.match(generator, /"--python-version",\n\s+"3\.14"/);
   assert.match(generator, /"--torch-backend",\n\s+"cpu"/);
   assert.match(generator, /"--torch-backend",\n\s+"cu126"/);
+});
+
+test("Torch extension profiles enforce exact versions, closure, and immutable markers", () => {
+  const nvidia = [
+    { name: "torch", version: "2.13.0" },
+    { name: "torchaudio", version: "2.11.0" },
+    { name: "triton", version: "3.7.1" },
+    { name: "cuda-bindings", version: "13.3.1" },
+    { name: "nvidia-cudnn-cu13", version: "9.20.0.48" },
+  ];
+  assert.doesNotThrow(() => assertTorchExtensionProfile(
+    nvidia,
+    "Nvidia",
+    ["cuda-bindings", "nvidia-cudnn-cu13"],
+  ));
+  assert.throws(
+    () => assertTorchExtensionProfile(nvidia, "Nvidia", ["cuda-bindings"]),
+    /does not match the locked family/,
+  );
+  const legacy = [
+    { name: "torch", version: "2.13.0+cu126" },
+    { name: "torchaudio", version: "2.11.0+cu126" },
+    { name: "triton", version: "3.7.1" },
+    { name: "cuda-bindings", version: "12.9.7" },
+    { name: "nvidia-cublas-cu12", version: "12.6.4.1" },
+  ];
+  assert.doesNotThrow(() => assertTorchExtensionProfile(legacy, "LegacyNvidia"));
+  assert.throws(
+    () => assertTorchExtensionProfile(legacy.map((pkg) =>
+      pkg.name === "torch" ? { ...pkg, version: "0.0.0" } : pkg), "LegacyNvidia"),
+    /requires torch/,
+  );
+  assert.throws(
+    () => assertTorchExtensionProfile(
+      legacy.map((pkg) => pkg.name === "nvidia-cublas-cu12"
+        ? { name: "nvidia-cublas-cu13", version: pkg.version }
+        : pkg),
+      "LegacyNvidia",
+    ),
+    /CUDA 13 package/,
+  );
+  const hashableNvidia = nvidia.map((pkg, index) => ({
+    ...pkg,
+    fileName: `${pkg.name}.whl`,
+    sha256: String(index).padStart(64, "a"),
+  }));
+  const { core, runtime } = partitionTorchExtensionPackages(hashableNvidia);
+  assert.deepEqual(core.map((pkg) => pkg.name), ["torch", "torchaudio", "triton"]);
+  assert.deepEqual(runtime.map((pkg) => pkg.name), ["cuda-bindings", "nvidia-cudnn-cu13"]);
+  assert.deepEqual(
+    [...core, ...runtime].map((pkg) => `${pkg.name}@${pkg.version}`).sort(),
+    hashableNvidia.map((pkg) => `${pkg.name}@${pkg.version}`).sort(),
+  );
+  const pairId = torchExtensionPairId("Nvidia", hashableNvidia);
+  assert.match(pairId, /^[a-f0-9]{64}$/);
+  assert.deepEqual(torchExtensionMarker("Nvidia", "core", pairId), {
+    schema_version: 2,
+    contract: "profile-pair-v1",
+    profile: "Nvidia",
+    role: "core",
+    ref_id: "com.tuneforge.desktop.Torch.Stack.Nvidia.Core",
+    python_abi: "cp314",
+    torch_version: "2.13.0",
+    torchaudio_version: "2.11.0",
+    triton_version: "3.7.1",
+    cuda_family: "13",
+    pair_id: pairId,
+  });
+});
+
+test("Rust launcher and Flatpak generator share the exact Torch extension contract", () => {
+  const rust = readFileSync(
+    new URL("../apps/desktop/src-tauri/src/lib.rs", import.meta.url),
+    "utf8",
+  );
+  const embedded = /const TORCH_EXTENSION_POLICY_JSON: &str = r#"([\s\S]*?)"#;/.exec(rust);
+  assert.ok(embedded, "Rust Torch extension policy JSON is missing");
+  const policy = JSON.parse(embedded[1]);
+  assert.deepEqual(Object.keys(policy.profiles).sort(), Object.keys(TORCH_EXTENSION_PROFILES).sort());
+  for (const [profileName, generatedProfile] of Object.entries(TORCH_EXTENSION_PROFILES)) {
+    assert.deepEqual(policy.profiles[profileName], generatedProfile);
+    for (const role of ["core", "runtime"]) {
+      const marker = torchExtensionMarker(profileName, role, generatedProfile.pair_id);
+      assert.equal(marker.schema_version, policy.schema_version);
+      assert.equal(marker.contract, policy.contract);
+      assert.equal(marker.python_abi, policy.python_abi);
+      assert.equal(marker.profile, profileName);
+      assert.equal(marker.role, role);
+      assert.equal(marker.ref_id, `${generatedProfile.ref_prefix}.${role === "core" ? "Core" : "Runtime"}`);
+    }
+  }
+});
+
+test("release inventory follows the normalized Flatpak profile selection", () => {
+  for (const [profiles, expectedIds] of [
+    [["cpu"], ["cpu"]],
+    [["nvidia"], ["cpu", "nvidia-core", "nvidia-runtime"]],
+    [["legacy-nvidia"], ["cpu", "legacy-nvidia-core", "legacy-nvidia-runtime"]],
+    [["legacy-nvidia", "cpu", "nvidia"], [
+      "cpu", "nvidia-core", "nvidia-runtime", "legacy-nvidia-core", "legacy-nvidia-runtime",
+    ]],
+  ]) {
+    const inventory = buildReleaseLicenseInventory({ flatpakProfiles: profiles });
+    const policy = inventory.modelPolicy;
+    assert.deepEqual(policy.flatpakTorchProfiles.map(({ id }) => id), expectedIds);
+    assert.equal(policy.flatpakTorchProfiles.find(({ id }) => id === "cpu").cudaFamily, null);
+    assert.equal(policy.flatpakChecksumContents.length, expectedIds.length);
+    assert.ok(policy.flatpakChecksumContents.every((artifact) => artifact.endsWith(".flatpak")));
+    const human = formatReleaseLicenseInventory(inventory);
+    assert.doesNotMatch(human, /Torch undefined|Torchaudio undefined|Triton undefined/);
+    if (expectedIds.some((id) => id.endsWith("runtime"))) {
+      assert.match(human, /CUDA\/NVIDIA runtime family/);
+    }
+    assert.deepEqual(JSON.parse(JSON.stringify(inventory)).modelPolicy.flatpakChecksumContents,
+      policy.flatpakChecksumContents);
+  }
+});
+
+test("Flatpak profile inventory uses exact generated artifacts and fails closed on license gaps", () => {
+  const root = mkdtempSync(path.join(tmpdir(), "tuneforge-flatpak-license-inventory-"));
+  try {
+    const writeProfile = (prefix, packages) => {
+      const artifacts = packages.map(({ name, version }, index) => {
+        const fileName = `${prefix}-${name}.whl`;
+        const url = `https://example.invalid/${fileName}`;
+        return { name, version, fileName, url, sha256: String(index + 1).repeat(64) };
+      });
+      writeFileSync(path.join(root, `${prefix}-requirements.txt`),
+        `${packages.map(({ name, version }) => `${name}==${version}`).join("\n")}\n`);
+      writeFileSync(path.join(root, `${prefix}-sources.json`), JSON.stringify(artifacts.map((artifact) => ({
+        url: artifact.url, sha256: artifact.sha256, "dest-filename": artifact.fileName,
+      }))));
+      writeFileSync(path.join(root, `${prefix}-size-report.json`), JSON.stringify(artifacts));
+    };
+    writeProfile("python", [
+      { name: "torch", version: "2.13.0" },
+      { name: "wheel", version: "0.48.0" },
+      { name: "pathspec", version: "1.1.1" },
+    ]);
+    writeFileSync(path.join(root, "python-build-requirements.txt"), "wheel==0.48.0\n");
+    writeProfile("python-nvidia-torch-core", [{ name: "torch", version: "2.13.0" }]);
+    writeProfile("python-legacy-torch-core", [{ name: "torch", version: "2.13.0+cu126" }]);
+    writeProfile("python-nvidia-torch-runtime", [
+      { name: "cuda-bindings", version: "13.3.1" },
+      { name: "nvidia-cublas", version: "13.1.1.3" },
+    ]);
+    writeProfile("python-legacy-torch-runtime", [
+      { name: "cuda-bindings", version: "12.9.7" },
+      { name: "nvidia-cublas-cu12", version: "12.6.4.1" },
+    ]);
+    const fixtureLicenses = {
+      "cuda-bindings": "Apache-2.0", pathspec: "MPL-2.0", torch: "BSD-3-Clause", wheel: "MIT",
+    };
+    const inventory = buildFlatpakProfileComponentInventory({
+      generatedRoot: root,
+      strict: true,
+      licenseMetadata: fixtureLicenses,
+    });
+    assert.deepEqual(inventory.profiles.map((profile) => profile.id), [
+      "cpu", "nvidia-core", "nvidia-runtime", "legacy-nvidia-core", "legacy-nvidia-runtime",
+    ]);
+    assert.equal(inventory.profiles[0].components[0].sha256, "1".repeat(64));
+    const runtimeComponents = inventory.profiles.find(({ id }) => id === "nvidia-runtime").components;
+    assert.equal(runtimeComponents.find(({ name }) => name === "cuda-bindings").license, "Apache-2.0");
+    assert.equal(
+      runtimeComponents.find(({ name }) => name === "nvidia-cublas").license,
+      "LicenseRef-NVIDIA-Software-License",
+    );
+    writeFileSync(path.join(root, "flatpak-profile-selection.json"), JSON.stringify({ profiles: ["cpu"] }));
+    assert.deepEqual(buildFlatpakProfileComponentInventory({
+      generatedRoot: root,
+      strict: true,
+      licenseMetadata: fixtureLicenses,
+    }).profiles.map(({ id }) => id), ["cpu"]);
+    assert.throws(
+      () => buildFlatpakProfileComponentInventory({
+        generatedRoot: root, strict: true, licenseMetadata: { torch: "BSD-3-Clause", wheel: "MIT" },
+      }),
+      /pathspec 1\.1\.1 lacks reviewed license metadata/,
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
 });
 
 test("Flatpak CPU resolver replaces the CUDA closure and rejects unwanted accelerator families", () => {
@@ -458,24 +741,13 @@ test("Flatpak wheel selection accepts CPython 3.14, compatible abi3, and univers
   assert.equal(wheelScore("runtime-1.0-cp314-cp314-macosx_14_0_arm64.whl"), -1);
 });
 
-test("legacy nvidia supports advanced dependency opt-outs", () => {
-  const options = parsePackageOptions(
-    ["--legacy-nvidia", "--no-advanced-chords", "--no-advanced-beats", "--no-lv-chordia"],
-    { platform: "linux" },
-  );
-
-  assert.deepEqual(
-    packageOptionsToGeneratorArgs(options),
-    ["--no-crema", "--no-beat-this", "--no-lv-chordia", "--legacy-nvidia"],
-  );
-  assert.deepEqual(backendSyncArgs(options), ["sync", "--python", "3.14", "--all-groups"]);
-});
-
 test("sandbox data is Flatpak-only and does not affect dependency generation beyond defaults", () => {
   const options = parsePackageOptions(["--sandbox-data"], { platform: "linux" });
 
   assert.equal(options.sandboxData, true);
-  assert.deepEqual(packageOptionsToGeneratorArgs(options), ["--crema", "--beat-this", "--lv-chordia"]);
+  assert.deepEqual(packageOptionsToGeneratorArgs(options), [
+    "--crema", "--beat-this", "--lv-chordia", "--cpu", "--nvidia", "--legacy-nvidia",
+  ]);
   assert.deepEqual(backendSyncArgs(options), [
     "sync",
     "--python",

--- a/scripts/release-license-inventory.mjs
+++ b/scripts/release-license-inventory.mjs
@@ -1,9 +1,11 @@
 import { spawnSync } from "node:child_process";
+import { existsSync, readFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { buildModelBundlePlan, DEFAULT_LYRICS_MODEL } from "./model-bundle-metadata.mjs";
 import {
   defaultPackageOptions,
+  normalizeFlatpakProfiles,
   packageOptionsToGeneratorArgs,
 } from "./package-options.mjs";
 
@@ -12,6 +14,113 @@ const scriptDir = path.dirname(__filename);
 const workspaceRoot = path.resolve(scriptDir, "..");
 const LV_CHORDIA_CHECKPOINT_BYTES = 28_730_939;
 const LV_CHORDIA_SOURCE_REVISION = "9d7de7bbf45efa6731ec8dc62d35280f141c0702";
+const flatpakGeneratedRoot = path.join(workspaceRoot, "packaging", "flatpak", "generated");
+
+export const REVIEWED_FLATPAK_PYTHON_LICENSES = Object.freeze({
+  alembic: "MIT", "annotated-doc": "MIT", "annotated-types": "MIT", anyio: "MIT",
+  "audioop-lts": "PSF-2.0", certifi: "MPL-2.0", cffi: "MIT", "charset-normalizer": "MIT",
+  click: "BSD-3-Clause", cryptography: "Apache-2.0 OR BSD-3-Clause", decorator: "BSD-2-Clause",
+  "beat-this": "MIT", demucs: "MIT", einops: "MIT", fastapi: "MIT", filelock: "Unlicense",
+  flatbuffers: "Apache-2.0", fsspec: "BSD-3-Clause",
+  greenlet: "MIT", h11: "MIT", "hf-xet": "Apache-2.0", httpcore: "BSD-3-Clause",
+  httpx: "BSD-3-Clause", "huggingface-hub": "Apache-2.0", idna: "BSD-3-Clause",
+  h5py: "BSD-3-Clause", hatchling: "MIT", "importlib-resources": "Apache-2.0", jinja2: "BSD-3-Clause",
+  joblib: "BSD-3-Clause", julius: "MIT", lameenc: "LGPL-3.0-only", "lazy-loader": "BSD-3-Clause",
+  librosa: "ISC", llvmlite: "BSD-2-Clause", "lv-chordia": "MIT", mako: "MIT",
+  markupsafe: "BSD-3-Clause", mido: "MIT", "more-itertools": "MIT", mpmath: "BSD-3-Clause",
+  msgpack: "Apache-2.0", narwhals: "MIT", networkx: "BSD-3-Clause", numba: "BSD-2-Clause",
+  numpy: "BSD-3-Clause", "onnxruntime": "MIT", "openai-whisper": "MIT",
+  packaging: "Apache-2.0 OR BSD-2-Clause", pathspec: "MPL-2.0", platformdirs: "MIT",
+  pluggy: "MIT", pooch: "BSD-3-Clause", "pretty-midi": "MIT", protobuf: "BSD-3-Clause",
+  pycparser: "BSD-3-Clause", pydantic: "MIT",
+  "pydantic-core": "MIT", pyyaml: "MIT", regex: "Apache-2.0", requests: "Apache-2.0",
+  pydub: "MIT", "rotary-embedding-torch": "MIT", safetensors: "Apache-2.0",
+  "scikit-learn": "BSD-3-Clause", scipy: "BSD-3-Clause", setuptools: "MIT", six: "MIT",
+  soundfile: "BSD-3-Clause", soxr: "LGPL-2.1-or-later", sphn: "MIT",
+  sqlalchemy: "MIT", starlette: "BSD-3-Clause", sympy: "BSD-3-Clause",
+  threadpoolctl: "BSD-3-Clause", tiktoken: "MIT", torch: "BSD-3-Clause",
+  torchaudio: "BSD-2-Clause", tqdm: "MPL-2.0 AND MIT", "typing-extensions": "PSF-2.0",
+  tomlkit: "MIT", "trove-classifiers": "Apache-2.0", "typing-inspection": "MIT",
+  urllib3: "MIT", uvicorn: "BSD-3-Clause", wheel: "MIT",
+  "cuda-bindings": "Apache-2.0", "cuda-pathfinder": "Apache-2.0", "cuda-toolkit": "Apache-2.0",
+  triton: "MIT",
+});
+
+function reviewedFlatpakLicense(name, metadata) {
+  if (name.startsWith("nvidia-")) return "LicenseRef-NVIDIA-Software-License";
+  return metadata[name];
+}
+
+function parseGeneratedRequirements(contents, label) {
+  return contents.trim().split("\n").filter(Boolean).map((line) => {
+    const match = /^([^=]+)==(.+)$/.exec(line);
+    if (!match) throw new Error(`Malformed ${label} requirement: ${line}`);
+    return { name: match[1].toLowerCase().replace(/[-_.]+/g, "-"), version: match[2] };
+  });
+}
+
+export function buildFlatpakProfileComponentInventory({
+  generatedRoot = flatpakGeneratedRoot,
+  strict = false,
+  licenseMetadata = REVIEWED_FLATPAK_PYTHON_LICENSES,
+  selectedProfiles,
+} = {}) {
+  const selectionPath = path.join(generatedRoot, "flatpak-profile-selection.json");
+  const normalizedProfiles = normalizeFlatpakProfiles(selectedProfiles ?? (
+    existsSync(selectionPath)
+      ? JSON.parse(readFileSync(selectionPath, "utf8")).profiles
+      : undefined
+  ));
+  const selected = new Set(normalizedProfiles);
+  const profiles = [
+    { id: "cpu", prefix: "python", requirementFiles: ["python-requirements.txt", "python-build-requirements.txt"] },
+    { id: "nvidia-core", prefix: "python-nvidia-torch-core", requirementFiles: ["python-nvidia-torch-core-requirements.txt"] },
+    { id: "nvidia-runtime", prefix: "python-nvidia-torch-runtime", requirementFiles: ["python-nvidia-torch-runtime-requirements.txt"] },
+    { id: "legacy-nvidia-core", prefix: "python-legacy-torch-core", requirementFiles: ["python-legacy-torch-core-requirements.txt"] },
+    { id: "legacy-nvidia-runtime", prefix: "python-legacy-torch-runtime", requirementFiles: ["python-legacy-torch-runtime-requirements.txt"] },
+  ].filter(({ id }) => id === "cpu" || selected.has(id.startsWith("legacy-") ? "legacy-nvidia" : "nvidia"));
+  const requiredFiles = profiles.flatMap(({ prefix, requirementFiles }) => [
+    ...requirementFiles, `${prefix}-sources.json`, `${prefix}-size-report.json`,
+  ]);
+  const missingFiles = requiredFiles.filter((file) => !existsSync(path.join(generatedRoot, file)));
+  if (missingFiles.length > 0) {
+    if (strict) throw new Error(`Missing generated Flatpak profile inventory: ${missingFiles.join(", ")}`);
+    return { generated: false, selectedProfiles: normalizedProfiles, profiles: [], errors: [] };
+  }
+  const errors = [];
+  const inventory = profiles.map(({ id, prefix, requirementFiles }) => {
+    const requirementRows = requirementFiles.flatMap((file) => parseGeneratedRequirements(
+      readFileSync(path.join(generatedRoot, file), "utf8"), id,
+    ));
+    const requirements = Array.from(
+      new Map(requirementRows.map((row) => [`${row.name}@${row.version}`, row])).values(),
+    );
+    const artifacts = JSON.parse(readFileSync(path.join(generatedRoot, `${prefix}-size-report.json`), "utf8"));
+    const sources = JSON.parse(readFileSync(path.join(generatedRoot, `${prefix}-sources.json`), "utf8"));
+    const artifactKeys = new Set(artifacts.map((entry) =>
+      `${entry.name.toLowerCase().replace(/[-_.]+/g, "-")}@${entry.version}`));
+    for (const { name, version } of requirements) {
+      if (!artifactKeys.has(`${name}@${version}`)) errors.push(`${id}: requirement ${name} ${version} lacks an exact generated artifact`);
+    }
+    const components = artifacts.map((artifact) => {
+      const name = artifact.name.toLowerCase().replace(/[-_.]+/g, "-");
+      const { version } = artifact;
+      const source = sources.find((entry) =>
+        entry.url === artifact.url && entry["dest-filename"] === artifact.fileName);
+      const license = reviewedFlatpakLicense(name, licenseMetadata);
+      if (!source || !/^[a-f0-9]{64}$/.test(source.sha256)) errors.push(`${id}: ${name} ${version} lacks an exact generated source/hash`);
+      if (!license) errors.push(`${id}: ${name} ${version} lacks reviewed license metadata`);
+      return {
+        name, version, license: license ?? null,
+        fileName: artifact?.fileName ?? null,
+        sha256: source?.sha256 ?? null,
+      };
+    });
+    return { id, components };
+  });
+  if (strict && errors.length > 0) throw new Error(errors.join("; "));
+  return { generated: true, selectedProfiles: normalizedProfiles, profiles: inventory, errors };
+}
 
 const TOOL_DEFINITIONS = {
   pnpm: {
@@ -116,7 +225,12 @@ export function shellCommand({ cwd, command }) {
   return cwd && cwd !== "." ? `cd ${quoteShellArg(cwd)} && ${renderedCommand}` : renderedCommand;
 }
 
-export function buildReleaseLicenseInventory({ includeToolStatus = false, checkTool = checkToolAvailability } = {}) {
+export function buildReleaseLicenseInventory({
+  includeToolStatus = false,
+  checkTool = checkToolAvailability,
+  strictFlatpakProfiles = false,
+  flatpakProfiles,
+} = {}) {
   const toolStatuses = includeToolStatus
     ? collectToolStatuses(releaseInventoryCommands, { checkTool })
     : [];
@@ -134,6 +248,38 @@ export function buildReleaseLicenseInventory({ includeToolStatus = false, checkT
     ...bundledPlan.manifest.torch_checkpoints,
     ...bundledPlan.manifest.whisper_models,
   ];
+  const flatpakProfileComponents = buildFlatpakProfileComponentInventory({
+    strict: strictFlatpakProfiles,
+    selectedProfiles: flatpakProfiles,
+  });
+  const selectedFlatpakProfiles = new Set(flatpakProfileComponents.selectedProfiles);
+  const flatpakTorchProfiles = [
+    {
+      id: "cpu", refId: "com.tuneforge.desktop", torch: "2.13.0", torchaudio: "2.11.0",
+      cudaFamily: null,
+      artifact: "Tuneforge_<version>_x86_64.flatpak",
+    },
+    {
+      id: "nvidia-core", refId: "com.tuneforge.desktop.Torch.Stack.Nvidia.Core",
+      torch: "2.13.0", torchaudio: "2.11.0", triton: "3.7.1", cudaFamily: "13",
+      artifact: "Tuneforge_<version>_Torch_Nvidia_Core_x86_64.flatpak",
+    },
+    {
+      id: "nvidia-runtime", refId: "com.tuneforge.desktop.Torch.Stack.Nvidia.Runtime",
+      cudaFamily: "13", artifact: "Tuneforge_<version>_Torch_Nvidia_Runtime_x86_64.flatpak",
+    },
+    {
+      id: "legacy-nvidia-core", refId: "com.tuneforge.desktop.Torch.Stack.LegacyNvidia.Core",
+      torch: "2.13.0+cu126", torchaudio: "2.11.0+cu126", triton: "3.7.1", cudaFamily: "12.6",
+      artifact: "Tuneforge_<version>_Torch_LegacyNvidia_Core_x86_64.flatpak",
+    },
+    {
+      id: "legacy-nvidia-runtime", refId: "com.tuneforge.desktop.Torch.Stack.LegacyNvidia.Runtime",
+      cudaFamily: "12.6", artifact: "Tuneforge_<version>_Torch_LegacyNvidia_Runtime_x86_64.flatpak",
+    },
+  ].filter(({ id }) => id === "cpu" || selectedFlatpakProfiles.has(
+    id.startsWith("legacy-") ? "legacy-nvidia" : "nvidia",
+  ));
 
   return {
     workspaceRoot: ".",
@@ -198,6 +344,9 @@ export function buildReleaseLicenseInventory({ includeToolStatus = false, checkT
         "packaging/flatpak/generated/model-bundle-sources.json",
         "packaging/flatpak/generated/model-bundle-manifest.json",
       ],
+      flatpakTorchProfiles: flatpakTorchProfiles.map(({ artifact: _artifact, ...profile }) => profile),
+      flatpakChecksumContents: flatpakTorchProfiles.map(({ artifact }) => artifact),
+      flatpakProfileComponents,
       defaultLyricsModel: DEFAULT_LYRICS_MODEL,
       explicitBundleSourceCount: bundledPlan.sources.length,
       explicitBundleBytes: sumBundleBytes(bundledManifestEntries),
@@ -211,6 +360,7 @@ export function buildReleaseLicenseInventory({ includeToolStatus = false, checkT
       "FFmpeg and ffprobe are host-installed and are not bundled.",
       "Python package license metadata can be incomplete; review missing fields manually.",
       "Do not commit redirected inventory reports or generated package resources.",
+      "NVIDIA extension wheels require their bundled NVIDIA component license metadata review.",
     ],
   };
 }
@@ -287,6 +437,21 @@ export function formatReleaseLicenseInventory(checklist) {
   lines.push(`- cache prewarm: ${checklist.modelPolicy.cachePrewarmCommand}`);
   lines.push(`- cache paths: ${checklist.modelPolicy.cachePaths.join(", ")}`);
   lines.push(`- package bundle paths: ${checklist.modelPolicy.packageBundlePaths.join(", ")}`);
+  for (const profile of checklist.modelPolicy.flatpakTorchProfiles) {
+    const details = profile.torch
+      ? [
+        `Torch ${profile.torch}`,
+        `Torchaudio ${profile.torchaudio}`,
+        ...(profile.triton ? [`Triton ${profile.triton}`] : []),
+        ...(profile.cudaFamily ? [`CUDA family ${profile.cudaFamily}`] : []),
+      ]
+      : [`CUDA/NVIDIA runtime family ${profile.cudaFamily}`];
+    lines.push(`- Flatpak Torch ${profile.id}: ${profile.refId}, ${details.join(", ")}`);
+  }
+  lines.push(`- Flatpak SHA256SUMS: ${checklist.modelPolicy.flatpakChecksumContents.join(", ")}`);
+  for (const profile of checklist.modelPolicy.flatpakProfileComponents.profiles) {
+    lines.push(`- Flatpak ${profile.id} licensed components: ${profile.components.length}`);
+  }
   lines.push(
     `- explicit bundle plan: ${checklist.modelPolicy.explicitBundleSourceCount} source files, ` +
       `${formatBytes(checklist.modelPolicy.explicitBundleBytes)}`,
@@ -374,7 +539,10 @@ function main(argv) {
     return 0;
   }
 
-  const checklist = buildReleaseLicenseInventory({ includeToolStatus: options.check });
+  const checklist = buildReleaseLicenseInventory({
+    includeToolStatus: options.check,
+    strictFlatpakProfiles: options.check,
+  });
   if (options.json) {
     process.stdout.write(`${JSON.stringify(checklist, null, 2)}\n`);
   } else {


### PR DESCRIPTION
## Summary

- Package the CPU application with optional modern and legacy NVIDIA Flatpak extensions as paired Core and Runtime refs.
- Add composable profile selection, fail-closed runtime activation, selected-ref reconciliation, per-artifact size and checksum gates, and license inventory coverage.
- Document CPU-default behavior, extension installation, generated artifacts, and evidence boundaries.
- Closes #491

## Testing

- Passed focused Node packaging, source-generation, cache, option, and license-inventory matrices.
- Passed Rust formatting, checking, and focused backend-launcher tests.
- Passed `pnpm lint`, `pnpm typecheck`, and full `pnpm test`.
- Passed `cd apps/backend && uv run --python 3.14 pytest` with 784 tests.
- User-supplied Linux evidence: sequential `pnpm package:linux` cold and warm builds completed; the warm module-cache defect is tracked separately in #496.
- Packaged NVIDIA inference, installation lifecycle, and release signing remain unverified.
