### PR TITLE
fix(packaging): make Flatpak source and profile caches deterministic

### DIFF
--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -179,7 +179,7 @@ const TORCH_EXTENSION_POLICY_JSON: &str = r#"{
       "torchaudio_version": "2.11.0+cu126",
       "triton_version": "3.7.1",
       "cuda_family": "12.6",
-      "pair_id": "112a80543c933ef4903aca2c0afcca91f21012c9e4ee1164222b08f118eba4f2"
+      "pair_id": "5896e6c2ba980be746fb7bb711d8e2e49f23713c58e0c6d3bec76ca048f60743"
     }
   }
 }"#;
@@ -691,13 +691,13 @@ mod tests {
                 "LegacyNvidia",
                 "core",
                 "com.tuneforge.desktop.Torch.Stack.LegacyNvidia.Core",
-                "112a80543c933ef4903aca2c0afcca91f21012c9e4ee1164222b08f118eba4f2",
+                "5896e6c2ba980be746fb7bb711d8e2e49f23713c58e0c6d3bec76ca048f60743",
             ),
             (
                 "LegacyNvidia",
                 "runtime",
                 "com.tuneforge.desktop.Torch.Stack.LegacyNvidia.Runtime",
-                "112a80543c933ef4903aca2c0afcca91f21012c9e4ee1164222b08f118eba4f2",
+                "5896e6c2ba980be746fb7bb711d8e2e49f23713c58e0c6d3bec76ca048f60743",
             ),
         ] {
             let marker = expected_torch_extension_profile(profile, role);

--- a/docs/PACKAGING.md
+++ b/docs/PACKAGING.md
@@ -220,29 +220,54 @@ clean output. Durable state and dependency/compiler caches default to
 `FLATPAK_STATE_DIR` and `FLATPAK_CACHE_DIR` paths to move them. Packaging rejects unsafe or
 overlapping roots; valid caches persist until deleted.
 
-Caches are namespaced by build schema, application, architecture, runtime, toolchain, and package
-options. Dependency installation remains frozen and offline. Integrity, lock, or cache failures stop
-the build without network fallback or automatic repair. Deterministic timestamps keep repeated build
-payloads comparable.
+Caches are namespaced by the `flatpak-cache-v1` contract: application, architecture, runtime,
+toolchain, and non-profile package options. CPU, NVIDIA, legacy NVIDIA, and the default/all
+selection reuse one Builder, pnpm, and sccache namespace; Flatpak Builder's per-module input keys
+decide which extension module must execute. Reports use the same `flatpak-cache-v1` contract.
+Outputs remain selection-specific. Packaging holds one checkout-wide Linux
+lock while it generates sources, runs Builder, reconciles refs, and writes reports, so concurrent
+commands wait without a timeout rather than corrupting shared state. Dependency installation remains frozen and offline.
+Integrity, lock, or cache failures stop the build without network fallback or automatic repair.
+Deterministic timestamps keep repeated build payloads comparable.
 
-Module inputs are separated so backend-only changes do not invalidate the Vite or Rust modules. The
-backend version in installed `version.json` describes the whole checkout. The frontend version uses
-the last commit affecting the exact Vite module inputs plus scoped dirty detection, so the displayed
-refs can intentionally differ. `TUNEFORGE_FRONTEND_GIT_REF` overrides only the frontend ref;
-`TUNEFORGE_GIT_REF` overrides the checkout/backend ref.
+After a successful export, the selected state directory stores ignored atomic
+`flatpak-output-state-v1.json` evidence: namespace, normalized profiles, payload digest, ordered
+OSTree ref commits, and checkout size evidence. On an ordinary same-profile warm run, exact state
+and repository refs are preserved and Builder receives `--require-changes`; unchanged refs report
+`preserved-unchanged` and reuse that bound payload/size evidence. Missing, corrupt, stale, or
+profile-mismatched state is discarded, selected refs are reconciled, and one normal export restores
+state. A Builder no-op may remove its checkout; the valid saved state remains sufficient for the
+next same-profile no-op. Changing profiles likewise exports once.
+
+Before Flatpak Builder runs, packaging writes deterministic USTAR snapshots for the frontend,
+desktop Rust shell, and backend static inputs. Snapshots include dirty and untracked inputs,
+dotfiles, empty directories, file and directory modes, and symlink targets with normalized `0777`
+modes; they use `SOURCE_DATE_EPOCH` (or the HEAD
+timestamp) and are ignored build outputs. A source change invalidates modules whose snapshots include
+it, then any downstream modules Builder must rebuild.
+Generated version metadata and Cargo, pnpm, and Python dependency sources remain separate.
+
+The backend version in installed `version.json` describes the whole checkout. The frontend version
+uses the last commit affecting the exact Vite module inputs plus scoped dirty detection, so the
+displayed refs can intentionally differ. `TUNEFORGE_FRONTEND_GIT_REF` overrides only the frontend
+ref; `TUNEFORGE_GIT_REF` overrides the checkout/backend ref.
 
 Every successful build writes the ignored, sanitized
 `packaging/flatpak/generated/cache-report.json`. Override it with
-`FLATPAK_CACHE_REPORT_PATH`. It records cache integrity and usage, timings, a deterministic
-installed-payload digest, and the exact CPU, NVIDIA, and legacy NVIDIA repository commits
-without exposing host cache paths.
+`FLATPAK_CACHE_REPORT_PATH`. `flatpak-cache-v1` records ordered module observations from Builder
+output (`cached`, `executed`, or `unknown`), observation completeness, first invalidated module,
+cache mode, dependency/compiler evidence, timings, deterministic payload digest, and selected
+repository commits. Its `output` observation records whether refs were exported or preserved and
+where payload evidence came from. Its independent `bundleCache` observation records per-ref bundle
+reuse or rebuild status, bytes, SHA-256, and the first rebuilt artifact; `--no-bundle` reports
+`not-requested`, while evidence mode reports `disabled-for-evidence`. Module/output comparisons do
+not infer bundle reuse. Unknown or incomplete observations do not fail a normal build; they fail a
+cold/warm comparison. Reports contain no host cache paths.
 
-Use a Linux x86_64 Flatpak host and never-before-used evidence roots for a cold/warm comparison:
+Use the normal Linux x86_64 checkout paths for a cold/warm comparison. Save the first report, then
+use it as the same-selection baseline:
 
 ```sh
-export FLATPAK_STATE_DIR="$PWD/.flatpak-builder/evidence-state"
-export FLATPAK_CACHE_DIR="$PWD/.flatpak-builder/evidence-cache"
-export FLATPAK_CACHE_EVIDENCE=1
 export FLATPAK_CACHE_REPORT_PATH="$PWD/packaging/flatpak/generated/cache-cold.json"
 pnpm package:linux:flatpak -- --no-bundle
 
@@ -252,9 +277,21 @@ export FLATPAK_CACHE_COMPARISON_REPORT_PATH="$PWD/packaging/flatpak/generated/ca
 pnpm package:linux:flatpak -- --no-bundle
 ```
 
-Evidence mode bypasses Flatpak's module-result cache while retaining the durable dependency and
-compiler caches. The warm build fails on cache errors, incompatible namespaces, or a changed payload
-digest. `FLATPAK_BUILD_DIR`, `FLATPAK_REPO_DIR`, and `FLATPAK_BUNDLE_PATH` configure output paths.
+The warm comparison requires `flatpak-cache-v1` reports, complete matching module observations, every warm module
+cached, no warm invalidation, matching namespaces, payloads, repository commits, and a
+`preserved-unchanged` warm output observation. It fails closed otherwise. `FLATPAK_CACHE_EVIDENCE=1`
+always performs a normal export and deliberately disables Builder's module-result cache to inspect
+pnpm and sccache behavior; its report says `disabled-for-evidence`, so it is not a normal module-cache
+warm comparison. To prove profile reuse, set `FLATPAK_CACHE_CROSS_PROFILE_BASELINE_REPORT` to a
+previous selection report before building a different selection; its target must be an exported
+report with a cached shared prefix.
+`FLATPAK_BUILD_DIR`, `FLATPAK_REPO_DIR`, and `FLATPAK_BUNDLE_PATH` configure output paths.
+
+CPU and legacy NVIDIA Torch wheels come from reviewed committed pylocks under
+`packaging/flatpak/locks/`; normal packaging never resolves them. Refresh a reviewed lock explicitly
+with `node scripts/refresh-flatpak-torch-locks.mjs --cpu` or `--legacy-nvidia`, then review its wheel
+closure, license inventory, and synchronized Node/Rust profile pair ID. NVIDIA derives from the
+committed backend `uv.lock` and is verified against its reviewed profile pair during source generation.
 
 Flatpak runtime lookups are not host `PATH` lookups. The manifest sets `TUNEFORGE_FFMPEG_PATH=/app/bin/ffmpeg` and `TUNEFORGE_FFPROBE_PATH=/app/bin/ffprobe`; those files are wrappers that search for `ffmpeg` and `ffprobe` inside the sandbox runtime/extension paths. If the runtime does not provide them, the Flatpak build or app reports the missing sandbox binary rather than falling back to the host shell.
 
@@ -328,9 +365,25 @@ Without profile flags or `--no-bundle`, packaging writes five independent bundle
 
 Selective builds write only the CPU bundle and the two bundles for each selected accelerator. The
 ignored `packaging/flatpak/generated/SHA256SUMS` contains exactly the artifacts from that run.
-Every run removes stale known default bundles and checksums before building. Each bundle
-must remain strictly below 2 GiB. The bundle step runs at most two independent bundle jobs
-concurrently; the Flatpak ref build remains sequential.
+The shared namespace stores atomic ignored `flatpak-bundle-state-v1.json` state whose header binds
+the namespace, exact Flatpak version, x86_64, stable, and canonical `build-bundle`. Each entry binds
+one output path and basename to its full ref, verified
+OSTree commit, app/runtime role, byte size, and SHA-256. There is no whole-profile bundle cache key.
+An ordinary run reuses each selected bundle only when that entry, the exact `SHA256SUMS` entry, and
+the full file hash all match. Ref changes rebuild only their artifacts; adding a profile builds only
+the additions, and removing one preserves the retained bundles then prunes managed unselected
+outputs. Missing or globally malformed state, or a malformed/duplicate checksum manifest, rebuilds
+all selected bundles. A fully valid warm selection launches no bundle builders and leaves bundles,
+state, and checksums untouched. `FLATPAK_CACHE_EVIDENCE=1` deliberately rebuilds every requested
+bundle and may seed verified state. `--no-bundle` never reads, hashes, creates, deletes, or rewrites
+bundle outputs, bundle state, or `SHA256SUMS`.
+Misses build to same-directory temporary paths, are size- and hash-verified, and move into place
+only after all pending builders succeed. Packaging removes both trust markers before mutation.
+Failure removes temporary and replaced outputs plus both trust markers. Profile transitions publish
+selected-only state and sorted checksums, and prune only caller-known managed paths.
+Each bundle must remain strictly below 2 GiB. Pending bundle work uses
+`max(1, available CPU workers - 1)`, capped by the pending count; the Flatpak ref build remains
+sequential.
 
 ## Size Expectations
 

--- a/packaging/flatpak/com.tuneforge.desktop.yml
+++ b/packaging/flatpak/com.tuneforge.desktop.yml
@@ -117,41 +117,10 @@ modules:
         HUSKY: "0"
         TUNEFORGE_VERSION_FILE: /run/build/tuneforge-frontend/frontend-version.json
     sources:
-      - type: file
-        path: ../../package.json
-      - type: file
-        path: ../../pnpm-lock.yaml
-      - type: file
-        path: ../../pnpm-workspace.yaml
-      - type: file
-        path: ../../scripts/build-info.mjs
-        dest: scripts
-      - type: file
-        path: seed-pnpm-store.mjs
-      - type: file
-        path: ../../apps/desktop/package.json
-        dest: apps/desktop
-      - type: file
-        path: ../../apps/desktop/index.html
-        dest: apps/desktop
-      - type: file
-        path: ../../apps/desktop/tsconfig.json
-        dest: apps/desktop
-      - type: file
-        path: ../../apps/desktop/tsconfig.node.json
-        dest: apps/desktop
-      - type: file
-        path: ../../apps/desktop/vite.config.ts
-        dest: apps/desktop
-      - type: dir
-        path: ../../apps/desktop/src
-        dest: apps/desktop/src
-      - type: file
-        path: ../../packages/shared-types/package.json
-        dest: packages/shared-types
-      - type: dir
-        path: ../../packages/shared-types/src
-        dest: packages/shared-types/src
+      - type: archive
+        path: generated/frontend-snapshot.tar
+        archive-type: tar
+        strip-components: 0
       - type: file
         path: generated/frontend-version.json
         dest-filename: frontend-version.json
@@ -186,30 +155,10 @@ modules:
         SCCACHE_DIR: /run/tuneforge-cache/@@FLATPAK_CACHE_NAMESPACE@@/sccache
         TUNEFORGE_GIT_REF: '@@TUNEFORGE_FRONTEND_GIT_REF@@'
     sources:
-      - type: file
-        path: ../../apps/desktop/src-tauri/Cargo.lock
-        dest: apps/desktop/src-tauri
-      - type: file
-        path: ../../apps/desktop/src-tauri/Cargo.toml
-        dest: apps/desktop/src-tauri
-      - type: file
-        path: ../../apps/desktop/src-tauri/build.rs
-        dest: apps/desktop/src-tauri
-      - type: file
-        path: ../../apps/desktop/src-tauri/tauri.conf.json
-        dest: apps/desktop/src-tauri
-      - type: dir
-        path: ../../apps/desktop/src-tauri/capabilities
-        dest: apps/desktop/src-tauri/capabilities
-      - type: dir
-        path: ../../apps/desktop/src-tauri/icons
-        dest: apps/desktop/src-tauri/icons
-      - type: dir
-        path: ../../apps/desktop/src-tauri/resources
-        dest: apps/desktop/src-tauri/resources
-      - type: dir
-        path: ../../apps/desktop/src-tauri/src
-        dest: apps/desktop/src-tauri/src
+      - type: archive
+        path: generated/desktop-snapshot.tar
+        archive-type: tar
+        strip-components: 0
       - generated/cargo-sources.json
     build-commands:
       - install -dm755 apps/desktop/dist
@@ -400,53 +349,10 @@ modules:
         LD_LIBRARY_PATH: /app/lib/tuneforge/backend/python/lib
         PYTHONPATH: /app/lib/tuneforge/backend/site-packages
     sources:
-      - type: file
-        path: ../../README.md
-      - type: file
-        path: ../../LICENSE
-      - type: file
-        path: ../../THIRD_PARTY_NOTICES.md
-      - type: file
-        path: ../../LICENSES/crema-0.2.0-BSD-2-Clause.txt
-        dest: LICENSES
-      - type: file
-        path: ../../docs/PACKAGING.md
-        dest: docs
-      - type: dir
-        path: ../../apps/backend/app
-        dest: apps/backend/app
-      - type: dir
-        path: ../../apps/backend/alembic
-        dest: apps/backend/alembic
-      - type: file
-        path: ../../apps/backend/alembic.ini
-        dest: apps/backend
-      - type: file
-        path: ../../apps/backend/pyproject.toml
-        dest: apps/backend
-      - type: file
-        path: ../../packaging/demucs/models.json
-        dest: apps/backend
-        dest-filename: demucs-models.json
-      - type: file
-        path: ffmpeg-wrapper.sh
-        dest-filename: ffmpeg
-      - type: file
-        path: ffprobe-wrapper.sh
-        dest-filename: ffprobe
-      - type: file
-        path: com.tuneforge.desktop.desktop
-      - type: file
-        path: com.tuneforge.desktop.metainfo.xml
-      - type: file
-        path: ../../apps/desktop/src-tauri/icons/32x32.png
-        dest: icons
-      - type: file
-        path: ../../apps/desktop/src-tauri/icons/128x128.png
-        dest: icons
-      - type: file
-        path: ../../apps/desktop/src-tauri/icons/512x512.png
-        dest: icons
+      - type: archive
+        path: generated/backend-snapshot.tar
+        archive-type: tar
+        strip-components: 0
       - type: file
         path: generated/version.json
     build-commands:

--- a/packaging/flatpak/locks/pylock.cpu-torch.toml
+++ b/packaging/flatpak/locks/pylock.cpu-torch.toml
@@ -1,0 +1,67 @@
+lock-version = "1.0"
+created-by = "uv"
+requires-python = ">=3.14"
+
+[[packages]]
+name = "filelock"
+version = "3.32.5"
+sdist = { url = "https://files.pythonhosted.org/packages/0a/a0/50c2c0ce5e74d7721bbb1b19a26ebd339aac5878553a6e35308c2f31f935/filelock-3.32.5.tar.gz", upload-time = 2026-08-31T18:56:34Z, size = 222838, hashes = { sha256 = "f6a6a28f743f9b95ce19db5abe0f376f75eb56517dff21e1a4751e2657d3e83d" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/36/d2/b70a31e13d04456d28493f31d2aa087e99eeb2767ef0293b2625727ccb8c/filelock-3.32.5-py3-none-any.whl", upload-time = 2026-08-31T18:56:33Z, size = 100003, hashes = { sha256 = "142cd9fa77a872c5e78c62329a0d15278fadc686eb89e760017968961a4fd6b2" } }]
+
+[[packages]]
+name = "fsspec"
+version = "2026.7.0"
+sdist = { url = "https://files.pythonhosted.org/packages/00/78/f34251dadb8f3921264a1d9b8946f5e542014ee2614b285261b4e40e6775/fsspec-2026.7.0.tar.gz", upload-time = 2026-07-28T16:34:51Z, size = 317040, hashes = { sha256 = "c803c40f4cf860b49dea58ee3e1c33cb9c790520e233537e1340049f89b82a88" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/fd/3c/6a2bf344106328fd04963664a60b9bb6496fc25df8e962fcdc1367285fb9/fsspec-2026.7.0-py3-none-any.whl", upload-time = 2026-07-28T16:34:49Z, size = 206583, hashes = { sha256 = "b57ddbafedfaef7018c1ecab32aa200a9d7ca26b77965f64e48b70061249d279" } }]
+
+[[packages]]
+name = "jinja2"
+version = "3.1.6"
+sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", upload-time = 2025-03-05T20:05:02Z, size = 245115, hashes = { sha256 = "0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", upload-time = 2025-03-05T20:05:00Z, size = 134899, hashes = { sha256 = "85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67" } }]
+
+[[packages]]
+name = "markupsafe"
+version = "3.0.3"
+sdist = { url = "https://files.pythonhosted.org/packages/7e/99/7690b6d4034fffd95959cbe0c02de8deb3098cc577c67bb6a24fe5d7caa7/markupsafe-3.0.3.tar.gz", upload-time = 2025-09-27T18:37:40Z, size = 80313, hashes = { sha256 = "722695808f4b6457b320fdc131280796bdceb04ab50fe1795cd540799ebe1698" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/41/3c/a36c2450754618e62008bf7435ccb0f88053e07592e6028a34776213d877/markupsafe-3.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", upload-time = 2025-09-27T18:37:10Z, size = 23005, hashes = { sha256 = "457a69a9577064c05a97c41f4e65148652db078a3a509039e64d3467b9e7ef97" } }]
+
+[[packages]]
+name = "mpmath"
+version = "1.3.0"
+sdist = { url = "https://files.pythonhosted.org/packages/e0/47/dd32fa426cc72114383ac549964eecb20ecfd886d1e5ccf5340b55b02f57/mpmath-1.3.0.tar.gz", upload-time = 2023-03-07T16:47:11Z, size = 508106, hashes = { sha256 = "7a28eb2a9774d00c7bc92411c19a89209d5da7c4c9a9e227be8330a23a25b91f" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/43/e3/7d92a15f894aa0c9c4b49b8ee9ac9850d6e63b03c9c32c0367a13ae62209/mpmath-1.3.0-py3-none-any.whl", upload-time = 2023-03-07T16:47:09Z, size = 536198, hashes = { sha256 = "a0b2b9fe80bbcd81a6647ff13108738cfb482d481d826cc0e02f5b35e5c88d2c" } }]
+
+[[packages]]
+name = "networkx"
+version = "3.6.1"
+sdist = { url = "https://files.pythonhosted.org/packages/6a/51/63fe664f3908c97be9d2e4f1158eb633317598cfa6e1fc14af5383f17512/networkx-3.6.1.tar.gz", upload-time = 2025-12-08T17:02:39Z, size = 2517025, hashes = { sha256 = "26b7c357accc0c8cde558ad486283728b65b6a95d85ee1cd66bafab4c8168509" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/9e/c9/b2622292ea83fbb4ec318f5b9ab867d0a28ab43c5717bb85b0a5f6b3b0a4/networkx-3.6.1-py3-none-any.whl", upload-time = 2025-12-08T17:02:38Z, size = 2068504, hashes = { sha256 = "d47fbf302e7d9cbbb9e2555a0d267983d2aa476bac30e90dfbe5669bd57f3762" } }]
+
+[[packages]]
+name = "setuptools"
+version = "84.0.0"
+sdist = { url = "https://files.pythonhosted.org/packages/6d/44/f5da03a8ef95d369145c5bb53050e7877c9f3d312e128605fd9504829143/setuptools-84.0.0.tar.gz", upload-time = 2026-08-08T18:27:58Z, size = 1168449, hashes = { sha256 = "f4695c21257f0d9b537ec2692c941d02ee143b7cc1276941349a546573b2ef73" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/95/9c/c510029fc6ef33a6275cd2c5d3cecd6613dfd6aa401d57c54f1c18852ccf/setuptools-84.0.0-py3-none-any.whl", upload-time = 2026-08-08T18:27:56Z, size = 818216, hashes = { sha256 = "51a52592b3b99e102b609654876bd65f19f999935166d1352678931132b0c670" } }]
+
+[[packages]]
+name = "sympy"
+version = "1.14.0"
+sdist = { url = "https://files.pythonhosted.org/packages/83/d3/803453b36afefb7c2bb238361cd4ae6125a569b4db67cd9e79846ba2d68c/sympy-1.14.0.tar.gz", upload-time = 2025-04-27T18:05:01Z, size = 7793921, hashes = { sha256 = "d3d3fe8df1e5a0b42f0e7bdf50541697dbe7d23746e894990c030e2b05e72517" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/a2/09/77d55d46fd61b4a135c444fc97158ef34a095e5681d0a6c10b75bf356191/sympy-1.14.0-py3-none-any.whl", upload-time = 2025-04-27T18:04:59Z, size = 6299353, hashes = { sha256 = "e091cc3e99d2141a0ba2847328f5479b05d94a6635cb96148ccb3f34671bd8f5" } }]
+
+[[packages]]
+name = "torch"
+version = "2.13.0+cpu"
+wheels = [{ url = "https://download-r2.pytorch.org/whl/cpu/torch-2.13.0%2Bcpu-cp314-cp314-manylinux_2_28_x86_64.whl", upload-time = 2026-07-08T19:30:45Z, hashes = { sha256 = "d20fa53ee744502fa4c69818a720b05ca0d37abd055d4f6e66cae155114bc691" } }]
+
+[[packages]]
+name = "torchaudio"
+version = "2.11.0+cpu"
+wheels = [{ url = "https://download-r2.pytorch.org/whl/cpu/torchaudio-2.11.0%2Bcpu-cp314-cp314-manylinux_2_28_x86_64.whl", upload-time = 2026-03-23T15:50:10Z, hashes = { sha256 = "34c5dcd704e17a2b01c097b4fe3b5f83c5cdbc42b9f2abd095e026c588f873d4" } }]
+
+[[packages]]
+name = "typing-extensions"
+version = "4.16.0"
+sdist = { url = "https://files.pythonhosted.org/packages/f6/cc/6253133b5bb138fc3306cebfbda2c520f545d36b5be2c7255cc528bb45d6/typing_extensions-4.16.0.tar.gz", upload-time = 2026-07-02T08:40:05Z, size = 113555, hashes = { sha256 = "dc983d19a509c94dba722ee6abd33940f7c05a89e243c47e907eb4db6f1a43e5" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/49/d3/b8441a820a491ddfc024b0b0cf0393375b75ea13866d9c66727e54c2fc80/typing_extensions-4.16.0-py3-none-any.whl", upload-time = 2026-07-02T08:40:04Z, size = 45571, hashes = { sha256 = "481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8" } }]

--- a/packaging/flatpak/locks/pylock.legacy-nvidia-torch.toml
+++ b/packaging/flatpak/locks/pylock.legacy-nvidia-torch.toml
@@ -1,0 +1,202 @@
+lock-version = "1.0"
+created-by = "uv"
+requires-python = ">=3.14"
+
+[[packages]]
+name = "cuda-bindings"
+version = "12.9.7"
+marker = "python_full_version < '3.15' and sys_platform == 'linux'"
+wheels = [{ url = "https://files.pythonhosted.org/packages/ec/cd/3289c810a4d45e5364a3387a74b4c9b6f6f57ee96ae0e5b537cc61dec242/cuda_bindings-12.9.7-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", upload-time = 2026-05-27T18:44:31Z, size = 7504419, hashes = { sha256 = "3c47ec1a7a441d91aab32339951df7a1be53451121a12c094bba51467717a35a" } }]
+
+[[packages]]
+name = "cuda-pathfinder"
+version = "1.8.0"
+marker = "python_full_version < '3.15' and sys_platform == 'linux'"
+wheels = [{ url = "https://files.pythonhosted.org/packages/a1/b1/ef21259ec74fe0b265ed201379de1d0ef7c14178313ee03705952f1b7093/cuda_pathfinder-1.8.0-py3-none-any.whl", upload-time = 2026-08-27T21:33:03Z, size = 62539, hashes = { sha256 = "c44e574dc997fae2814721d1ae97d0fd6db76db82decbe9b753bf75de53f515e" } }]
+
+[[packages]]
+name = "cuda-toolkit"
+version = "12.6.3"
+marker = "sys_platform == 'linux'"
+wheels = [{ url = "https://files.pythonhosted.org/packages/ad/88/2dbc37975fffb874418b14380418a1b99cb36f2101fd1d08c54e06ee8c95/cuda_toolkit-12.6.3-py2.py3-none-any.whl", upload-time = 2025-08-13T02:03:05Z, size = 2288, hashes = { sha256 = "79d8605baeb6c2f695761e0efb54bc62dbc3c9e32eb0742df7669c07befaa8f7" } }]
+
+[[packages]]
+name = "filelock"
+version = "3.32.5"
+sdist = { url = "https://files.pythonhosted.org/packages/0a/a0/50c2c0ce5e74d7721bbb1b19a26ebd339aac5878553a6e35308c2f31f935/filelock-3.32.5.tar.gz", upload-time = 2026-08-31T18:56:34Z, size = 222838, hashes = { sha256 = "f6a6a28f743f9b95ce19db5abe0f376f75eb56517dff21e1a4751e2657d3e83d" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/36/d2/b70a31e13d04456d28493f31d2aa087e99eeb2767ef0293b2625727ccb8c/filelock-3.32.5-py3-none-any.whl", upload-time = 2026-08-31T18:56:33Z, size = 100003, hashes = { sha256 = "142cd9fa77a872c5e78c62329a0d15278fadc686eb89e760017968961a4fd6b2" } }]
+
+[[packages]]
+name = "fsspec"
+version = "2026.7.0"
+sdist = { url = "https://files.pythonhosted.org/packages/00/78/f34251dadb8f3921264a1d9b8946f5e542014ee2614b285261b4e40e6775/fsspec-2026.7.0.tar.gz", upload-time = 2026-07-28T16:34:51Z, size = 317040, hashes = { sha256 = "c803c40f4cf860b49dea58ee3e1c33cb9c790520e233537e1340049f89b82a88" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/fd/3c/6a2bf344106328fd04963664a60b9bb6496fc25df8e962fcdc1367285fb9/fsspec-2026.7.0-py3-none-any.whl", upload-time = 2026-07-28T16:34:49Z, size = 206583, hashes = { sha256 = "b57ddbafedfaef7018c1ecab32aa200a9d7ca26b77965f64e48b70061249d279" } }]
+
+[[packages]]
+name = "jinja2"
+version = "3.1.6"
+sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", upload-time = 2025-03-05T20:05:02Z, size = 245115, hashes = { sha256 = "0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", upload-time = 2025-03-05T20:05:00Z, size = 134899, hashes = { sha256 = "85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67" } }]
+
+[[packages]]
+name = "markupsafe"
+version = "3.0.3"
+sdist = { url = "https://files.pythonhosted.org/packages/7e/99/7690b6d4034fffd95959cbe0c02de8deb3098cc577c67bb6a24fe5d7caa7/markupsafe-3.0.3.tar.gz", upload-time = 2025-09-27T18:37:40Z, size = 80313, hashes = { sha256 = "722695808f4b6457b320fdc131280796bdceb04ab50fe1795cd540799ebe1698" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/41/3c/a36c2450754618e62008bf7435ccb0f88053e07592e6028a34776213d877/markupsafe-3.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", upload-time = 2025-09-27T18:37:10Z, size = 23005, hashes = { sha256 = "457a69a9577064c05a97c41f4e65148652db078a3a509039e64d3467b9e7ef97" } }]
+
+[[packages]]
+name = "mpmath"
+version = "1.3.0"
+sdist = { url = "https://files.pythonhosted.org/packages/e0/47/dd32fa426cc72114383ac549964eecb20ecfd886d1e5ccf5340b55b02f57/mpmath-1.3.0.tar.gz", upload-time = 2023-03-07T16:47:11Z, size = 508106, hashes = { sha256 = "7a28eb2a9774d00c7bc92411c19a89209d5da7c4c9a9e227be8330a23a25b91f" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/43/e3/7d92a15f894aa0c9c4b49b8ee9ac9850d6e63b03c9c32c0367a13ae62209/mpmath-1.3.0-py3-none-any.whl", upload-time = 2023-03-07T16:47:09Z, size = 536198, hashes = { sha256 = "a0b2b9fe80bbcd81a6647ff13108738cfb482d481d826cc0e02f5b35e5c88d2c" } }]
+
+[[packages]]
+name = "networkx"
+version = "3.6.1"
+sdist = { url = "https://files.pythonhosted.org/packages/6a/51/63fe664f3908c97be9d2e4f1158eb633317598cfa6e1fc14af5383f17512/networkx-3.6.1.tar.gz", upload-time = 2025-12-08T17:02:39Z, size = 2517025, hashes = { sha256 = "26b7c357accc0c8cde558ad486283728b65b6a95d85ee1cd66bafab4c8168509" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/9e/c9/b2622292ea83fbb4ec318f5b9ab867d0a28ab43c5717bb85b0a5f6b3b0a4/networkx-3.6.1-py3-none-any.whl", upload-time = 2025-12-08T17:02:38Z, size = 2068504, hashes = { sha256 = "d47fbf302e7d9cbbb9e2555a0d267983d2aa476bac30e90dfbe5669bd57f3762" } }]
+
+[[packages]]
+name = "nvidia-cublas-cu12"
+version = "12.6.4.1"
+marker = "sys_platform == 'linux'"
+wheels = [{ url = "https://files.pythonhosted.org/packages/af/eb/ff4b8c503fa1f1796679dce648854d58751982426e4e4b37d6fce49d259c/nvidia_cublas_cu12-12.6.4.1-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", upload-time = 2024-11-20T17:40:25Z, size = 393138322, hashes = { sha256 = "08ed2686e9875d01b58e3cb379c6896df8e76c75e0d4a7f7dace3d7b6d9ef8eb" } }]
+
+[[packages]]
+name = "nvidia-cuda-cupti-cu12"
+version = "12.6.80"
+marker = "sys_platform == 'linux'"
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/60/7b6497946d74bcf1de852a21824d63baad12cd417db4195fc1bfe59db953/nvidia_cuda_cupti_cu12-12.6.80-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", upload-time = 2024-11-20T17:36:04Z, size = 8917980, hashes = { sha256 = "6768bad6cab4f19e8292125e5f1ac8aa7d1718704012a0e3272a6f61c4bce132" } },
+    { url = "https://files.pythonhosted.org/packages/a5/24/120ee57b218d9952c379d1e026c4479c9ece9997a4fb46303611ee48f038/nvidia_cuda_cupti_cu12-12.6.80-py3-none-manylinux2014_x86_64.whl", upload-time = 2024-10-01T16:58:06Z, size = 8917972, hashes = { sha256 = "a3eff6cdfcc6a4c35db968a06fcadb061cbc7d6dde548609a941ff8701b98b73" } },
+]
+
+[[packages]]
+name = "nvidia-cuda-nvrtc-cu12"
+version = "12.6.85"
+marker = "sys_platform == 'linux'"
+wheels = [{ url = "https://files.pythonhosted.org/packages/f5/31/ffb400c5ae99daf09687aa6c42831c5d824f71c4851363ed2a4a1ac52bab/nvidia_cuda_nvrtc_cu12-12.6.85-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", upload-time = 2024-11-20T17:38:06Z, size = 23649944, hashes = { sha256 = "800927308ccc5dd6246d3f61f7fcef2ed7ec4e59e199090d360d3293f78bd5a2" } }]
+
+[[packages]]
+name = "nvidia-cuda-runtime-cu12"
+version = "12.6.77"
+marker = "sys_platform == 'linux'"
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e1/23/e717c5ac26d26cf39a27fbc076240fad2e3b817e5889d671b67f4f9f49c5/nvidia_cuda_runtime_cu12-12.6.77-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", upload-time = 2024-11-20T17:35:30Z, size = 897690, hashes = { sha256 = "ba3b56a4f896141e25e19ab287cd71e52a6a0f4b29d0d31609f60e3b4d5219b7" } },
+    { url = "https://files.pythonhosted.org/packages/f0/62/65c05e161eeddbafeca24dc461f47de550d9fa8a7e04eb213e32b55cfd99/nvidia_cuda_runtime_cu12-12.6.77-py3-none-manylinux2014_x86_64.whl", upload-time = 2024-10-01T16:57:33Z, size = 897678, hashes = { sha256 = "a84d15d5e1da416dd4774cb42edf5e954a3e60cc945698dc1d5be02321c44dc8" } },
+]
+
+[[packages]]
+name = "nvidia-cudnn-cu12"
+version = "9.10.2.21"
+marker = "sys_platform == 'linux'"
+wheels = [{ url = "https://files.pythonhosted.org/packages/ba/51/e123d997aa098c61d029f76663dedbfb9bc8dcf8c60cbd6adbe42f76d049/nvidia_cudnn_cu12-9.10.2.21-py3-none-manylinux_2_27_x86_64.whl", upload-time = 2025-06-06T21:54:08Z, size = 706758467, hashes = { sha256 = "949452be657fa16687d0930933f032835951ef0892b37d2d53824d1a84dc97a8" } }]
+
+[[packages]]
+name = "nvidia-cufft-cu12"
+version = "11.3.0.4"
+marker = "sys_platform == 'linux'"
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8f/16/73727675941ab8e6ffd86ca3a4b7b47065edcca7a997920b831f8147c99d/nvidia_cufft_cu12-11.3.0.4-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", upload-time = 2024-11-20T17:41:32Z, size = 200221632, hashes = { sha256 = "ccba62eb9cef5559abd5e0d54ceed2d9934030f51163df018532142a8ec533e5" } },
+    { url = "https://files.pythonhosted.org/packages/60/de/99ec247a07ea40c969d904fc14f3a356b3e2a704121675b75c366b694ee1/nvidia_cufft_cu12-11.3.0.4-py3-none-manylinux2014_x86_64.whl", upload-time = 2024-10-01T17:03:58Z, size = 200221622, hashes = { sha256 = "768160ac89f6f7b459bee747e8d175dbf53619cfe74b2a5636264163138013ca" } },
+]
+
+[[packages]]
+name = "nvidia-cufile-cu12"
+version = "1.11.1.6"
+marker = "sys_platform == 'linux'"
+wheels = [{ url = "https://files.pythonhosted.org/packages/b2/66/cc9876340ac68ae71b15c743ddb13f8b30d5244af344ec8322b449e35426/nvidia_cufile_cu12-1.11.1.6-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", upload-time = 2024-11-20T17:42:11Z, size = 1142103, hashes = { sha256 = "cc23469d1c7e52ce6c1d55253273d32c565dd22068647f3aa59b3c6b005bf159" } }]
+
+[[packages]]
+name = "nvidia-curand-cu12"
+version = "10.3.7.77"
+marker = "sys_platform == 'linux'"
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/73/1b/44a01c4e70933637c93e6e1a8063d1e998b50213a6b65ac5a9169c47e98e/nvidia_curand_cu12-10.3.7.77-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", upload-time = 2024-11-20T17:42:50Z, size = 56279010, hashes = { sha256 = "a42cd1344297f70b9e39a1e4f467a4e1c10f1da54ff7a85c12197f6c652c8bdf" } },
+    { url = "https://files.pythonhosted.org/packages/4a/aa/2c7ff0b5ee02eaef890c0ce7d4f74bc30901871c5e45dee1ae6d0083cd80/nvidia_curand_cu12-10.3.7.77-py3-none-manylinux2014_x86_64.whl", upload-time = 2024-10-01T17:04:45Z, size = 56279000, hashes = { sha256 = "99f1a32f1ac2bd134897fc7a203f779303261268a65762a623bf30cc9fe79117" } },
+]
+
+[[packages]]
+name = "nvidia-cusolver-cu12"
+version = "11.7.1.2"
+marker = "sys_platform == 'linux'"
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f0/6e/c2cf12c9ff8b872e92b4a5740701e51ff17689c4d726fca91875b07f655d/nvidia_cusolver_cu12-11.7.1.2-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", upload-time = 2024-11-20T17:43:43Z, size = 158229790, hashes = { sha256 = "e9e49843a7707e42022babb9bcfa33c29857a93b88020c4e4434656a655b698c" } },
+    { url = "https://files.pythonhosted.org/packages/9f/81/baba53585da791d043c10084cf9553e074548408e04ae884cfe9193bd484/nvidia_cusolver_cu12-11.7.1.2-py3-none-manylinux2014_x86_64.whl", upload-time = 2024-10-01T17:05:39Z, size = 158229780, hashes = { sha256 = "6cf28f17f64107a0c4d7802be5ff5537b2130bfc112f25d5a30df227058ca0e6" } },
+]
+
+[[packages]]
+name = "nvidia-cusparse-cu12"
+version = "12.5.4.2"
+marker = "sys_platform == 'linux'"
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/06/1e/b8b7c2f4099a37b96af5c9bb158632ea9e5d9d27d7391d7eb8fc45236674/nvidia_cusparse_cu12-12.5.4.2-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", upload-time = 2024-11-20T17:44:54Z, size = 216561367, hashes = { sha256 = "7556d9eca156e18184b94947ade0fba5bb47d69cec46bf8660fd2c71a4b48b73" } },
+    { url = "https://files.pythonhosted.org/packages/43/ac/64c4316ba163e8217a99680c7605f779accffc6a4bcd0c778c12948d3707/nvidia_cusparse_cu12-12.5.4.2-py3-none-manylinux2014_x86_64.whl", upload-time = 2024-10-01T17:06:29Z, size = 216561357, hashes = { sha256 = "23749a6571191a215cb74d1cdbff4a86e7b19f1200c071b3fcf844a5bea23a2f" } },
+]
+
+[[packages]]
+name = "nvidia-cusparselt-cu12"
+version = "0.7.1"
+marker = "sys_platform == 'linux'"
+wheels = [{ url = "https://files.pythonhosted.org/packages/56/79/12978b96bd44274fe38b5dde5cfb660b1d114f70a65ef962bcbbed99b549/nvidia_cusparselt_cu12-0.7.1-py3-none-manylinux2014_x86_64.whl", upload-time = 2025-02-26T00:15:44Z, size = 287193691, hashes = { sha256 = "f1bb701d6b930d5a7cea44c19ceb973311500847f81b634d802b7b539dc55623" } }]
+
+[[packages]]
+name = "nvidia-nccl-cu12"
+version = "2.29.3"
+marker = "sys_platform == 'linux'"
+wheels = [{ url = "https://files.pythonhosted.org/packages/31/5a/cac7d231f322b66caa16fd4b136ebc8e4b18b2805811c2d58dc47210cdea/nvidia_nccl_cu12-2.29.3-py3-none-manylinux_2_18_x86_64.whl", upload-time = 2026-02-03T21:11:37Z, size = 289760316, hashes = { sha256 = "35ad42e7d5d722a83c36a3a478e281c20a5646383deaf1b9ed1a9ab7d61bed53" } }]
+
+[[packages]]
+name = "nvidia-nvjitlink-cu12"
+version = "12.6.85"
+marker = "sys_platform == 'linux'"
+wheels = [{ url = "https://files.pythonhosted.org/packages/9d/d7/c5383e47c7e9bf1c99d5bd2a8c935af2b6d705ad831a7ec5c97db4d82f4f/nvidia_nvjitlink_cu12-12.6.85-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", upload-time = 2024-11-20T17:46:53Z, size = 19744971, hashes = { sha256 = "eedc36df9e88b682efe4309aa16b5b4e78c2407eac59e8c10a6a47535164369a" } }]
+
+[[packages]]
+name = "nvidia-nvshmem-cu12"
+version = "3.4.5"
+marker = "sys_platform == 'linux'"
+wheels = [{ url = "https://files.pythonhosted.org/packages/b5/09/6ea3ea725f82e1e76684f0708bbedd871fc96da89945adeba65c3835a64c/nvidia_nvshmem_cu12-3.4.5-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", upload-time = 2025-09-06T00:32:31Z, size = 139103095, hashes = { sha256 = "042f2500f24c021db8a06c5eec2539027d57460e1c1a762055a6554f72c369bd" } }]
+
+[[packages]]
+name = "nvidia-nvtx-cu12"
+version = "12.6.77"
+marker = "sys_platform == 'linux'"
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/56/9a/fff8376f8e3d084cd1530e1ef7b879bb7d6d265620c95c1b322725c694f4/nvidia_nvtx_cu12-12.6.77-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", upload-time = 2024-11-20T17:38:27Z, size = 89276, hashes = { sha256 = "b90bed3df379fa79afbd21be8e04a0314336b8ae16768b58f2d34cb1d04cd7d2" } },
+    { url = "https://files.pythonhosted.org/packages/9e/4e/0d0c945463719429b7bd21dece907ad0bde437a2ff12b9b12fee94722ab0/nvidia_nvtx_cu12-12.6.77-py3-none-manylinux2014_x86_64.whl", upload-time = 2024-10-01T17:00:38Z, size = 89265, hashes = { sha256 = "6574241a3ec5fdc9334353ab8c479fe75841dbe8f4532a8fc97ce63503330ba1" } },
+]
+
+[[packages]]
+name = "setuptools"
+version = "84.0.0"
+sdist = { url = "https://files.pythonhosted.org/packages/6d/44/f5da03a8ef95d369145c5bb53050e7877c9f3d312e128605fd9504829143/setuptools-84.0.0.tar.gz", upload-time = 2026-08-08T18:27:58Z, size = 1168449, hashes = { sha256 = "f4695c21257f0d9b537ec2692c941d02ee143b7cc1276941349a546573b2ef73" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/95/9c/c510029fc6ef33a6275cd2c5d3cecd6613dfd6aa401d57c54f1c18852ccf/setuptools-84.0.0-py3-none-any.whl", upload-time = 2026-08-08T18:27:56Z, size = 818216, hashes = { sha256 = "51a52592b3b99e102b609654876bd65f19f999935166d1352678931132b0c670" } }]
+
+[[packages]]
+name = "sympy"
+version = "1.14.0"
+sdist = { url = "https://files.pythonhosted.org/packages/83/d3/803453b36afefb7c2bb238361cd4ae6125a569b4db67cd9e79846ba2d68c/sympy-1.14.0.tar.gz", upload-time = 2025-04-27T18:05:01Z, size = 7793921, hashes = { sha256 = "d3d3fe8df1e5a0b42f0e7bdf50541697dbe7d23746e894990c030e2b05e72517" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/a2/09/77d55d46fd61b4a135c444fc97158ef34a095e5681d0a6c10b75bf356191/sympy-1.14.0-py3-none-any.whl", upload-time = 2025-04-27T18:04:59Z, size = 6299353, hashes = { sha256 = "e091cc3e99d2141a0ba2847328f5479b05d94a6635cb96148ccb3f34671bd8f5" } }]
+
+[[packages]]
+name = "torch"
+version = "2.13.0+cu126"
+wheels = [{ url = "https://download-r2.pytorch.org/whl/cu126/torch-2.13.0%2Bcu126-cp314-cp314-manylinux_2_28_x86_64.whl", upload-time = 2026-07-08T19:50:59Z, hashes = { sha256 = "affd3b49a4e48aef895ffd9e196181bd505422d7c37b4a6f9afa76899d2acd3d" } }]
+
+[[packages]]
+name = "torchaudio"
+version = "2.11.0+cu126"
+wheels = [{ url = "https://download-r2.pytorch.org/whl/cu126/torchaudio-2.11.0%2Bcu126-cp314-cp314-manylinux_2_28_x86_64.whl", upload-time = 2026-03-23T15:50:21Z, hashes = { sha256 = "08800408b1ab0a1992aea704b788103285703d009e232228886f9efa3cbc6a1b" } }]
+
+[[packages]]
+name = "triton"
+version = "3.7.1"
+marker = "python_full_version < '3.15' and sys_platform == 'linux'"
+wheels = [{ url = "https://download-r2.pytorch.org/whl/triton-3.7.1-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", upload-time = 2026-06-17T16:39:58Z, hashes = { sha256 = "c56cb810349d3699020b5b7695429b9b997574dab1b9f46b2b63fa23d7954894" } }]
+
+[[packages]]
+name = "typing-extensions"
+version = "4.16.0"
+sdist = { url = "https://files.pythonhosted.org/packages/f6/cc/6253133b5bb138fc3306cebfbda2c520f545d36b5be2c7255cc528bb45d6/typing_extensions-4.16.0.tar.gz", upload-time = 2026-07-02T08:40:05Z, size = 113555, hashes = { sha256 = "dc983d19a509c94dba722ee6abd33940f7c05a89e243c47e907eb4db6f1a43e5" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/49/d3/b8441a820a491ddfc024b0b0cf0393375b75ea13866d9c66727e54c2fc80/typing_extensions-4.16.0-py3-none-any.whl", upload-time = 2026-07-02T08:40:04Z, size = 45571, hashes = { sha256 = "481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8" } }]

--- a/scripts/flatpak-cache.test.mjs
+++ b/scripts/flatpak-cache.test.mjs
@@ -1,22 +1,30 @@
 import assert from "node:assert/strict";
 import { createHash } from "node:crypto";
 import { EventEmitter } from "node:events";
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, utimesSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, lstatSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, renameSync, rmSync, statSync, symlinkSync, truncateSync, utimesSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { spawnSync } from "node:child_process";
+import { createServer } from "node:net";
 import test from "node:test";
 import {
   cacheNamespace,
   buildFlatpakBundles,
   cleanupFlatpakBundleOutputs,
   compareCacheReports,
+  compareCrossProfileCacheReports,
+  defaultFlatpakBundleConcurrency,
   digestBuildPayload,
   enforceFlatpakBundleSize,
   flatpakArtifactSizeReport,
   flatpakBundlePlan,
+  flatpakBundleStatePath,
+  flatpakBundleSizeReportFromCheckout,
+  flatpakBundleWorkerLimit,
+  flatpakOutputStatePath,
   flatpakSizeReport,
   frontendModuleInputPaths,
+  manifestWithPackageOptions,
   isValidPnpmCacheReport,
   normalizeGeneratedModelBundleManifest,
   parseSccacheStats,
@@ -26,10 +34,18 @@ import {
   resolveSourceDateEpoch,
   selectedFlatpakOutputRefs,
   verifyFlatpakOutputRefs,
+  readFlatpakOutputState,
+  reuseFlatpakBundles,
+  selectPreservedFlatpakOutputState,
+  validateFlatpakOutputState,
+  writeFlatpakOutputState,
   writeFlatpakChecksums,
   withFreshFlatpakBundleOutputs,
+  expectedFlatpakModuleOrder,
+  parseFlatpakModuleCacheOutput,
 } from "./package-flatpak.mjs";
 import { parsePackageOptions } from "./package-options.mjs";
+import { compareUtf8, createFlatpakSourceSnapshot, flatpakSourceSnapshotInputs } from "./flatpak-source-snapshots.mjs";
 
 const manifest = readFileSync(
   new URL("../packaging/flatpak/com.tuneforge.desktop.yml", import.meta.url),
@@ -50,7 +66,60 @@ function moduleSource(name, nextName) {
   return manifest.slice(start, end);
 }
 
-test("Flatpak cache namespace includes every invalidation dimension", () => {
+function cacheReportFixture({ profiles = ["cpu"], statuses = "executed", outputMode } = {}) {
+  const options = parsePackageOptions(profiles.map((profile) => `--${profile}`), { platform: "linux" });
+  const namespace = cacheNamespace(options);
+  const names = expectedFlatpakModuleOrder(manifestWithPackageOptions(manifest, options));
+  const modules = names.map((name, index) => ({
+    name,
+    status: typeof statuses === "function" ? statuses(name, index) : statuses,
+  }));
+  const firstInvalidatedModule = modules.find(({ status }) => status === "executed")?.name ?? null;
+  return {
+    schema: "flatpak-cache-v1",
+    namespace: namespace.name,
+    namespaceInputs: namespace.inputs,
+    selectedProfiles: options.flatpakProfiles,
+    payload: { sha256: "c".repeat(64), entryCount: 4 },
+    refCommits: selectedFlatpakOutputRefs(options.flatpakProfiles).map(({ id, ref }, index) => ({
+      id, ref, commitSha256: String(index).padStart(64, "a"),
+    })),
+    errors: [],
+    moduleCache: { mode: "enabled", observationComplete: true, firstInvalidatedModule, modules },
+    output: {
+      mode: outputMode ?? (statuses === "cached" ? "preserved-unchanged" : "exported"),
+      observationComplete: true,
+      payloadObservationSource: statuses === "cached" ? "output-state" : "checkout",
+    },
+  };
+}
+
+function checkoutSizeFixture() {
+  return {
+    schema: "flatpak-size-v1",
+    unit: "bytes",
+    compressedBundle: { path: "Tuneforge.flatpak", available: false },
+    installedApp: { path: "/app", available: true, bytes: 10, topLevelDirectories: [{ path: "/app/lib", bytes: 10 }] },
+    pythonRuntime: { path: "/app/lib/tuneforge/backend/python", available: true, bytes: 4 },
+    sitePackages: { path: "/app/lib/tuneforge/backend/site-packages", available: true, bytes: 6 },
+    wheelInputs: { knownBytes: 0, unknownCount: 0, complete: true, entries: [] },
+    sourceArchives: { knownBytes: 0, unknownCount: 0, complete: true, entries: [] },
+  };
+}
+
+function outputStateFixture({ profiles = ["cpu"], payload = { sha256: "c".repeat(64), entryCount: 4 } } = {}) {
+  const report = cacheReportFixture({ profiles });
+  return {
+    namespace: report.namespace,
+    namespaceInputs: report.namespaceInputs,
+    selectedProfiles: report.selectedProfiles,
+    payload,
+    refCommits: report.refCommits,
+    checkoutSize: checkoutSizeFixture(),
+  };
+}
+
+test("Flatpak cache namespace shares profiles but keeps non-profile invalidation dimensions", () => {
   const defaults = parsePackageOptions([], { platform: "linux" });
   const first = cacheNamespace(defaults, "1.3.0");
   const second = cacheNamespace(defaults, "1.3.0");
@@ -70,10 +139,12 @@ test("Flatpak cache namespace includes every invalidation dimension", () => {
   const noBundle = parsePackageOptions(["--no-bundle"], { platform: "linux" });
   assert.equal(cacheNamespace(explicitAll, "1.3.0").name, first.name);
   assert.equal(cacheNamespace(noBundle, "1.3.0").name, first.name);
-  assert.notEqual(
+  assert.equal(
     cacheNamespace(parsePackageOptions(["--cpu"], { platform: "linux" }), "1.3.0").name,
     cacheNamespace(parsePackageOptions(["--nvidia"], { platform: "linux" }), "1.3.0").name,
   );
+  assert.equal(Object.hasOwn(first.inputs, "selectedProfiles"), false);
+  assert.equal(Object.hasOwn(first.inputs.packageOptions, "flatpakProfiles"), false);
 });
 
 test("Flatpak state and cache roots reject force-clean overlap and unsafe roots", () => {
@@ -104,6 +175,13 @@ test("source date epoch is validated, stable, and passed to Flatpak builder", ()
   assert.throws(() => resolveSourceDateEpoch({ override: "0" }), /SOURCE_DATE_EPOCH/);
   assert.equal(resolveSourceDateEpoch({ root: mkdtempSync(path.join(os.tmpdir(), "tuneforge-no-git-")), override: undefined }), "1");
   assert.match(packageScript, /--override-source-date-epoch=\$\{sourceDateEpoch\}/);
+});
+
+test("Flatpak packaging uses a per-invocation flock handshake", () => {
+  assert.match(packageScript, /flock", \["--verbose", lockPath/);
+  assert.match(packageScript, /Waiting for Flatpak packaging lock/);
+  assert.match(packageScript, /--flatpak-lock-token=\$\{token\}/);
+  assert.doesNotMatch(packageScript, /TUNEFORGE_FLATPAK_LOCK_HELD/);
 });
 
 test("generated model bundle manifest gets the source date epoch", () => {
@@ -163,17 +241,166 @@ test("Flatpak modules split frontend, Rust, and backend source boundaries", () =
   const frontend = moduleSource("tuneforge-frontend", "sccache");
   const desktop = moduleSource("tuneforge-desktop", "cpython-3.14");
   const backend = moduleSource("tuneforge-backend");
-  assert.match(frontend, /apps\/desktop\/src/);
+  assert.match(frontend, /generated\/frontend-snapshot\.tar/);
   assert.match(frontend, /frontend-version\.json/);
   assert.doesNotMatch(frontend, /apps\/backend|src-tauri\/Cargo/);
   assert.match(desktop, /frontend-dist\/. apps\/desktop\/dist/);
   assert.match(desktop, /RUSTC_WRAPPER: \/app\/bin\/sccache/);
+  assert.match(desktop, /generated\/desktop-snapshot\.tar/);
   assert.doesNotMatch(desktop, /apps\/backend|apps\/desktop\/src$/m);
-  assert.match(backend, /apps\/backend\/app/);
+  assert.match(backend, /generated\/backend-snapshot\.tar/);
   assert.doesNotMatch(backend, /cargo-sources|seed-pnpm-store|vite\.config/);
   assert.match(manifest, /sccache-v0\.17\.0-x86_64-unknown-linux-musl\.tar\.gz/);
   assert.match(manifest, /67c4a96dd237c1f518f6b36083f270f9976d516f1e57fce891755ea782e50006/);
   assert.match(backend, /rm -rf .*\/app\/bin\/sccache/);
+});
+
+test("source snapshots are deterministic and preserve files, modes, empty directories, and links", () => {
+  const root = mkdtempSync(path.join(os.tmpdir(), "tuneforge-source-snapshot-"));
+  const first = path.join(root, "first.tar");
+  const second = path.join(root, "second.tar");
+  try {
+    mkdirSync(path.join(root, "input", "empty"), { recursive: true });
+    writeFileSync(path.join(root, "input", "a"), "one");
+    writeFileSync(path.join(root, "input", "b"), "two");
+    chmodSync(path.join(root, "input", "a"), 0o755);
+    symlinkSync("a", path.join(root, "input", "link"));
+    createFlatpakSourceSnapshot({ root, outputPath: first, inputs: [{ source: "input" }], sourceDateEpoch: "123" });
+    utimesSync(path.join(root, "input", "a"), new Date(1), new Date(2));
+    createFlatpakSourceSnapshot({ root, outputPath: second, inputs: [{ source: "input" }], sourceDateEpoch: "123" });
+    assert.deepEqual(readFileSync(second), readFileSync(first));
+    writeFileSync(path.join(root, "input", "a"), "changed");
+    createFlatpakSourceSnapshot({ root, outputPath: second, inputs: [{ source: "input" }], sourceDateEpoch: "123" });
+    assert.notDeepEqual(readFileSync(second), readFileSync(first));
+    writeFileSync(path.join(root, "input", "a"), "one");
+    chmodSync(path.join(root, "input", "a"), 0o644);
+    createFlatpakSourceSnapshot({ root, outputPath: second, inputs: [{ source: "input" }], sourceDateEpoch: "123" });
+    assert.notDeepEqual(readFileSync(second), readFileSync(first));
+    chmodSync(path.join(root, "input", "a"), 0o755);
+    rmSync(path.join(root, "input", "link"));
+    symlinkSync("b", path.join(root, "input", "link"));
+    createFlatpakSourceSnapshot({ root, outputPath: second, inputs: [{ source: "input" }], sourceDateEpoch: "123" });
+    assert.notDeepEqual(readFileSync(second), readFileSync(first));
+    const archive = readFileSync(first);
+    const members = [];
+    for (let offset = 0; offset < archive.length - 1024;) {
+      const name = archive.subarray(offset, offset + 100).toString("utf8").replace(/\0.*$/, "");
+      const size = Number.parseInt(archive.subarray(offset + 124, offset + 136).toString("utf8"), 8);
+      if (!name) break;
+      members.push({ name, mode: archive.subarray(offset + 100, offset + 108).toString("utf8"), type: String.fromCharCode(archive[offset + 156]), link: archive.subarray(offset + 157, offset + 257).toString("utf8").replace(/\0.*$/, "") });
+      offset += 512 + Math.ceil(size / 512) * 512;
+    }
+    assert.deepEqual(members.map(({ name }) => name), ["input/", "input/a", "input/b", "input/empty/", "input/link"]);
+    assert.match(members.find(({ name }) => name === "input/a").mode, /^0000755/);
+    assert.deepEqual(members.find(({ name }) => name === "input/link"), { name: "input/link", mode: "0000777\u0000", type: "2", link: "a" });
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("source snapshots use byte ordering and retain the exact Flatpak input mappings", () => {
+  const root = mkdtempSync(path.join(os.tmpdir(), "tuneforge-source-snapshot-order-"));
+  try {
+    const names = ["b", "a"];
+    for (const [directory, order] of [["first", names], ["second", [...names].reverse()]]) {
+      mkdirSync(path.join(root, directory), { recursive: true });
+      for (const name of order) writeFileSync(path.join(root, directory, name), "same");
+    }
+    const first = path.join(root, "first.tar");
+    const second = path.join(root, "second.tar");
+    createFlatpakSourceSnapshot({ root, outputPath: first, inputs: [{ source: "first", destination: "input" }], sourceDateEpoch: "1" });
+    createFlatpakSourceSnapshot({ root, outputPath: second, inputs: [{ source: "second", destination: "input" }], sourceDateEpoch: "1" });
+    assert.deepEqual(readFileSync(first), readFileSync(second));
+    const unicodeNames = ["é", "e\u0301"];
+    assert.equal(unicodeNames[0].localeCompare(unicodeNames[1]), 0);
+    assert.deepEqual([...unicodeNames].sort(compareUtf8), ["e\u0301", "é"]);
+    assert.deepEqual(flatpakSourceSnapshotInputs.frontend.map((input) => typeof input === "string" ? input : `${input.source}:${input.destination}`), [
+      "package.json", "pnpm-lock.yaml", "pnpm-workspace.yaml", "scripts/build-info.mjs",
+      "packaging/flatpak/seed-pnpm-store.mjs:seed-pnpm-store.mjs", "apps/desktop/package.json", "apps/desktop/index.html",
+      "apps/desktop/tsconfig.json", "apps/desktop/tsconfig.node.json", "apps/desktop/vite.config.ts", "apps/desktop/src",
+      "packages/shared-types/package.json", "packages/shared-types/src",
+    ]);
+    assert.deepEqual(flatpakSourceSnapshotInputs.desktop, [
+      "apps/desktop/src-tauri/Cargo.lock", "apps/desktop/src-tauri/Cargo.toml", "apps/desktop/src-tauri/build.rs",
+      "apps/desktop/src-tauri/tauri.conf.json", "apps/desktop/src-tauri/capabilities", "apps/desktop/src-tauri/icons",
+      "apps/desktop/src-tauri/resources", "apps/desktop/src-tauri/src",
+    ]);
+    assert.deepEqual(flatpakSourceSnapshotInputs.backend.map((input) => typeof input === "string" ? input : `${input.source}:${input.destination}`), [
+      "README.md", "LICENSE", "THIRD_PARTY_NOTICES.md", "LICENSES/crema-0.2.0-BSD-2-Clause.txt", "docs/PACKAGING.md",
+      "apps/backend/app", "apps/backend/alembic", "apps/backend/alembic.ini", "apps/backend/pyproject.toml",
+      "packaging/demucs/models.json:apps/backend/demucs-models.json", "packaging/flatpak/ffmpeg-wrapper.sh:ffmpeg",
+      "packaging/flatpak/ffprobe-wrapper.sh:ffprobe", "packaging/flatpak/com.tuneforge.desktop.desktop:com.tuneforge.desktop.desktop",
+      "packaging/flatpak/com.tuneforge.desktop.metainfo.xml:com.tuneforge.desktop.metainfo.xml",
+      "apps/desktop/src-tauri/icons/32x32.png:icons/32x32.png", "apps/desktop/src-tauri/icons/128x128.png:icons/128x128.png",
+      "apps/desktop/src-tauri/icons/512x512.png:icons/512x512.png",
+    ]);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("source snapshots reject duplicate paths, unsafe paths, and unsupported inputs", () => {
+  const root = mkdtempSync(path.join(os.tmpdir(), "tuneforge-source-snapshot-errors-"));
+  try {
+    writeFileSync(path.join(root, "file"), "fixture");
+    assert.throws(() => createFlatpakSourceSnapshot({ root, outputPath: path.join(root, "out.tar"), inputs: [{ source: "file" }, { source: "file" }], sourceDateEpoch: "1" }), /Duplicate/);
+    assert.throws(() => createFlatpakSourceSnapshot({ root, outputPath: path.join(root, "out.tar"), inputs: [{ source: "../outside" }], sourceDateEpoch: "1" }), /Unsafe/);
+    assert.throws(() => createFlatpakSourceSnapshot({ root, outputPath: path.join(root, "out.tar"), inputs: [{ source: "file", destination: `${"a".repeat(156)}/file` }], sourceDateEpoch: "1" }), /USTAR path overflow/);
+    const sparse = path.join(root, "sparse");
+    writeFileSync(sparse, "");
+    truncateSync(sparse, 8 ** 11);
+    assert.throws(() => createFlatpakSourceSnapshot({ root, outputPath: path.join(root, "out.tar"), inputs: [{ source: "sparse" }], sourceDateEpoch: "1" }), /USTAR size overflow/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("source snapshots reject Unix sockets", { skip: process.platform === "win32" }, async (context) => {
+  const root = mkdtempSync(path.join(os.tmpdir(), "tuneforge-source-snapshot-socket-"));
+  const socketPath = path.join(root, "socket");
+  const server = createServer();
+  let listening = false;
+  try {
+    try {
+      await new Promise((resolve, reject) => {
+        server.once("error", reject);
+        server.listen(socketPath, () => resolve());
+      });
+      listening = true;
+    } catch (error) {
+      if (error?.code === "EPERM" || error?.code === "EAFNOSUPPORT") return context.skip("Unix sockets unavailable");
+      throw error;
+    }
+    assert.throws(() => createFlatpakSourceSnapshot({ root, outputPath: path.join(root, "out.tar"), inputs: [{ source: "socket" }], sourceDateEpoch: "1" }), /Unsupported snapshot entry type/);
+  } finally {
+    if (listening) await new Promise((resolve) => server.close(resolve));
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("module cache output is anchored, complete only when observed, and profile order follows manifest", () => {
+  const expected = expectedFlatpakModuleOrder(manifestWithPackageOptions(
+    manifest,
+    parsePackageOptions(["--cpu"], { platform: "linux" }),
+  ));
+  assert.equal(expected.includes("nvidia-torch-core-extension"), false);
+  const complete = parseFlatpakModuleCacheOutput(expected.map((name) => `\u001b[32mCache hit for ${name}, skipping build\u001b[0m`).join("\r\n"), expected);
+  assert.equal(complete.observationComplete, true);
+  assert.equal(complete.firstInvalidatedModule, null);
+  assert.ok(complete.modules.every(({ status }) => status === "cached"));
+  const partial = parseFlatpakModuleCacheOutput("\u001b[32mBuilding module pnpm in /run/build/pnpm\u001b[0m\nnoise Building module node-sources in /run/build/node-sources", expected);
+  assert.equal(partial.observationComplete, false);
+  assert.equal(partial.firstInvalidatedModule, "pnpm");
+  const spacedPath = parseFlatpakModuleCacheOutput("Building module pnpm in /tmp/build root/pnpm-1", expected);
+  assert.equal(spacedPath.modules[0].status, "executed");
+  const uncertainPrefix = parseFlatpakModuleCacheOutput(`Building module ${expected[1]} in /run/build/${expected[1]}`, expected);
+  assert.equal(uncertainPrefix.firstInvalidatedModule, null);
+  const conflict = parseFlatpakModuleCacheOutput("Cache hit for pnpm, skipping build\nBuilding module pnpm in /run/build/pnpm", expected, { evidence: true });
+  assert.equal(conflict.mode, "disabled-for-evidence");
+  assert.equal(conflict.observationComplete, false);
+  assert.equal(conflict.modules[0].status, "unknown");
+  const nearMisses = parseFlatpakModuleCacheOutput("Cache hit for pnpm\nBuilding module pnpm\nBuilding module pnpm in relative/path", expected);
+  assert.equal(nearMisses.modules[0].status, "unknown");
 });
 
 test("sccache JSON stats are normalized and fail closed on malformed or error data", () => {
@@ -240,27 +467,73 @@ test("payload digest is metadata-complete, order-stable, and content-sensitive",
 });
 
 test("cold and warm reports compare payloads and propagate report errors", () => {
-  const refCommits = [
-    { id: "cpu", commitSha256: "a".repeat(64) },
-    { id: "nvidia-core", commitSha256: "b".repeat(64) },
-    { id: "nvidia-runtime", commitSha256: "c".repeat(64) },
-    { id: "legacy-nvidia-core", commitSha256: "d".repeat(64) },
-    { id: "legacy-nvidia-runtime", commitSha256: "e".repeat(64) },
-  ];
-  const cold = { namespace: "same", payload: { sha256: "abc", entryCount: 4 }, refCommits, errors: [] };
-  const warm = { namespace: "same", payload: { sha256: "abc", entryCount: 4 }, refCommits, errors: [] };
+  const cold = cacheReportFixture({ profiles: ["cpu", "nvidia", "legacy-nvidia"] });
+  const warm = cacheReportFixture({ profiles: ["cpu", "nvidia", "legacy-nvidia"], statuses: "cached" });
   assert.equal(compareCacheReports(cold, warm).equivalent, true);
   assert.deepEqual(
-    compareCacheReports(cold, { ...warm, payload: { sha256: "def", entryCount: 4 } }).errors,
+    compareCacheReports(cold, { ...warm, payload: { sha256: "d".repeat(64), entryCount: 4 } }).errors,
+    ["Cold and warm payload digests differ."],
+  );
+  assert.deepEqual(
+    compareCacheReports(cold, { ...warm, payload: { ...warm.payload, entryCount: 5 } }).errors,
     ["Cold and warm payload digests differ."],
   );
   assert.equal(compareCacheReports(cold, { ...warm, errors: ["stats error"] }).equivalent, false);
+  assert.equal(compareCacheReports(cold, { ...warm, output: { ...warm.output, mode: "exported" } }).equivalent, false);
   assert.equal(compareCacheReports(cold, { ...warm, namespace: "different" }).equivalent, false);
-  const changedNvidia = refCommits.map((entry) =>
+  assert.equal(compareCacheReports({ ...cold, schema: "flatpak-cache-unknown" }, warm).equivalent, false);
+  assert.equal(compareCacheReports({ ...cold, namespace: "" }, warm).equivalent, false);
+  assert.equal(compareCacheReports({ ...cold, payload: { sha256: "not-a-digest", entryCount: -1 } }, warm).equivalent, false);
+  assert.equal(compareCacheReports({ ...cold, refCommits: [] }, warm).equivalent, false);
+  assert.equal(compareCacheReports({ ...cold, refCommits: [null] }, warm).equivalent, false);
+  assert.equal(compareCacheReports({ ...cold, errors: "invalid" }, warm).equivalent, false);
+  assert.equal(compareCacheReports(cold, { ...warm, moduleCache: { ...warm.moduleCache, modules: [{ name: "pnpm", status: "unknown" }] } }).equivalent, false);
+  assert.equal(compareCacheReports(null, warm).equivalent, false);
+  assert.equal(compareCacheReports(cold, { ...warm, moduleCache: { ...warm.moduleCache, observationComplete: false } }).equivalent, false);
+  assert.equal(compareCacheReports(cold, { ...warm, moduleCache: { ...warm.moduleCache, firstInvalidatedModule: "pnpm", modules: [{ name: "pnpm", status: "executed" }] } }).equivalent, false);
+  const changedNvidia = cold.refCommits.map((entry) =>
     entry.id === "nvidia-runtime" ? { ...entry, commitSha256: "f".repeat(64) } : entry);
   assert.deepEqual(compareCacheReports(cold, { ...warm, refCommits: changedNvidia }).errors, [
     "Cold and warm Flatpak output ref commits differ.",
   ]);
+});
+
+test("cross-profile cache comparisons require a cached shared module prefix", () => {
+  const source = cacheReportFixture({ profiles: ["cpu"] });
+  const sourceNames = source.moduleCache.modules.map(({ name }) => name);
+  const target = cacheReportFixture({
+    profiles: ["cpu", "nvidia"],
+    statuses: (name) => sourceNames.includes(name) ? "cached" : "executed",
+  });
+  const comparison = compareCrossProfileCacheReports(source, target);
+  assert.equal(comparison.equivalent, true);
+  assert.ok(comparison.sharedModulePrefix.length > 0);
+  assert.equal(comparison.firstTargetExecution, "nvidia-torch-core-extension");
+  assert.equal(compareCrossProfileCacheReports(source, {
+    ...target,
+    moduleCache: { ...target.moduleCache, modules: [{ name: "pnpm", status: "executed" }] },
+  }).equivalent, false);
+  assert.equal(compareCrossProfileCacheReports(source, { ...target, selectedProfiles: ["cpu"] }).equivalent, false);
+  assert.equal(compareCrossProfileCacheReports(source, {
+    ...target,
+    namespaceInputs: { ...target.namespaceInputs, packageOptions: { ...target.namespaceInputs.packageOptions, beatThis: false } },
+  }).equivalent, false);
+  assert.equal(compareCrossProfileCacheReports(source, {
+    ...target,
+    moduleCache: { ...target.moduleCache, modules: [...target.moduleCache.modules].reverse() },
+  }).equivalent, false);
+  assert.equal(compareCrossProfileCacheReports(source, {
+    ...target,
+    refCommits: target.refCommits.map((entry, index) => index === 0 ? { ...entry, ref: "app/forged" } : entry),
+  }).equivalent, false);
+  assert.equal(compareCrossProfileCacheReports(source, {
+    ...target,
+    refCommits: target.refCommits.map((entry, index) => index === 0 ? { ...entry, id: "forged" } : entry),
+  }).equivalent, false);
+  assert.equal(compareCrossProfileCacheReports(source, {
+    ...target,
+    output: { ...target.output, mode: "preserved-unchanged" },
+  }).equivalent, false);
 });
 
 test("Flatpak repo reconciliation removes only known refs and verifies the selected set", () => {
@@ -309,6 +582,124 @@ test("Flatpak repo reconciliation removes only known refs and verifies the selec
     listRefs: () => [known[0]],
     resolveCommit: () => "not-a-digest",
   }), /Malformed commit/);
+});
+
+test("Flatpak output state is atomic, self-healing, and profile-specific", () => {
+  const root = mkdtempSync(path.join(os.tmpdir(), "tuneforge-flatpak-output-state-"));
+  try {
+    const cpu = outputStateFixture();
+    const statePath = flatpakOutputStatePath(root);
+    const written = writeFlatpakOutputState({ statePath, ...cpu });
+    assert.equal(written.schema, "flatpak-output-state-v1");
+    assert.equal(existsSync(statePath), true);
+    assert.equal(readdirSync(root).some((name) => name.includes(".tmp")), false);
+    assert.deepEqual(readFlatpakOutputState({ statePath, ...cpu }), written);
+    assert.deepEqual(validateFlatpakOutputState(written, { ...cpu }), []);
+    const firstWarmNoop = selectPreservedFlatpakOutputState({
+      statePath,
+      namespace: cpu.namespace,
+      selectedProfiles: cpu.selectedProfiles,
+      refCommits: cpu.refCommits,
+    });
+    const secondWarmNoop = selectPreservedFlatpakOutputState({
+      statePath,
+      namespace: cpu.namespace,
+      selectedProfiles: cpu.selectedProfiles,
+      refCommits: cpu.refCommits,
+    });
+    assert.deepEqual(firstWarmNoop, written);
+    assert.deepEqual(secondWarmNoop, written);
+
+    const nvidia = outputStateFixture({ profiles: ["cpu", "nvidia"] });
+    assert.equal(readFlatpakOutputState({ statePath, ...nvidia }), null);
+    assert.equal(existsSync(statePath), false);
+
+    writeFileSync(statePath, "not json\n");
+    assert.equal(readFlatpakOutputState({ statePath, ...cpu }), null);
+    assert.equal(existsSync(statePath), false);
+
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("reused Flatpak checkout size evidence is complete enough for downstream bundle reporting", () => {
+  const root = mkdtempSync(path.join(os.tmpdir(), "tuneforge-flatpak-reused-size-"));
+  try {
+    const { checkoutSize, selectedProfiles } = outputStateFixture();
+    const bundle = path.join(root, "app.flatpak");
+    writeFileSync(bundle, "compressed");
+    const report = flatpakBundleSizeReportFromCheckout({
+      checkoutSize,
+      bundle,
+      selectedProfiles,
+      extensionBundles: [],
+    });
+    assert.equal(report.compressedBundle.available, true);
+    assert.equal(report.installedApp.path, "/app");
+    assert.deepEqual(report.installedApp.topLevelDirectories, [{ path: "/app/lib", bytes: 10 }]);
+    assert.equal(report.selectedProfiles[0], "cpu");
+    const malformed = {
+      ...checkoutSize,
+      installedApp: { ...checkoutSize.installedApp, topLevelDirectories: [{ path: "/wrong", bytes: 1 }] },
+    };
+    assert.throws(
+      () => flatpakBundleSizeReportFromCheckout({ checkoutSize: malformed, bundle, selectedProfiles, extensionBundles: [] }),
+      /checkout size evidence is incomplete/,
+    );
+    assert.ok(validateFlatpakOutputState({ ...outputStateFixture(), checkoutSize: malformed }).length > 0);
+    const malformedCompressed = {
+      ...checkoutSize,
+      compressedBundle: { ...checkoutSize.compressedBundle, bytes: 0 },
+      pythonRuntime: { ...checkoutSize.pythonRuntime, path: "/wrong" },
+    };
+    assert.throws(
+      () => flatpakBundleSizeReportFromCheckout({ checkoutSize: malformedCompressed, bundle, selectedProfiles, extensionBundles: [] }),
+      /checkout size evidence is incomplete/,
+    );
+    const oversizedLib = {
+      ...checkoutSize,
+      installedApp: { ...checkoutSize.installedApp, topLevelDirectories: [{ path: "/app/lib", bytes: 99 }] },
+    };
+    assert.throws(
+      () => flatpakBundleSizeReportFromCheckout({ checkoutSize: oversizedLib, bundle, selectedProfiles, extensionBundles: [] }),
+      /checkout size evidence is incomplete/,
+    );
+    const inconsistentRows = {
+      ...checkoutSize,
+      installedApp: { ...checkoutSize.installedApp, topLevelDirectories: [{ path: "/app/lib", bytes: 4 }] },
+    };
+    assert.throws(
+      () => flatpakBundleSizeReportFromCheckout({ checkoutSize: inconsistentRows, bundle, selectedProfiles, extensionBundles: [] }),
+      /checkout size evidence is incomplete/,
+    );
+    const unavailableBundleCompliance = { ...checkoutSize, compliance: { targetMet: true } };
+    assert.throws(
+      () => flatpakBundleSizeReportFromCheckout({ checkoutSize: unavailableBundleCompliance, bundle, selectedProfiles, extensionBundles: [] }),
+      /checkout size evidence is incomplete/,
+    );
+    const missingLib = {
+      ...checkoutSize,
+      installedApp: { ...checkoutSize.installedApp, topLevelDirectories: [{ path: "/app/share", bytes: 10 }] },
+    };
+    assert.throws(
+      () => flatpakBundleSizeReportFromCheckout({ checkoutSize: missingLib, bundle, selectedProfiles, extensionBundles: [] }),
+      /checkout size evidence is incomplete/,
+    );
+    const subtreesExceedLib = {
+      ...checkoutSize,
+      installedApp: {
+        ...checkoutSize.installedApp,
+        topLevelDirectories: [{ path: "/app/lib", bytes: 9 }, { path: "/app/share", bytes: 1 }],
+      },
+    };
+    assert.throws(
+      () => flatpakBundleSizeReportFromCheckout({ checkoutSize: subtreesExceedLib, bundle, selectedProfiles, extensionBundles: [] }),
+      /checkout size evidence is incomplete/,
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
 });
 
 test("Flatpak size report is deterministic, byte-based, and has no compliance claim without a bundle", () => {
@@ -389,6 +780,75 @@ test("Flatpak bundle size follows a symlink target and requires a regular file",
     rmSync(root, { recursive: true, force: true });
   }
 });
+
+function bundleFixture(root, selectedProfiles = ["cpu", "nvidia", "legacy-nvidia"]) {
+  const plan = flatpakBundlePlan({
+    selectedProfiles,
+    applicationBundle: path.join(root, "app.flatpak"),
+    nvidiaCoreBundle: path.join(root, "nvidia-core.flatpak"),
+    nvidiaRuntimeBundle: path.join(root, "nvidia-runtime.flatpak"),
+    legacyCoreBundle: path.join(root, "legacy-core.flatpak"),
+    legacyRuntimeBundle: path.join(root, "legacy-runtime.flatpak"),
+  });
+  const ids = ["cpu", "nvidia-core", "nvidia-runtime", "legacy-nvidia-core", "legacy-nvidia-runtime"];
+  const refs = [
+    "app/com.tuneforge.desktop/x86_64/stable",
+    "runtime/com.tuneforge.desktop.Torch.Stack.Nvidia.Core/x86_64/stable",
+    "runtime/com.tuneforge.desktop.Torch.Stack.Nvidia.Runtime/x86_64/stable",
+    "runtime/com.tuneforge.desktop.Torch.Stack.LegacyNvidia.Core/x86_64/stable",
+    "runtime/com.tuneforge.desktop.Torch.Stack.LegacyNvidia.Runtime/x86_64/stable",
+  ];
+  const wantedIds = plan.map(({ refId }) => {
+    if (refId === "com.tuneforge.desktop") return "cpu";
+    const legacy = refId.includes("LegacyNvidia");
+    const core = refId.endsWith(".Core");
+    return `${legacy ? "legacy-nvidia" : "nvidia"}-${core ? "core" : "runtime"}`;
+  });
+  const refCommits = wantedIds.map((id) => {
+    const index = ids.indexOf(id);
+    return { id, ref: refs[index], commitSha256: String(index + 1).repeat(64) };
+  });
+  return {
+    plan,
+    refCommits,
+    statePath: flatpakBundleStatePath(path.join(root, "state")),
+    checksumPath: path.join(root, "generated", "SHA256SUMS"),
+    managedBundlePaths: ["app.flatpak", "nvidia-core.flatpak", "nvidia-runtime.flatpak", "legacy-core.flatpak", "legacy-runtime.flatpak"]
+      .map((name) => path.join(root, name)),
+  };
+}
+
+function bundleSpawner(spawned, { failRef } = {}) {
+  return (_command, args) => {
+    const child = new EventEmitter();
+    child.kill = () => queueMicrotask(() => child.emit("exit", null, "SIGTERM"));
+    const output = args.at(-3);
+    const refId = args.at(-2);
+    spawned.push({ output, refId });
+    queueMicrotask(() => {
+      if (refId === failRef) child.emit("exit", 1, null);
+      else {
+        writeFileSync(output, `bundle:${refId}:${spawned.length}`);
+        child.emit("exit", 0, null);
+      }
+    });
+    return child;
+  };
+}
+
+async function runBundleReuse(fixture, spawned, overrides = {}) {
+  return reuseFlatpakBundles({
+    bundlePlan: fixture.plan,
+    refCommits: fixture.refCommits,
+    namespace: "flatpak-cache-v1-test",
+    flatpakVersion: "Flatpak 1.16.1",
+    statePath: fixture.statePath,
+    checksumPath: fixture.checksumPath,
+    managedBundlePaths: fixture.managedBundlePaths,
+    spawnProcess: bundleSpawner(spawned),
+    ...overrides,
+  });
+}
 
 test("Flatpak bundle plan emits the CPU app and exact runtime extension refs", () => {
   const plan = flatpakBundlePlan({
@@ -483,6 +943,276 @@ test("each Flatpak artifact has an independent size gate and stable checksum ent
   }
 });
 
+test("no-bundle path does not invoke bundle cleanup, reuse, checksums, or state", () => {
+  const mainSource = packageScript.slice(
+    packageScript.indexOf("async function main()"),
+    packageScript.indexOf("function runWithPackagingLock()"),
+  );
+  const noBundleBranch = mainSource.slice(mainSource.indexOf("if (skipBundle)"), mainSource.indexOf("try {", mainSource.indexOf("if (skipBundle)")));
+  assert.doesNotMatch(mainSource, /cleanupFlatpakBundleOutputs/);
+  assert.doesNotMatch(noBundleBranch, /reuseFlatpakBundles|writeFlatpakChecksums|bundleStatePath|rmSync\([^)]*flatpak/);
+  assert.match(noBundleBranch, /return;/);
+  assert.match(mainSource, /Flatpak bundle \$\{status\} at/);
+  assert.match(mainSource, /Flatpak checksums verified at/);
+  assert.doesNotMatch(mainSource, /Flatpak (?:bundle|checksums) written/);
+});
+
+test("Flatpak bundles rebuild cold and exact warm reuse is zero-spawn and no-touch", async () => {
+  const root = mkdtempSync(path.join(os.tmpdir(), "tuneforge-flatpak-reuse-"));
+  const fixture = bundleFixture(root);
+  try {
+    mkdirSync(path.dirname(fixture.checksumPath), { recursive: true });
+    for (const artifact of fixture.plan) writeFileSync(artifact.path, "old bundle must be ignored");
+    writeFileSync(fixture.checksumPath, `${"0".repeat(64)}  app.flatpak\n`);
+    const coldSpawned = [];
+    const cold = await runBundleReuse(fixture, coldSpawned);
+    assert.equal(coldSpawned.length, 5);
+    assert.deepEqual(cold.entries.map(({ status }) => status), Array(5).fill("rebuilt"));
+    assert.equal(cold.firstRebuiltArtifact, "cpu");
+    assert.deepEqual(readFileSync(fixture.checksumPath, "utf8").trim().split("\n").map((line) => line.slice(66)), [
+      "app.flatpak", "legacy-core.flatpak", "legacy-runtime.flatpak", "nvidia-core.flatpak", "nvidia-runtime.flatpak",
+    ]);
+    const state = JSON.parse(readFileSync(fixture.statePath, "utf8"));
+    assert.equal(state.schema, "flatpak-bundle-state-v1");
+    assert.equal(state.namespace, "flatpak-cache-v1-test");
+    assert.equal(state.flatpakVersion, "Flatpak 1.16.1");
+    assert.equal(state.arch, "x86_64");
+    assert.equal(state.branch, "stable");
+    assert.match(state.commandContract, /^flatpak build-bundle/);
+    assert.ok(state.entries.every((entry) => path.isAbsolute(entry.outputPath) && entry.bytes > 0));
+
+    const before = [fixture.statePath, fixture.checksumPath, ...fixture.plan.map(({ path: output }) => output)]
+      .map((target) => ({ target, contents: readFileSync(target), mtimeMs: statSync(target).mtimeMs }));
+    const warmSpawned = [];
+    const warm = await runBundleReuse(fixture, warmSpawned);
+    assert.equal(warmSpawned.length, 0);
+    assert.deepEqual(warm.entries.map(({ status }) => status), Array(5).fill("reused"));
+    assert.equal(warm.firstRebuiltArtifact, null);
+    for (const previous of before) {
+      assert.deepEqual(readFileSync(previous.target), previous.contents);
+      assert.equal(statSync(previous.target).mtimeMs, previous.mtimeMs);
+    }
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("bundle reuse invalidates exact NVIDIA and legacy refs independently", async () => {
+  const root = mkdtempSync(path.join(os.tmpdir(), "tuneforge-flatpak-refs-"));
+  const fixture = bundleFixture(root);
+  try {
+    await runBundleReuse(fixture, []);
+    const legacy = fixture.refCommits.find(({ id }) => id === "legacy-nvidia-core");
+    legacy.commitSha256 = "a".repeat(64);
+    const legacySpawned = [];
+    const legacyReport = await runBundleReuse(fixture, legacySpawned);
+    assert.deepEqual(legacySpawned.map(({ refId }) => refId), ["com.tuneforge.desktop.Torch.Stack.LegacyNvidia.Core"]);
+    assert.equal(legacyReport.entries.find(({ name }) => name === "cpu").status, "reused");
+    assert.equal(legacyReport.entries.find(({ name }) => name === "legacy-nvidia-runtime").status, "reused");
+
+    const nvidia = fixture.refCommits.find(({ id }) => id === "nvidia-runtime");
+    nvidia.commitSha256 = "b".repeat(64);
+    const nvidiaSpawned = [];
+    const nvidiaReport = await runBundleReuse(fixture, nvidiaSpawned);
+    assert.deepEqual(nvidiaSpawned.map(({ refId }) => refId), ["com.tuneforge.desktop.Torch.Stack.Nvidia.Runtime"]);
+    assert.equal(nvidiaReport.entries.filter(({ status }) => status === "rebuilt").length, 1);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("bundle state, checksum, path, ref, and file mismatches fail closed at the right scope", async (t) => {
+  const cases = [
+    ["malformed state", 5, ({ fixture }) => writeFileSync(fixture.statePath, "{broken")],
+    ["wrong command contract", 5, ({ state, fixture }) => {
+      state.commandContract = "old contract";
+      writeFileSync(fixture.statePath, JSON.stringify(state));
+    }],
+    ["wrong Flatpak version", 5, ({ state, fixture }) => {
+      state.flatpakVersion = "Flatpak 0.0.0";
+      writeFileSync(fixture.statePath, JSON.stringify(state));
+    }],
+    ["missing checksum", 5, ({ fixture }) => rmSync(fixture.checksumPath)],
+    ["malformed checksum", 5, ({ fixture }) => writeFileSync(fixture.checksumPath, "broken\n")],
+    ["duplicate checksum", 5, ({ fixture }) => {
+      const line = readFileSync(fixture.checksumPath, "utf8").split("\n")[0];
+      writeFileSync(fixture.checksumPath, `${line}\n${line}\n`);
+    }],
+    ["entry path outside managed allowlist", 5, ({ state, fixture }) => {
+      state.entries[2].outputPath = path.join(path.dirname(state.entries[2].outputPath), "moved.flatpak");
+      writeFileSync(fixture.statePath, JSON.stringify(state));
+    }],
+    ["entry ref", 1, ({ state, fixture }) => {
+      state.entries[1].ref += "-changed";
+      writeFileSync(fixture.statePath, JSON.stringify(state));
+    }],
+    ["entry commit", 1, ({ state, fixture }) => {
+      state.entries[3].commit = "f".repeat(64);
+      writeFileSync(fixture.statePath, JSON.stringify(state));
+    }],
+    ["checksum hash", 1, ({ fixture }) => {
+      const lines = readFileSync(fixture.checksumPath, "utf8").trim().split("\n");
+      lines[0] = `${"f".repeat(64)}  app.flatpak`;
+      writeFileSync(fixture.checksumPath, `${lines.join("\n")}\n`);
+    }],
+    ["missing file", 1, ({ fixture }) => rmSync(fixture.plan[1].path)],
+    ["tampered file", 1, ({ fixture }) => {
+      const original = readFileSync(fixture.plan[2].path);
+      writeFileSync(fixture.plan[2].path, Buffer.alloc(original.length, 120));
+    }],
+    ["truncated file", 1, ({ fixture }) => truncateSync(fixture.plan[3].path, 1)],
+    ["symlink file", 1, ({ fixture }) => {
+      const output = fixture.plan[4].path;
+      const target = `${output}.target`;
+      writeFileSync(target, readFileSync(output));
+      rmSync(output);
+      symlinkSync(target, output);
+      assert.equal(lstatSync(output).isSymbolicLink(), true);
+    }],
+  ];
+  for (const [name, expectedBuilds, mutate] of cases) await t.test(name, async () => {
+    const root = mkdtempSync(path.join(os.tmpdir(), "tuneforge-flatpak-mismatch-"));
+    const fixture = bundleFixture(root);
+    try {
+      await runBundleReuse(fixture, []);
+      const state = JSON.parse(readFileSync(fixture.statePath, "utf8"));
+      mutate({ fixture, state });
+      const spawned = [];
+      const report = await runBundleReuse(fixture, spawned);
+      assert.equal(spawned.length, expectedBuilds);
+      assert.equal(report.entries.filter(({ status }) => status === "rebuilt").length, expectedBuilds);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});
+
+test("hostile bundle-state paths cannot authorize deletion", async () => {
+  const root = mkdtempSync(path.join(os.tmpdir(), "tuneforge-flatpak-hostile-"));
+  const fixture = bundleFixture(root);
+  const sentinel = path.join(root, "sentinel.keep");
+  try {
+    await runBundleReuse(fixture, []);
+    writeFileSync(sentinel, "do not delete");
+    const state = JSON.parse(readFileSync(fixture.statePath, "utf8"));
+    state.entries.push({ ...state.entries[0], id: "hostile", outputPath: sentinel, basename: path.basename(sentinel) });
+    writeFileSync(fixture.statePath, JSON.stringify(state));
+    const spawned = [];
+    await runBundleReuse(fixture, spawned);
+    assert.equal(spawned.length, 5);
+    assert.equal(readFileSync(sentinel, "utf8"), "do not delete");
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("bundle publication failures cannot leave trusted or partially replaced outputs", async (t) => {
+  await t.test("hash race becomes a one-artifact miss", async () => {
+    const root = mkdtempSync(path.join(os.tmpdir(), "tuneforge-flatpak-hash-race-"));
+    const fixture = bundleFixture(root);
+    try {
+      await runBundleReuse(fixture, []);
+      let hashes = 0;
+      const spawned = [];
+      const report = await runBundleReuse(fixture, spawned, {
+        hashFile: (target) => {
+          if (hashes++ === 0) throw new Error("simulated read race");
+          return createHash("sha256").update(readFileSync(target)).digest("hex");
+        },
+      });
+      assert.equal(spawned.length, 1);
+      assert.equal(report.entries[0].status, "rebuilt");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  for (const failure of ["second rename", "state publication"]) await t.test(failure, async () => {
+    const root = mkdtempSync(path.join(os.tmpdir(), "tuneforge-flatpak-publish-failure-"));
+    const fixture = bundleFixture(root);
+    try {
+      await runBundleReuse(fixture, []);
+      fixture.refCommits[0].commitSha256 = "a".repeat(64);
+      if (failure === "second rename") fixture.refCommits[1].commitSha256 = "b".repeat(64);
+      const retainedSecond = readFileSync(fixture.plan[1].path);
+      let renames = 0;
+      await assert.rejects(runBundleReuse(fixture, [], failure === "second rename" ? {
+        renameArtifact: (source, destination) => {
+          if (++renames === 2) throw new Error("simulated final rename failure");
+          renameSync(source, destination);
+        },
+      } : { writeState: () => { throw new Error("simulated state publication failure"); } }));
+      assert.equal(existsSync(fixture.statePath), false);
+      assert.equal(existsSync(fixture.checksumPath), false);
+      assert.equal(existsSync(fixture.plan[0].path), false);
+      if (failure === "second rename") assert.deepEqual(readFileSync(fixture.plan[1].path), retainedSecond);
+      assert.deepEqual(readdirSync(root).filter((name) => name.endsWith(".tmp")), []);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});
+
+test("profile transitions reuse overlap, build additions, and publish selected-only artifacts", async () => {
+  const root = mkdtempSync(path.join(os.tmpdir(), "tuneforge-flatpak-profiles-"));
+  const all = bundleFixture(root);
+  try {
+    await runBundleReuse(all, []);
+    const retained = bundleFixture(root, ["cpu", "nvidia"]);
+    const removeSpawned = [];
+    const removed = await runBundleReuse(retained, removeSpawned);
+    assert.equal(removeSpawned.length, 0);
+    assert.deepEqual(removed.entries.map(({ status }) => status), ["reused", "reused", "reused"]);
+    assert.ok(all.plan.slice(3).every(({ path: output }) => !existsSync(output)));
+    assert.equal(JSON.parse(readFileSync(retained.statePath, "utf8")).entries.length, 3);
+    assert.equal(readFileSync(retained.checksumPath, "utf8").trim().split("\n").length, 3);
+
+    const addSpawned = [];
+    const added = await runBundleReuse(all, addSpawned);
+    assert.equal(addSpawned.length, 2);
+    assert.deepEqual(added.entries.map(({ status }) => status), ["reused", "reused", "reused", "rebuilt", "rebuilt"]);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("bundle failures remove trust markers and temps, then evidence mode rebuilds every artifact", async () => {
+  const root = mkdtempSync(path.join(os.tmpdir(), "tuneforge-flatpak-failure-"));
+  const fixture = bundleFixture(root);
+  try {
+    await runBundleReuse(fixture, []);
+    rmSync(fixture.plan[0].path);
+    rmSync(fixture.plan[1].path);
+    const failedSpawns = [];
+    await assert.rejects(
+      reuseFlatpakBundles({
+        bundlePlan: fixture.plan,
+        refCommits: fixture.refCommits,
+        namespace: "flatpak-cache-v1-test",
+        flatpakVersion: "Flatpak 1.16.1",
+        statePath: fixture.statePath,
+        checksumPath: fixture.checksumPath,
+        managedBundlePaths: fixture.managedBundlePaths,
+        concurrency: 2,
+        spawnProcess: bundleSpawner(failedSpawns, { failRef: fixture.plan[0].refId }),
+      }),
+      (error) => error.bundleCache?.observationComplete === false,
+    );
+    assert.equal(failedSpawns.length, 2);
+    assert.equal(existsSync(fixture.statePath), false);
+    assert.equal(existsSync(fixture.checksumPath), false);
+    assert.deepEqual(readdirSync(root).filter((name) => name.endsWith(".tmp")), []);
+
+    const evidenceSpawned = [];
+    const evidence = await runBundleReuse(fixture, evidenceSpawned, { evidence: true });
+    assert.equal(evidenceSpawned.length, 5);
+    assert.equal(evidence.mode, "disabled-for-evidence");
+    assert.ok(evidence.entries.every(({ status }) => status === "rebuilt"));
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
 test("no-bundle cleanup and bundle failures cannot preserve stale artifacts", async () => {
   const root = mkdtempSync(path.join(os.tmpdir(), "tuneforge-flatpak-cleanup-"));
   const bundlePlan = ["app.flatpak", "nvidia-core.flatpak", "nvidia-runtime.flatpak", "legacy-core.flatpak", "legacy-runtime.flatpak"].map((name) => ({
@@ -535,34 +1265,70 @@ test("no-bundle cleanup and bundle failures cannot preserve stale artifacts", as
   }
 });
 
-test("Flatpak bundle queue runs at most two jobs and terminates peers after failure", async () => {
-  const plan = Array.from({ length: 5 }, (_, index) => ({
-    refId: `ref-${index}`,
-    runtime: index > 0,
-    path: `/tmp/ref-${index}.flatpak`,
+test("Flatpak bundle workers reserve one core, use five workers when available, and cap queued work", async () => {
+  assert.equal(defaultFlatpakBundleConcurrency(1), 1);
+  assert.equal(defaultFlatpakBundleConcurrency(2), 1);
+  assert.equal(defaultFlatpakBundleConcurrency(8), 7);
+  assert.equal(flatpakBundleWorkerLimit([{ path: "/tmp/one" }], 7), 1);
+  assert.equal(flatpakBundleWorkerLimit([{ path: "/tmp/one" }, { path: "/tmp/two" }], 7), 2);
+  const plan = (count) => Array.from({ length: count }, (_, index) => ({
+    refId: `ref-${index}`, runtime: index > 0, path: `/tmp/ref-${index}.flatpak`,
   }));
-  let active = 0;
-  let maximum = 0;
-  const killed = [];
-  const spawnProcess = (_command, args) => {
-    const child = new EventEmitter();
-    child.kill = () => {
-      killed.push(args.at(-2));
-      queueMicrotask(() => child.emit("exit", null, "SIGTERM"));
-    };
-    active += 1;
-    maximum = Math.max(maximum, active);
-    const refId = args.at(-2);
-    queueMicrotask(() => {
-      active -= 1;
-      child.emit("exit", refId === "ref-1" ? 1 : 0, null);
+  const run = (bundlePlan, concurrency) => {
+    const children = [];
+    const spawned = [];
+    const operation = buildFlatpakBundles({
+      bundlePlan,
+      repository: "/tmp/repo",
+      concurrency,
+      spawnProcess: (_command, args) => {
+        const child = new EventEmitter();
+        child.kill = () => queueMicrotask(() => child.emit("exit", null, "SIGTERM"));
+        spawned.push(args.at(-2));
+        children.push(child);
+        return child;
+      },
     });
-    return child;
+    return { children, operation, spawned };
   };
-  await assert.rejects(
-    buildFlatpakBundles({ bundlePlan: plan, repository: "/tmp/repo", spawnProcess }),
-    /ref-1.*status 1/,
-  );
-  assert.equal(maximum, 2);
-  assert.ok(killed.length <= 1);
+
+  const five = run(plan(5), 7);
+  assert.equal(five.spawned.length, 5);
+  for (const child of five.children) child.emit("exit", 0, null);
+  await five.operation;
+
+  const larger = run(plan(8), 7);
+  assert.equal(larger.spawned.length, 7);
+  larger.children[0].emit("exit", 0, null);
+  assert.equal(larger.spawned.length, 8);
+  for (const child of larger.children.slice(1)) child.emit("exit", 0, null);
+  await larger.operation;
+});
+
+test("Flatpak bundle failure stops queued work and terminates active children", async () => {
+  const plan = Array.from({ length: 5 }, (_, index) => ({
+    refId: `ref-${index}`, runtime: index > 0, path: `/tmp/ref-${index}.flatpak`,
+  }));
+  const spawned = [];
+  const killed = [];
+  const operation = buildFlatpakBundles({
+    bundlePlan: plan,
+    repository: "/tmp/repo",
+    concurrency: 2,
+    spawnProcess: (_command, args) => {
+      const child = new EventEmitter();
+      const refId = args.at(-2);
+      child.kill = () => {
+        killed.push(refId);
+        queueMicrotask(() => child.emit("exit", null, "SIGTERM"));
+      };
+      spawned.push({ child, refId });
+      return child;
+    },
+  });
+  assert.equal(spawned.length, 2);
+  spawned[1].child.emit("exit", 1, null);
+  await assert.rejects(operation, /ref-1.*status 1/);
+  assert.deepEqual(spawned.map(({ refId }) => refId), ["ref-0", "ref-1"]);
+  assert.deepEqual(killed, ["ref-0"]);
 });

--- a/scripts/flatpak-source-snapshots.mjs
+++ b/scripts/flatpak-source-snapshots.mjs
@@ -1,0 +1,141 @@
+import { Buffer } from "node:buffer";
+import { lstatSync, mkdirSync, readFileSync, readdirSync, readlinkSync, renameSync, writeFileSync } from "node:fs";
+import path from "node:path";
+
+const blockSize = 512;
+export const compareUtf8 = (left, right) => Buffer.compare(Buffer.from(left), Buffer.from(right));
+
+function posixPath(value, label) {
+  const normalized = value.split(path.sep).join("/").replace(/^\.\//, "");
+  if (!normalized || normalized.startsWith("/") || normalized.split("/").includes("..")) {
+    throw new Error(`Unsafe snapshot ${label}: ${value}`);
+  }
+  return normalized;
+}
+
+function octal(value, width, label) {
+  const text = value.toString(8);
+  if (text.length > width - 1) throw new Error(`USTAR ${label} overflow.`);
+  return `${"0".repeat(width - 1 - text.length)}${text}\0`;
+}
+
+function tarPath(value) {
+  if (Buffer.byteLength(value) <= 100) return { name: value, prefix: "" };
+  const slash = value.lastIndexOf("/", 155);
+  if (slash <= 0 || Buffer.byteLength(value.slice(0, slash)) > 155 || Buffer.byteLength(value.slice(slash + 1)) > 100) {
+    throw new Error(`USTAR path overflow: ${value}`);
+  }
+  return { prefix: value.slice(0, slash), name: value.slice(slash + 1) };
+}
+
+function put(buffer, offset, width, value) {
+  const bytes = Buffer.from(value, "utf8");
+  if (bytes.length > width) throw new Error("USTAR field overflow.");
+  bytes.copy(buffer, offset);
+}
+
+function header(entry, epoch) {
+  const output = Buffer.alloc(blockSize);
+  const target = tarPath(entry.path);
+  put(output, 0, 100, target.name);
+  put(output, 100, 8, octal(entry.mode, 8, "mode"));
+  put(output, 108, 8, octal(0, 8, "uid"));
+  put(output, 116, 8, octal(0, 8, "gid"));
+  put(output, 124, 12, octal(entry.size, 12, "size"));
+  put(output, 136, 12, octal(epoch, 12, "mtime"));
+  output.fill(0x20, 148, 156);
+  put(output, 156, 1, entry.type);
+  put(output, 157, 100, entry.link ?? "");
+  put(output, 257, 6, "ustar\0");
+  put(output, 263, 2, "00");
+  put(output, 345, 155, target.prefix);
+  const checksum = output.reduce((total, byte) => total + byte, 0);
+  put(output, 148, 8, `${octal(checksum, 7, "checksum")} `);
+  return output;
+}
+
+function collectEntry(root, source, destination, entries) {
+  const absolute = path.resolve(root, source);
+  const rootRelative = path.relative(root, absolute);
+  if (rootRelative.startsWith("..") || path.isAbsolute(rootRelative)) throw new Error(`Unsafe snapshot source: ${source}`);
+  const stats = lstatSync(absolute);
+  const archivePath = posixPath(destination, "path");
+  if (stats.isDirectory()) {
+    entries.push({ path: `${archivePath}/`, mode: stats.mode & 0o7777, size: 0, type: "5" });
+    for (const name of readdirSync(absolute).sort(compareUtf8)) {
+      collectEntry(root, path.join(source, name), `${archivePath}/${name}`, entries);
+    }
+  } else if (stats.isFile()) {
+    entries.push({ path: archivePath, mode: stats.mode & 0o7777, size: stats.size, type: "0", absolute });
+  } else if (stats.isSymbolicLink()) {
+    const link = readlinkSync(absolute);
+    if (Buffer.byteLength(link) > 100) throw new Error(`USTAR symlink target overflow: ${archivePath}`);
+    entries.push({ path: archivePath, mode: 0o777, size: 0, type: "2", link });
+  } else {
+    throw new Error(`Unsupported snapshot entry type: ${source}`);
+  }
+}
+
+export function createFlatpakSourceSnapshot({ root, outputPath, inputs, sourceDateEpoch }) {
+  const epoch = Number(sourceDateEpoch);
+  if (!Number.isSafeInteger(epoch) || epoch < 1) throw new Error("SOURCE_DATE_EPOCH must be a positive integer.");
+  const entries = [];
+  for (const { source, destination = source } of inputs) collectEntry(root, source, destination, entries);
+  entries.sort((left, right) => compareUtf8(left.path, right.path));
+  for (let index = 1; index < entries.length; index += 1) {
+    if (entries[index - 1].path === entries[index].path) throw new Error(`Duplicate snapshot path: ${entries[index].path}`);
+  }
+  const chunks = [];
+  for (const entry of entries) {
+    chunks.push(header(entry, epoch));
+    if (entry.type === "0") {
+      const contents = readFileSync(entry.absolute);
+      chunks.push(contents);
+      const padding = (blockSize - (contents.length % blockSize)) % blockSize;
+      if (padding) chunks.push(Buffer.alloc(padding));
+    }
+  }
+  chunks.push(Buffer.alloc(blockSize * 2));
+  mkdirSync(path.dirname(outputPath), { recursive: true });
+  const temporary = `${outputPath}.tmp-${process.pid}`;
+  writeFileSync(temporary, Buffer.concat(chunks));
+  renameSync(temporary, outputPath);
+  return { entryCount: entries.length, outputPath };
+}
+
+export const flatpakSourceSnapshotInputs = {
+  frontend: [
+    "package.json", "pnpm-lock.yaml", "pnpm-workspace.yaml", "scripts/build-info.mjs",
+    { source: "packaging/flatpak/seed-pnpm-store.mjs", destination: "seed-pnpm-store.mjs" },
+    "apps/desktop/package.json", "apps/desktop/index.html", "apps/desktop/tsconfig.json",
+    "apps/desktop/tsconfig.node.json", "apps/desktop/vite.config.ts", "apps/desktop/src",
+    "packages/shared-types/package.json", "packages/shared-types/src",
+  ],
+  desktop: [
+    "apps/desktop/src-tauri/Cargo.lock", "apps/desktop/src-tauri/Cargo.toml",
+    "apps/desktop/src-tauri/build.rs", "apps/desktop/src-tauri/tauri.conf.json",
+    "apps/desktop/src-tauri/capabilities", "apps/desktop/src-tauri/icons",
+    "apps/desktop/src-tauri/resources", "apps/desktop/src-tauri/src",
+  ],
+  backend: [
+    "README.md", "LICENSE", "THIRD_PARTY_NOTICES.md", "LICENSES/crema-0.2.0-BSD-2-Clause.txt",
+    "docs/PACKAGING.md", "apps/backend/app", "apps/backend/alembic", "apps/backend/alembic.ini",
+    "apps/backend/pyproject.toml", { source: "packaging/demucs/models.json", destination: "apps/backend/demucs-models.json" },
+    { source: "packaging/flatpak/ffmpeg-wrapper.sh", destination: "ffmpeg" },
+    { source: "packaging/flatpak/ffprobe-wrapper.sh", destination: "ffprobe" },
+    { source: "packaging/flatpak/com.tuneforge.desktop.desktop", destination: "com.tuneforge.desktop.desktop" },
+    { source: "packaging/flatpak/com.tuneforge.desktop.metainfo.xml", destination: "com.tuneforge.desktop.metainfo.xml" },
+    { source: "apps/desktop/src-tauri/icons/32x32.png", destination: "icons/32x32.png" },
+    { source: "apps/desktop/src-tauri/icons/128x128.png", destination: "icons/128x128.png" },
+    { source: "apps/desktop/src-tauri/icons/512x512.png", destination: "icons/512x512.png" },
+  ],
+};
+
+export function generateFlatpakSourceSnapshots({ root, generatedRoot, sourceDateEpoch }) {
+  return Object.entries(flatpakSourceSnapshotInputs).map(([name, inputs]) => createFlatpakSourceSnapshot({
+    root,
+    inputs: inputs.map((input) => typeof input === "string" ? { source: input } : input),
+    outputPath: path.join(generatedRoot, `${name}-snapshot.tar`),
+    sourceDateEpoch,
+  }));
+}

--- a/scripts/generate-flatpak-sources.mjs
+++ b/scripts/generate-flatpak-sources.mjs
@@ -7,12 +7,18 @@ import { fileURLToPath } from "node:url";
 import { parsePnpmLock } from "../packaging/flatpak/seed-pnpm-store.mjs";
 import { buildModelBundlePlan } from "./model-bundle-metadata.mjs";
 import { parsePackageOptions } from "./package-options.mjs";
+import { generateFlatpakSourceSnapshots } from "./flatpak-source-snapshots.mjs";
 
 const __filename = fileURLToPath(import.meta.url);
 const scriptDir = path.dirname(__filename);
 const workspaceRoot = path.resolve(scriptDir, "..");
 const flatpakRoot = path.join(workspaceRoot, "packaging", "flatpak");
 const generatedRoot = path.join(flatpakRoot, "generated");
+export const flatpakTorchLocksRoot = path.join(flatpakRoot, "locks");
+export const flatpakTorchLockPaths = Object.freeze({
+  cpu: path.join(flatpakTorchLocksRoot, "pylock.cpu-torch.toml"),
+  "legacy-nvidia": path.join(flatpakTorchLocksRoot, "pylock.legacy-nvidia-torch.toml"),
+});
 const obsoleteTorchStem = ["modern", "torch"].join("-");
 const obsoleteTorchExtensionOutputs = [
   `${obsoleteTorchStem}-profile.json`,
@@ -34,7 +40,6 @@ const torchProfileOutputs = {
       `python-nvidia-torch-${role}-size-report.json`,
     ])],
   "legacy-nvidia": ["legacy-torch-core-profile.json", "legacy-torch-runtime-profile.json",
-    "python-legacy-torch.in", "pylock.legacy-torch.toml",
     ...["core", "runtime"].flatMap((role) => [
       `python-legacy-torch-${role}-requirements.txt`,
       `python-legacy-torch-${role}-sources.json`,
@@ -378,7 +383,7 @@ function parsePythonArtifactsFromInlineTables(contents) {
   ).map((match) => parsePythonArtifact(match[0]));
 }
 
-function parsePylock(contents) {
+export function parsePylock(contents) {
   const packages = new Map();
   for (const match of contents.matchAll(/\[\[packages\]\]\n([\s\S]*?)(?=\n\[\[packages\]\]|\s*$)/g)) {
     const block = match[1];
@@ -432,7 +437,7 @@ export function wheelScore(fileName) {
   return -1;
 }
 
-function selectPythonArtifact(pkg) {
+export function selectPythonArtifact(pkg) {
   const wheel = pkg.wheels
     .map((candidate) => ({ ...candidate, score: wheelScore(candidate.fileName) }))
     .filter((candidate) => candidate.score >= 0)
@@ -503,7 +508,7 @@ export function resolvePythonRuntimePackages(packages, { extras = [] } = {}) {
   return Array.from(resolved.values()).sort((left, right) => packageIdentity(left).localeCompare(packageIdentity(right)));
 }
 
-function resolveNamedPythonPackages(packages, names) {
+export function resolveNamedPythonPackages(packages, names) {
   const resolved = new Map();
   const processedExtrasByPackage = new Map();
   const queue = names.map((name) => ({ name }));
@@ -531,73 +536,12 @@ function resolveNamedPythonPackages(packages, names) {
   return Array.from(resolved.values()).sort((left, right) => packageIdentity(left).localeCompare(packageIdentity(right)));
 }
 
-function run(command, args, options = {}) {
-  const result = spawnSync(command, args, {
-    cwd: workspaceRoot,
-    stdio: "inherit",
-    env: {
-      ...process.env,
-      UV_CACHE_DIR: process.env.UV_CACHE_DIR ?? path.join(flatpakRoot, ".uv-cache"),
-      ...options.env,
-    },
-  });
-
-  if (result.error?.code === "ENOENT") {
-    throw new Error(`Required command not found: ${command}`);
-  }
-  if (result.status !== 0) {
-    throw new Error(`${command} exited with status ${result.status}`);
-  }
-}
-
 function resolveLegacyTorchPackages() {
-  const requirementsPath = path.join(generatedRoot, "python-legacy-torch.in");
-  const pylockPath = path.join(generatedRoot, "pylock.legacy-torch.toml");
-  writeGeneratedFile("python-legacy-torch.in", "torch==2.13.0\ntorchaudio==2.11.0\n");
-  run("uv", [
-    "--quiet",
-    "pip",
-    "compile",
-    requirementsPath,
-    "--python-version",
-    "3.14",
-    "--python-platform",
-    "x86_64-manylinux_2_28",
-    "--torch-backend",
-    "cu126",
-    "--format",
-    "pylock.toml",
-    "--output-file",
-    pylockPath,
-    "--no-header",
-    "--no-annotate",
-  ]);
-  return parsePylock(readRequiredFile(pylockPath));
+  return parsePylock(readRequiredFile(flatpakTorchLockPaths["legacy-nvidia"]));
 }
 
 function resolveCpuTorchPackages() {
-  const requirementsPath = path.join(generatedRoot, "python-cpu-torch.in");
-  const pylockPath = path.join(generatedRoot, "pylock.cpu-torch.toml");
-  writeGeneratedFile("python-cpu-torch.in", "torch==2.13.0\ntorchaudio==2.11.0\n");
-  run("uv", [
-    "--quiet",
-    "pip",
-    "compile",
-    requirementsPath,
-    "--python-version",
-    "3.14",
-    "--python-platform",
-    "x86_64-manylinux_2_28",
-    "--torch-backend",
-    "cpu",
-    "--format",
-    "pylock.toml",
-    "--output-file",
-    pylockPath,
-    "--no-header",
-    "--no-annotate",
-  ]);
-  return parsePylock(readRequiredFile(pylockPath));
+  return parsePylock(readRequiredFile(flatpakTorchLockPaths.cpu));
 }
 
 function isLegacyTorchPackage(packageName) {
@@ -650,7 +594,7 @@ export const TORCH_EXTENSION_PROFILES = Object.freeze({
     torchaudio_version: "2.11.0+cu126",
     triton_version: "3.7.1",
     cuda_family: "12.6",
-    pair_id: "112a80543c933ef4903aca2c0afcca91f21012c9e4ee1164222b08f118eba4f2",
+    pair_id: "5896e6c2ba980be746fb7bb711d8e2e49f23713c58e0c6d3bec76ca048f60743",
   }),
 });
 
@@ -708,6 +652,32 @@ export function torchExtensionPairId(profileName, packages) {
   return createHash("sha256")
     .update(JSON.stringify({ contract: "profile-pair-v1", profile: profileName, packages: rows }))
     .digest("hex");
+}
+
+export function assertReviewedTorchExtensionPair(profileName, packages) {
+  const expected = TORCH_EXTENSION_PROFILES[profileName]?.pair_id;
+  if (!expected) throw new Error(`Unknown Torch extension profile: ${profileName}`);
+  const actual = torchExtensionPairId(profileName, packages);
+  if (actual !== expected) {
+    throw new Error(`${profileName} locked wheel manifest changed; update its reviewed pair ID and launcher marker`);
+  }
+  return actual;
+}
+
+export function validateFlatpakTorchLock(profile, contents) {
+  if (!["cpu", "legacy-nvidia"].includes(profile)) throw new Error(`Unknown Flatpak Torch lock profile: ${profile}`);
+  const packages = parsePylock(contents);
+  const rows = packageRows(packages);
+  const roots = profile === "cpu"
+    ? ["torch@2.13.0+cpu", "torchaudio@2.11.0+cpu"]
+    : ["torch@2.13.0+cu126", "torchaudio@2.11.0+cu126"];
+  if (roots.some((identity) => !packages.has(identity))) {
+    throw new Error(`Refreshed ${profile} lock is missing reviewed Torch roots.`);
+  }
+  if (profile === "cpu") assertDefaultCpuTorchClosure(rows);
+  else assertTorchExtensionProfile(packages, "LegacyNvidia");
+  for (const pkg of rows) selectPythonArtifact(pkg);
+  return { packages, pairId: profile === "legacy-nvidia" ? torchExtensionPairId("LegacyNvidia", packages) : null };
 }
 
 export function assertTorchExtensionProfile(packages, profileName, expectedAcceleratorNames) {
@@ -806,6 +776,10 @@ export function selectedTorchExtensionProfileSpecs(selectedProfiles, {
 
 function generatePythonSources() {
   const lockedPackages = parseUvLock(readRequiredFile(uvLockPath));
+  const nvidiaPackages = resolveNamedPythonPackages(lockedPackages, ["torch", "torchaudio"]);
+  const nvidiaAcceleratorNames = acceleratorPackageNames(lockedPackages);
+  assertTorchExtensionProfile(nvidiaPackages, "Nvidia", nvidiaAcceleratorNames);
+  assertReviewedTorchExtensionPair("Nvidia", nvidiaPackages);
   let runtimePackages = resolvePythonRuntimePackages(lockedPackages, { extras: selectedPythonExtras });
   runtimePackages = mergeLegacyTorchPackageSets(
     runtimePackages,
@@ -814,8 +788,8 @@ function generatePythonSources() {
   assertDefaultCpuTorchClosure(runtimePackages);
   const extensionSpecs = selectedTorchExtensionProfileSpecs(packageOptions.flatpakProfiles, {
     resolveNvidia: () => ({
-      packages: resolveNamedPythonPackages(lockedPackages, ["torch", "torchaudio"]),
-      expectedAcceleratorNames: acceleratorPackageNames(lockedPackages),
+      packages: nvidiaPackages,
+      expectedAcceleratorNames: nvidiaAcceleratorNames,
     }),
     resolveLegacy: () => ({ packages: resolveLegacyTorchPackages() }),
   });
@@ -823,10 +797,7 @@ function generatePythonSources() {
   for (const { profileName, stem, packages, expectedAcceleratorNames } of extensionSpecs) {
     assertTorchExtensionProfile(packages, profileName, expectedAcceleratorNames);
     const partition = partitionTorchExtensionPackages(packages);
-    const pairId = torchExtensionPairId(profileName, packages);
-    if (pairId !== TORCH_EXTENSION_PROFILES[profileName].pair_id) {
-      throw new Error(`${profileName} locked wheel manifest changed; update its reviewed pair ID and launcher marker`);
-    }
+    const pairId = assertReviewedTorchExtensionPair(profileName, packages);
     for (const role of ["core", "runtime"]) {
       writePythonPackageSet(`python-${stem}-torch-${role}`, partition[role]);
       writeGeneratedJson(
@@ -875,6 +846,14 @@ function generateModelBundleSources() {
   return plan.sources.length;
 }
 
+function resolveSourceDateEpoch() {
+  if (/^[1-9][0-9]*$/.test(process.env.SOURCE_DATE_EPOCH ?? "")) return process.env.SOURCE_DATE_EPOCH;
+  const result = spawnSync("git", ["log", "-1", "--format=%ct", "HEAD"], {
+    cwd: workspaceRoot, encoding: "utf8", stdio: ["ignore", "pipe", "ignore"],
+  });
+  return result.status === 0 && /^[1-9][0-9]*$/.test(result.stdout.trim()) ? result.stdout.trim() : "1";
+}
+
 export function cremaOnlyModelBundlePlan(plan) {
   const fileNames = new Set(plan.manifest.crema_onnx_files.map((entry) => entry.file_name));
   return {
@@ -898,9 +877,14 @@ function main() {
   const nodeCount = generateNodeSources();
   const pythonCount = generatePythonSources();
   const modelBundleCount = generateModelBundleSources();
+  const snapshots = generateFlatpakSourceSnapshots({
+    root: workspaceRoot,
+    generatedRoot,
+    sourceDateEpoch: resolveSourceDateEpoch(),
+  });
 
   process.stdout.write(
-    `Generated Flatpak sources: ${cargoCount} Cargo crates, ${nodeCount} pnpm tarballs, ${pythonCount} Python packages, ${modelBundleCount} model bundle files.\n`,
+    `Generated Flatpak sources: ${cargoCount} Cargo crates, ${nodeCount} pnpm tarballs, ${pythonCount} Python packages, ${modelBundleCount} model bundle files, ${snapshots.length} source snapshots.\n`,
   );
 }
 

--- a/scripts/package-flatpak.mjs
+++ b/scripts/package-flatpak.mjs
@@ -1,4 +1,4 @@
-import { createHash } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import {
   closeSync,
   existsSync,
@@ -9,20 +9,24 @@ import {
   readlinkSync,
   readdirSync,
   readSync,
+  renameSync,
   rmSync,
   statSync,
   writeFileSync,
 } from "node:fs";
+import { availableParallelism } from "node:os";
 import path from "node:path";
 import { spawn, spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import { writeBuildInfoFile, writeResolvedBuildInfoFile } from "./build-info.mjs";
 import {
   normalizeFlatpakProfiles,
+  frontendPackageOptionsEnvironment,
   packageOptionsEnvironment,
   packageOptionsToGeneratorArgs,
   parsePackageOptions,
   printModelBundleWarning,
+  validatePackageOptions,
 } from "./package-options.mjs";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -49,7 +53,10 @@ const torchProfileArtifacts = {
 };
 const localRepoRemote = "tuneforge-local";
 const cacheSchema = "flatpak-cache-v1";
+const outputStateSchema = "flatpak-output-state-v1";
+const bundleStateSchema = "flatpak-bundle-state-v1";
 const sizeReportSchema = "flatpak-size-v1";
+const bundleCommandContract = "flatpak build-bundle [--runtime] --arch=x86_64 <repository> <output> <ref-id> stable";
 const gibibyte = 1024 ** 3;
 const flatpakBundleHardLimitBytes = 2 * gibibyte;
 const flatpakBundleTargetBytes = 1.9 * gibibyte;
@@ -76,6 +83,10 @@ const legacyTorchCoreBundlePath = process.env.FLATPAK_LEGACY_TORCH_CORE_BUNDLE_P
   defaultLegacyTorchCoreBundlePath;
 const legacyTorchRuntimeBundlePath = process.env.FLATPAK_LEGACY_TORCH_RUNTIME_BUNDLE_PATH ??
   defaultLegacyTorchRuntimeBundlePath;
+const configuredBundlePaths = [
+  bundlePath, nvidiaTorchCoreBundlePath, nvidiaTorchRuntimeBundlePath,
+  legacyTorchCoreBundlePath, legacyTorchRuntimeBundlePath,
+];
 const currentDefaultBundlePaths = [
   defaultBundlePath,
   defaultNvidiaTorchCoreBundlePath,
@@ -111,6 +122,35 @@ function run(command, args, options = {}) {
   }
 }
 
+function runAndTee(command, args, options = {}) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, {
+      cwd: workspaceRoot,
+      env: { ...process.env, ...options.env },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let output = "";
+    const forward = (stream, destination) => {
+      stream.on("data", (chunk) => {
+        output += chunk;
+        destination.write(chunk);
+      });
+    };
+    forward(child.stdout, process.stdout);
+    forward(child.stderr, process.stderr);
+    let failed = false;
+    child.once("error", (error) => {
+      failed = true;
+      reject(error?.code === "ENOENT" ? new Error(`Required command not found: ${command}`) : error);
+    });
+    child.once("close", (status, signal) => {
+      if (failed) return;
+      if (status === 0) resolve(output);
+      else reject(new Error(`${command} failed (${signal ?? `status ${status}`})`));
+    });
+  });
+}
+
 function checkCommand(command, installHint) {
   const result = spawnSync(command, ["--version"], { stdio: "ignore" });
   if (result.error?.code === "ENOENT") {
@@ -119,6 +159,13 @@ function checkCommand(command, installHint) {
   if (result.status !== 0) {
     throw new Error(`Could not run ${command} --version`);
   }
+}
+
+function commandVersion(command) {
+  const result = spawnSync(command, ["--version"], { encoding: "utf8", stdio: ["ignore", "pipe", "inherit"] });
+  if (result.error?.code === "ENOENT") throw new Error(`Required command not found: ${command}`);
+  if (result.status !== 0) throw new Error(`Could not run ${command} --version`);
+  return result.stdout.trim();
 }
 
 function generatedManifestPath(options, cacheRoot, namespace, frontendGitRef) {
@@ -194,7 +241,7 @@ function generatedManifestPath(options, cacheRoot, namespace, frontendGitRef) {
 }
 
 export function manifestWithPackageOptions(manifest, options) {
-  const encodedPackageOptions = packageOptionsEnvironment(options).TUNEFORGE_PACKAGE_OPTIONS;
+  const encodedPackageOptions = frontendPackageOptionsEnvironment(options).TUNEFORGE_PACKAGE_OPTIONS;
   const tuneforgeEnvAnchor =
     "  - name: tuneforge-frontend\n" +
     "    buildsystem: simple\n" +
@@ -333,14 +380,16 @@ export function resolveFrontendGitRef({
 
 export function cacheNamespace(options, version = appVersion) {
   const buildOptions = { ...options, noBundle: false };
+  const { flatpakProfiles: _flatpakProfiles, ...nonProfileOptions } = JSON.parse(
+    packageOptionsEnvironment(buildOptions).TUNEFORGE_PACKAGE_OPTIONS,
+  );
   const inputs = {
     schema: cacheSchema,
     app: `${appId}@${version}`,
     arch: "x86_64",
     runtime: "org.gnome.Platform/50",
     tools: "node26-llvm20-rust-stable-pnpm11.22.0-sccache0.17.0",
-    profile: packageOptionsEnvironment(buildOptions).TUNEFORGE_PACKAGE_OPTIONS,
-    selectedProfiles: normalizeFlatpakProfiles(options.flatpakProfiles),
+    packageOptions: nonProfileOptions,
   };
   const digest = createHash("sha256").update(JSON.stringify(inputs)).digest("hex").slice(0, 16);
   return { name: `${cacheSchema}-${digest}`, inputs };
@@ -521,19 +570,327 @@ export function verifyFlatpakOutputRefs({
   });
 }
 
+function equalJson(left, right) {
+  return JSON.stringify(left) === JSON.stringify(right);
+}
+
+function validPayload(payload) {
+  return Boolean(payload && /^[a-f0-9]{64}$/.test(payload.sha256) &&
+    Number.isInteger(payload.entryCount) && payload.entryCount >= 0);
+}
+
+function validRefCommits(refCommits, profiles) {
+  if (!Array.isArray(refCommits) || !refCommits.every((entry) =>
+    entry && typeof entry === "object" && typeof entry.id === "string" && typeof entry.ref === "string" &&
+    /^[a-f0-9]{64}$/.test(entry.commitSha256))) return false;
+  return equalJson(
+    refCommits.map(({ id, ref }) => ({ id, ref })),
+    selectedFlatpakOutputRefs(profiles).map(({ id, ref }) => ({ id, ref })),
+  );
+}
+
+function validCheckoutSizeEvidence(size) {
+  const exactKeys = (value, keys) => value && typeof value === "object" &&
+    equalJson(Object.keys(value).sort(), [...keys].sort());
+  const validSize = (entry, expectedPath) => entry && typeof entry === "object" && entry.path === expectedPath &&
+    entry.available === true && Number.isInteger(entry.bytes) && entry.bytes >= 0;
+  const directories = size?.installedApp?.topLevelDirectories;
+  const validArtifacts = (artifacts) => exactKeys(artifacts, ["complete", "entries", "knownBytes", "unknownCount"]) &&
+    Number.isInteger(artifacts.knownBytes) && artifacts.knownBytes >= 0 && Number.isInteger(artifacts.unknownCount) &&
+    artifacts.unknownCount >= 0 && typeof artifacts.complete === "boolean" && Array.isArray(artifacts.entries) &&
+    artifacts.entries.every((entry) => exactKeys(entry, ["bytes", "fileName", "name", "version"]) &&
+      ["fileName", "name", "version"].every((key) => typeof entry[key] === "string" && entry[key]) &&
+      (entry.bytes === null || Number.isInteger(entry.bytes) && entry.bytes >= 0)) &&
+    artifacts.knownBytes === artifacts.entries.reduce((total, entry) => total + (entry.bytes ?? 0), 0) &&
+    artifacts.unknownCount === artifacts.entries.filter((entry) => entry.bytes === null).length &&
+    artifacts.complete === (artifacts.unknownCount === 0);
+  const libRows = directories?.filter((entry) => entry.path === "/app/lib");
+  const libBytes = libRows?.[0]?.bytes;
+  return Boolean(exactKeys(size, ["compressedBundle", "installedApp", "pythonRuntime", "schema", "sitePackages", "sourceArchives", "unit", "wheelInputs"]) &&
+    size.schema === sizeReportSchema && size.unit === "bytes" && exactKeys(size.compressedBundle, ["available", "path"]) &&
+    typeof size.compressedBundle.path === "string" && size.compressedBundle.path && size.compressedBundle.available === false &&
+    exactKeys(size.installedApp, ["available", "bytes", "path", "topLevelDirectories"]) && validSize(size.installedApp, "/app") &&
+    Array.isArray(directories) && directories.every((entry) => exactKeys(entry, ["bytes", "path"]) &&
+      typeof entry.path === "string" && entry.path.startsWith("/app/") && Number.isInteger(entry.bytes) && entry.bytes >= 0) &&
+    new Set(directories.map(({ path: entryPath }) => entryPath)).size === directories.length &&
+    directories.reduce((total, entry) => total + entry.bytes, 0) === size.installedApp.bytes &&
+    libRows.length === 1 &&
+    validSize(size.pythonRuntime, "/app/lib/tuneforge/backend/python") &&
+    validSize(size.sitePackages, "/app/lib/tuneforge/backend/site-packages") &&
+    size.pythonRuntime.bytes <= size.installedApp.bytes && size.sitePackages.bytes <= size.installedApp.bytes &&
+    size.pythonRuntime.bytes + size.sitePackages.bytes <= libBytes &&
+    validArtifacts(size.wheelInputs) && validArtifacts(size.sourceArchives));
+}
+
+export function flatpakOutputStatePath(stateDir) {
+  return path.join(stateDir, `${outputStateSchema}.json`);
+}
+
+export function validateFlatpakOutputState(state, {
+  namespace,
+  selectedProfiles,
+  payload,
+  refCommits,
+} = {}) {
+  const errors = [];
+  if (!state || typeof state !== "object" || Array.isArray(state)) return ["Flatpak output state is malformed."];
+  if (state.schema !== outputStateSchema) errors.push(`Flatpak output state must use ${outputStateSchema}.`);
+  let normalizedProfiles;
+  try {
+    normalizedProfiles = Array.isArray(state.selectedProfiles) ? normalizeFlatpakProfiles(state.selectedProfiles) : null;
+  } catch {
+    normalizedProfiles = null;
+  }
+  if (!normalizedProfiles || !equalJson(state.selectedProfiles, normalizedProfiles)) {
+    errors.push("Flatpak output state has invalid selected profiles.");
+  }
+  if (typeof state.namespace !== "string" || !state.namespace) errors.push("Flatpak output state has an invalid namespace.");
+  if (!validPayload(state.payload)) errors.push("Flatpak output state has an invalid payload.");
+  if (!normalizedProfiles || !validRefCommits(state.refCommits, normalizedProfiles)) {
+    errors.push("Flatpak output state has invalid output refs.");
+  }
+  if (!validCheckoutSizeEvidence(state.checkoutSize)) {
+    errors.push("Flatpak output state has incomplete checkout size evidence.");
+  }
+  if (namespace !== undefined && state.namespace !== namespace) errors.push("Flatpak output state namespace differs.");
+  if (selectedProfiles !== undefined && !equalJson(state.selectedProfiles, normalizeFlatpakProfiles(selectedProfiles))) {
+    errors.push("Flatpak output state profiles differ.");
+  }
+  if (payload !== undefined && !equalJson(state.payload, payload)) errors.push("Flatpak output state payload differs.");
+  if (refCommits !== undefined && !equalJson(state.refCommits, refCommits)) {
+    errors.push("Flatpak output state ref commits differ.");
+  }
+  return errors;
+}
+
+export function readFlatpakOutputState({ statePath, ...expected } = {}) {
+  if (!statePath || !existsSync(statePath)) return null;
+  let state;
+  try {
+    state = readJson(statePath);
+  } catch {
+    rmSync(statePath, { force: true });
+    return null;
+  }
+  if (validateFlatpakOutputState(state, expected).length > 0) {
+    rmSync(statePath, { force: true });
+    return null;
+  }
+  return state;
+}
+
+export function selectPreservedFlatpakOutputState({
+  statePath,
+  namespace,
+  selectedProfiles,
+  refCommits,
+  checkoutPayload,
+  evidence = false,
+} = {}) {
+  if (evidence || !refCommits) {
+    if (statePath) rmSync(statePath, { force: true });
+    return null;
+  }
+  const state = readFlatpakOutputState({ statePath, namespace, selectedProfiles, refCommits });
+  if (!state) return null;
+  if (checkoutPayload && !equalJson(state.payload, checkoutPayload)) {
+    rmSync(statePath, { force: true });
+    return null;
+  }
+  return state;
+}
+
+export function writeFlatpakOutputState({ statePath, namespace, selectedProfiles, payload, refCommits, checkoutSize }) {
+  const state = {
+    schema: outputStateSchema,
+    namespace,
+    selectedProfiles: normalizeFlatpakProfiles(selectedProfiles),
+    payload,
+    refCommits,
+    checkoutSize,
+  };
+  const errors = validateFlatpakOutputState(state, { namespace, selectedProfiles, payload, refCommits });
+  if (errors.length > 0) throw new Error(errors.join(" "));
+  mkdirSync(path.dirname(statePath), { recursive: true });
+  const temporaryPath = `${statePath}.${randomUUID()}.tmp`;
+  try {
+    writeFileSync(temporaryPath, `${JSON.stringify(state, null, 2)}\n`);
+    renameSync(temporaryPath, statePath);
+  } finally {
+    rmSync(temporaryPath, { force: true });
+  }
+  return state;
+}
+
+function cacheReportValidationErrors(report, label) {
+  const errors = [];
+  if (!report || typeof report !== "object" || Array.isArray(report)) return [`${label} cache report is malformed.`];
+  if (report.schema !== cacheSchema) errors.push(`${label} report must use ${cacheSchema}.`);
+  if (typeof report.namespace !== "string" || !report.namespace) errors.push(`${label} report has an invalid namespace.`);
+  const selectedProfiles = report.selectedProfiles;
+  let normalizedProfiles;
+  try {
+    normalizedProfiles = Array.isArray(selectedProfiles) ? normalizeFlatpakProfiles(selectedProfiles) : null;
+  } catch {
+    normalizedProfiles = null;
+  }
+  if (!normalizedProfiles || JSON.stringify(selectedProfiles) !== JSON.stringify(normalizedProfiles)) {
+    errors.push(`${label} report has invalid selected profiles.`);
+  }
+  let expectedOptions;
+  if (!report.namespaceInputs || typeof report.namespaceInputs !== "object" || Array.isArray(report.namespaceInputs) ||
+    !report.namespaceInputs.packageOptions || typeof report.namespaceInputs.packageOptions !== "object" ||
+    Array.isArray(report.namespaceInputs.packageOptions)) {
+    errors.push(`${label} report has invalid namespace inputs.`);
+  } else if (normalizedProfiles) {
+    try {
+      expectedOptions = validatePackageOptions({
+        ...report.namespaceInputs.packageOptions,
+        noBundle: false,
+        flatpakProfiles: normalizedProfiles,
+      }, { platform: "linux" });
+      const expectedNamespace = cacheNamespace(expectedOptions);
+      if (report.namespace !== expectedNamespace.name ||
+        JSON.stringify(report.namespaceInputs) !== JSON.stringify(expectedNamespace.inputs)) {
+        errors.push(`${label} report namespace identity is not canonical.`);
+      }
+    } catch {
+      errors.push(`${label} report has invalid namespace inputs.`);
+    }
+  }
+  if (!validPayload(report.payload)) {
+    errors.push(`${label} report has an invalid payload.`);
+  }
+  if (!Array.isArray(report.refCommits) || report.refCommits.length === 0 ||
+    report.refCommits.some((entry) => !entry || typeof entry !== "object" || typeof entry.id !== "string" || !entry.id || typeof entry.ref !== "string" || !entry.ref || !/^[a-f0-9]{64}$/.test(entry.commitSha256)) ||
+    new Set(report.refCommits.map(({ id }) => id)).size !== report.refCommits.length ||
+    new Set(report.refCommits.map(({ ref }) => ref)).size !== report.refCommits.length) {
+    errors.push(`${label} report has invalid output refs.`);
+  }
+  if (!Array.isArray(report.errors) || report.errors.some((error) => typeof error !== "string" || !error)) {
+    errors.push(`${label} report has invalid errors.`);
+  } else {
+    errors.push(...report.errors);
+  }
+  const cache = report.moduleCache;
+  const modules = cache?.modules;
+  if (cache?.mode !== "enabled" || cache?.observationComplete !== true || !Array.isArray(modules) || modules.length === 0 ||
+    modules.some((entry) => !entry || typeof entry !== "object" || typeof entry.name !== "string" || !entry.name || !["cached", "executed"].includes(entry.status)) ||
+    new Set(modules.map(({ name }) => name)).size !== modules.length) {
+    errors.push(`${label} report has an invalid module-cache observation.`);
+  } else {
+    const firstExecuted = modules.findIndex(({ status }) => status === "executed");
+    const expectedInvalidation = firstExecuted < 0 ? null : modules[firstExecuted].name;
+    if (cache.firstInvalidatedModule !== expectedInvalidation) {
+      errors.push(`${label} report has an incoherent first invalidated module.`);
+    }
+  }
+  if (expectedOptions && Array.isArray(modules) && modules.every((entry) => entry && typeof entry === "object")) {
+    const expectedModules = expectedFlatpakModuleOrder(
+      manifestWithPackageOptions(readFileSync(baseManifestPath, "utf8"), expectedOptions),
+    );
+    if (JSON.stringify(modules.map(({ name }) => name)) !== JSON.stringify(expectedModules)) {
+      errors.push(`${label} report module order does not match its selected profiles.`);
+    }
+  }
+  if (normalizedProfiles && Array.isArray(report.refCommits) &&
+    report.refCommits.every((entry) => entry && typeof entry === "object")) {
+    const expectedRefs = selectedFlatpakOutputRefs(normalizedProfiles).map(({ id, ref }) => ({ id, ref }));
+    const actualRefs = report.refCommits.map(({ id, ref }) => ({ id, ref }));
+    if (JSON.stringify(actualRefs) !== JSON.stringify(expectedRefs)) {
+      errors.push(`${label} report output refs do not match its selected profiles.`);
+    }
+  }
+  const output = report.output;
+  if (!output || typeof output !== "object" || !["exported", "preserved-unchanged"].includes(output.mode) ||
+    output.observationComplete !== true || !["checkout", "output-state"].includes(output.payloadObservationSource)) {
+    errors.push(`${label} report has an invalid output observation.`);
+  } else if ((output.mode === "exported" && output.payloadObservationSource !== "checkout") ||
+    (output.mode === "preserved-unchanged" && output.payloadObservationSource !== "output-state")) {
+    errors.push(`${label} report has an incoherent output observation.`);
+  }
+  return errors;
+}
+
 export function compareCacheReports(cold, warm) {
-  const errors = [...(cold.errors ?? []), ...(warm.errors ?? [])];
-  if (cold.namespace !== warm.namespace) errors.push("Cold and warm cache namespaces differ.");
-  if (cold.payload?.sha256 !== warm.payload?.sha256) errors.push("Cold and warm payload digests differ.");
-  if (JSON.stringify(cold.refCommits) !== JSON.stringify(warm.refCommits)) {
+  const errors = [...cacheReportValidationErrors(cold, "Cold"), ...cacheReportValidationErrors(warm, "Warm")];
+  const coldReport = cold && typeof cold === "object" ? cold : {};
+  const warmReport = warm && typeof warm === "object" ? warm : {};
+  if (coldReport.namespace !== warmReport.namespace) errors.push("Cold and warm cache namespaces differ.");
+  if (JSON.stringify(coldReport.selectedProfiles) !== JSON.stringify(warmReport.selectedProfiles)) {
+    errors.push("Cold and warm profile selections differ.");
+  }
+  if (!equalJson(coldReport.payload, warmReport.payload)) errors.push("Cold and warm payload digests differ.");
+  if (JSON.stringify(coldReport.refCommits) !== JSON.stringify(warmReport.refCommits)) {
     errors.push("Cold and warm Flatpak output ref commits differ.");
+  }
+  const coldModules = coldReport.moduleCache?.modules;
+  const warmModules = warmReport.moduleCache?.modules;
+  if (!Array.isArray(coldModules) || !Array.isArray(warmModules) ||
+    JSON.stringify(coldModules.map(({ name }) => name)) !== JSON.stringify(warmModules.map(({ name }) => name))) {
+    errors.push("Cold and warm module-cache module sets differ.");
+  }
+  if (!Array.isArray(warmModules) || warmModules.some(({ status }) => status !== "cached")) {
+    errors.push("Warm Flatpak modules must all be cached.");
+  }
+  if (warmReport.moduleCache?.firstInvalidatedModule !== null) {
+    errors.push("Warm Flatpak report has an invalidated module.");
+  }
+  if (warmReport.output?.mode !== "preserved-unchanged") {
+    errors.push("Warm Flatpak report must preserve unchanged output refs.");
   }
   return {
     schema: cacheSchema,
     equivalent: errors.length === 0,
     errors,
-    cold: { payload: cold.payload, refCommits: cold.refCommits },
-    warm: { payload: warm.payload, refCommits: warm.refCommits },
+    cold: { payload: coldReport.payload, refCommits: coldReport.refCommits, moduleCache: coldReport.moduleCache },
+    warm: { payload: warmReport.payload, refCommits: warmReport.refCommits, moduleCache: warmReport.moduleCache, output: warmReport.output },
+  };
+}
+
+export function compareCrossProfileCacheReports(source, target) {
+  const errors = [
+    ...cacheReportValidationErrors(source, "Source"),
+    ...cacheReportValidationErrors(target, "Target"),
+  ];
+  const sourceReport = source && typeof source === "object" ? source : {};
+  const targetReport = target && typeof target === "object" ? target : {};
+  if (sourceReport.namespace !== targetReport.namespace) {
+    errors.push("Source and target cache namespaces differ.");
+  }
+  if (JSON.stringify(sourceReport.selectedProfiles) === JSON.stringify(targetReport.selectedProfiles)) {
+    errors.push("Cross-profile cache comparison requires different profile selections.");
+  }
+  const sourceModules = sourceReport.moduleCache?.modules;
+  const targetModules = targetReport.moduleCache?.modules;
+  const sharedModulePrefix = [];
+  if (Array.isArray(sourceModules) && Array.isArray(targetModules)) {
+    for (let index = 0; index < Math.min(sourceModules.length, targetModules.length); index += 1) {
+      if (sourceModules[index].name !== targetModules[index].name) break;
+      sharedModulePrefix.push(sourceModules[index].name);
+    }
+    if (sharedModulePrefix.length === 0) errors.push("Cross-profile reports have no shared module prefix.");
+    if (targetModules.slice(0, sharedModulePrefix.length).some(({ status }) => status !== "cached")) {
+      errors.push("Target shared Flatpak modules must be cached.");
+    }
+  } else {
+    errors.push("Cross-profile reports have invalid module observations.");
+  }
+  const firstTargetExecution = Array.isArray(targetModules)
+    ? targetModules.slice(sharedModulePrefix.length).find(({ status }) => status === "executed")?.name ?? null
+    : null;
+  if (targetReport.output?.mode !== "exported") {
+    errors.push("Cross-profile target report must export output refs.");
+  }
+  return {
+    schema: cacheSchema,
+    equivalent: errors.length === 0,
+    errors,
+    namespace: targetReport.namespace,
+    sharedModulePrefix,
+    firstTargetExecution,
+    source: { selectedProfiles: sourceReport.selectedProfiles, moduleCache: sourceReport.moduleCache },
+    target: { selectedProfiles: targetReport.selectedProfiles, moduleCache: targetReport.moduleCache },
   };
 }
 
@@ -660,6 +1017,10 @@ export function flatpakBundlePlan({
   return plan;
 }
 
+export function flatpakBundleStatePath(stateDir) {
+  return path.join(stateDir, `${bundleStateSchema}.json`);
+}
+
 export function validateFlatpakArtifactPaths(artifacts) {
   const resolved = artifacts.map((artifact) => path.resolve(artifact));
   const duplicatePath = resolved.find((artifact, index) => resolved.indexOf(artifact) !== index);
@@ -692,14 +1053,24 @@ export async function withFreshFlatpakBundleOutputs(operation, options = {}) {
   }
 }
 
+export function defaultFlatpakBundleConcurrency(parallelism = availableParallelism()) {
+  if (!Number.isInteger(parallelism) || parallelism < 1) throw new Error("Available bundle parallelism must be a positive integer");
+  return Math.max(1, parallelism - 1);
+}
+
+export function flatpakBundleWorkerLimit(bundlePlan, concurrency = defaultFlatpakBundleConcurrency()) {
+  if (!Number.isInteger(concurrency) || concurrency < 1) throw new Error("Bundle concurrency must be a positive integer");
+  return Math.min(concurrency, bundlePlan.length);
+}
+
 export function buildFlatpakBundles({
   bundlePlan = flatpakBundlePlan(),
   repository = repoDir,
-  concurrency = 2,
+  concurrency = defaultFlatpakBundleConcurrency(),
   spawnProcess = spawn,
 } = {}) {
   validateFlatpakArtifactPaths(bundlePlan.map((artifact) => artifact.path));
-  if (!Number.isInteger(concurrency) || concurrency < 1) throw new Error("Bundle concurrency must be a positive integer");
+  const workerLimit = flatpakBundleWorkerLimit(bundlePlan, concurrency);
   return new Promise((resolve, reject) => {
     const active = new Set();
     let next = 0;
@@ -719,7 +1090,7 @@ export function buildFlatpakBundles({
       finish();
     };
     const launch = () => {
-      while (!failure && active.size < concurrency && next < bundlePlan.length) {
+      while (!failure && active.size < workerLimit && next < bundlePlan.length) {
         const artifact = bundlePlan[next++];
         const args = [
           "build-bundle",
@@ -777,6 +1148,18 @@ export function flatpakArtifactSizeReport(bundle) {
   };
 }
 
+export function flatpakBundleSizeReportFromCheckout({ checkoutSize, bundle, selectedProfiles, extensionBundles }) {
+  if (!validCheckoutSizeEvidence(checkoutSize)) {
+    throw new Error("Flatpak checkout size evidence is incomplete.");
+  }
+  return {
+    ...checkoutSize,
+    ...flatpakArtifactSizeReport(bundle),
+    selectedProfiles: normalizeFlatpakProfiles(selectedProfiles),
+    extensionBundles,
+  };
+}
+
 export function writeFlatpakChecksums(artifacts, outputPath = sha256SumsPath) {
   validateFlatpakArtifactPaths(artifacts);
   const lines = artifacts
@@ -784,8 +1167,213 @@ export function writeFlatpakChecksums(artifacts, outputPath = sha256SumsPath) {
     .sort((left, right) => left.name.localeCompare(right.name))
     .map(({ name, sha256 }) => `${sha256}  ${name}`);
   mkdirSync(path.dirname(outputPath), { recursive: true });
-  writeFileSync(outputPath, `${lines.join("\n")}\n`);
+  const temporaryPath = `${outputPath}.${randomUUID()}.tmp`;
+  try {
+    writeFileSync(temporaryPath, `${lines.join("\n")}\n`);
+    renameSync(temporaryPath, outputPath);
+  } finally {
+    rmSync(temporaryPath, { force: true });
+  }
   return lines;
+}
+
+function readBundleChecksums(checksumPath) {
+  let lines;
+  try {
+    if (!existsSync(checksumPath)) return { checksums: new Map() };
+    lines = readFileSync(checksumPath, "utf8").split("\n");
+  } catch {
+    return null;
+  }
+  if (lines.at(-1) !== "") return null;
+  lines.pop();
+  const checksums = new Map();
+  for (const line of lines) {
+    const match = /^([a-f0-9]{64})  ([^/\n]+)$/.exec(line);
+    if (!match || checksums.has(match[2])) return null;
+    checksums.set(match[2], match[1]);
+  }
+  return { checksums };
+}
+
+function readBundleState(statePath, expectedHeader, managedPaths) {
+  if (!existsSync(statePath)) return null;
+  let state;
+  try {
+    state = readJson(statePath);
+  } catch {
+    return null;
+  }
+  if (!state || typeof state !== "object" || Array.isArray(state) ||
+    !Object.entries(expectedHeader).every(([key, value]) => state[key] === value) ||
+    !Array.isArray(state.entries)) return null;
+  const ids = state.entries.map((entry) => entry?.id);
+  const paths = state.entries.map((entry) => entry?.outputPath);
+  const knownIds = new Set(knownFlatpakOutputRefs.map(({ id }) => id));
+  const allowedPaths = new Set(managedPaths.map((entryPath) => path.resolve(entryPath)));
+  if (ids.some((id) => typeof id !== "string" || !knownIds.has(id)) || new Set(ids).size !== ids.length ||
+    paths.some((entryPath) => typeof entryPath !== "string" || !path.isAbsolute(entryPath)) ||
+    new Set(paths).size !== paths.length || paths.some((entryPath) => !allowedPaths.has(entryPath))) return null;
+  return state;
+}
+
+function validBundleEntry(entry, artifact, refCommit, checksum) {
+  return Boolean(entry && entry.id === refCommit.id && entry.refId === artifact.refId &&
+    entry.ref === refCommit.ref && entry.commit === refCommit.commitSha256 &&
+    entry.role === (artifact.runtime ? "runtime" : "app") &&
+    entry.outputPath === path.resolve(artifact.path) && entry.basename === path.basename(artifact.path) &&
+    Number.isInteger(entry.bytes) && entry.bytes > 0 && /^[a-f0-9]{64}$/.test(entry.sha256) &&
+    checksum === entry.sha256);
+}
+
+function verifiedBundleFile(artifactPath, entry, hashFile) {
+  try {
+    if (!existsSync(artifactPath)) return false;
+    const stats = lstatSync(artifactPath);
+    return stats.isFile() && stats.size === entry.bytes && hashFile(artifactPath) === entry.sha256;
+  } catch {
+    return false;
+  }
+}
+
+function bundleEntry(artifact, refCommit, artifactPath, hashFile) {
+  const stats = lstatSync(artifactPath);
+  if (!stats.isFile() || stats.size <= 0) {
+    throw new Error(`Flatpak bundle target must be a non-empty regular file: ${artifactPath}`);
+  }
+  const report = flatpakArtifactSizeReport(artifactPath);
+  enforceFlatpakBundleSize(report);
+  return {
+    id: refCommit.id,
+    refId: artifact.refId,
+    ref: refCommit.ref,
+    commit: refCommit.commitSha256,
+    role: artifact.runtime ? "runtime" : "app",
+    outputPath: path.resolve(artifact.path),
+    basename: path.basename(artifact.path),
+    bytes: stats.size,
+    sha256: hashFile(artifactPath),
+  };
+}
+
+function atomicWriteBundleState(statePath, state) {
+  mkdirSync(path.dirname(statePath), { recursive: true });
+  const temporaryPath = `${statePath}.${randomUUID()}.tmp`;
+  try {
+    writeFileSync(temporaryPath, `${JSON.stringify(state, null, 2)}\n`);
+    renameSync(temporaryPath, statePath);
+  } finally {
+    rmSync(temporaryPath, { force: true });
+  }
+}
+
+export async function reuseFlatpakBundles({
+  bundlePlan,
+  refCommits,
+  namespace,
+  flatpakVersion,
+  statePath,
+  checksumPath = sha256SumsPath,
+  repository = repoDir,
+  evidence = false,
+  concurrency = defaultFlatpakBundleConcurrency(),
+  reportWorkerLimit = false,
+  spawnProcess = spawn,
+  managedBundlePaths = [...configuredBundlePaths, ...currentDefaultBundlePaths, ...obsoleteDefaultBundlePaths],
+  hashFile = fileSha256, renameArtifact = renameSync,
+  writeChecksums = writeFlatpakChecksums, writeState = atomicWriteBundleState,
+} = {}) {
+  validateFlatpakArtifactPaths(bundlePlan.map((artifact) => artifact.path));
+  if (!Array.isArray(refCommits) || refCommits.length !== bundlePlan.length) {
+    throw new Error("Flatpak bundle refs must match the selected bundle plan.");
+  }
+  if (typeof namespace !== "string" || !namespace || typeof flatpakVersion !== "string" || !flatpakVersion ||
+    refCommits.some((entry, index) => !entry || typeof entry.id !== "string" || !entry.id ||
+      entry.ref !== `${bundlePlan[index].runtime ? "runtime" : "app"}/${bundlePlan[index].refId}/x86_64/stable` ||
+      !/^[a-f0-9]{64}$/.test(entry.commitSha256))) {
+    throw new Error("Flatpak bundle state inputs are malformed.");
+  }
+  const header = {
+    schema: bundleStateSchema, namespace, flatpakVersion,
+    arch: "x86_64", branch: "stable", commandContract: bundleCommandContract,
+  };
+  const state = evidence ? null : readBundleState(statePath, header, managedBundlePaths);
+  const manifest = evidence ? null : readBundleChecksums(checksumPath);
+  const entriesById = new Map(state?.entries.map((entry) => [entry.id, entry]) ?? []);
+  const observations = [];
+  const pending = [];
+  for (let index = 0; index < bundlePlan.length; index += 1) {
+    const artifact = bundlePlan[index];
+    const refCommit = refCommits[index];
+    const cached = entriesById.get(refCommit.id);
+    if (!evidence && state && manifest && validBundleEntry(
+      cached, artifact, refCommit, manifest.checksums.get(path.basename(artifact.path)),
+    ) && verifiedBundleFile(artifact.path, cached, hashFile)) {
+      observations.push({ ...cached, status: "reused" });
+    } else {
+      const temporaryPath = `${artifact.path}.${randomUUID()}.tmp`;
+      pending.push({ index, artifact, refCommit, temporaryPath });
+      observations.push(null);
+    }
+  }
+  const firstRebuiltArtifact = pending[0]?.refCommit.id ?? null, mode = evidence ? "disabled-for-evidence" : "enabled";
+  const selectedPaths = new Set(bundlePlan.map(({ path: artifactPath }) => path.resolve(artifactPath)));
+  const selectedNames = bundlePlan.map(({ path: artifactPath }) => path.basename(artifactPath)).sort();
+  const existingNames = [...(manifest?.checksums.keys() ?? [])].sort();
+  const selectedStateIds = refCommits.map(({ id }) => id), existingStateIds = state?.entries.map(({ id }) => id) ?? [];
+  const publicationNeeded = pending.length > 0 || !equalJson(selectedNames, existingNames) ||
+    !equalJson(selectedStateIds, existingStateIds);
+  const replacedDestinations = [];
+  try {
+    if (publicationNeeded) {
+      rmSync(statePath, { force: true });
+      rmSync(checksumPath, { force: true });
+    }
+    if (pending.length > 0) {
+      const workerLimit = flatpakBundleWorkerLimit(pending, concurrency);
+      if (reportWorkerLimit) process.stdout.write(`Flatpak bundle worker limit: ${workerLimit}\n`);
+      await buildFlatpakBundles({
+        bundlePlan: pending.map(({ artifact, temporaryPath }) => ({ ...artifact, path: temporaryPath })),
+        repository,
+        concurrency: workerLimit,
+        spawnProcess,
+      });
+      for (const item of pending) {
+        const entry = bundleEntry(item.artifact, item.refCommit, item.temporaryPath, hashFile);
+        observations[item.index] = { ...entry, status: "rebuilt" };
+      }
+      for (const item of pending) {
+        renameArtifact(item.temporaryPath, item.artifact.path);
+        replacedDestinations.push(item.artifact.path);
+      }
+    }
+    if (publicationNeeded) {
+      for (const managedPath of managedBundlePaths) {
+        if (!selectedPaths.has(path.resolve(managedPath))) rmSync(managedPath, { force: true });
+      }
+      writeChecksums(bundlePlan.map((artifact) => artifact.path), checksumPath);
+      writeState(statePath, { ...header, entries: observations.map(({ status, ...entry }) => entry) });
+    }
+    return {
+      mode,
+      observationComplete: true,
+      entries: observations.map(({ id: name, ref, commit, status, bytes, sha256 }) =>
+        ({ name, ref, commit, status, bytes, sha256 })),
+      firstRebuiltArtifact,
+    };
+  } catch (error) {
+    rmSync(statePath, { force: true }); rmSync(checksumPath, { force: true });
+    for (const { temporaryPath } of pending) rmSync(temporaryPath, { force: true });
+    for (const destination of replacedDestinations) rmSync(destination, { force: true });
+    error.bundleCache = {
+      mode,
+      observationComplete: false,
+      entries: observations.filter(Boolean).map(({ id: name, ref, commit, status, bytes, sha256 }) =>
+        ({ name, ref, commit, status, bytes, sha256 })),
+      firstRebuiltArtifact,
+    };
+    throw error;
+  }
 }
 
 function printFlatpakSizeReport(report) {
@@ -820,7 +1408,39 @@ export function isValidPnpmCacheReport(pnpm) {
   );
 }
 
-function cacheReport({ namespace, inputs, cacheRoot, timings, evidence, refCommits, selectedProfiles }) {
+export function expectedFlatpakModuleOrder(manifest) {
+  return [...manifest.matchAll(/^  - name: ([^\n]+)$/gm)].map((match) => match[1]);
+}
+
+export function parseFlatpakModuleCacheOutput(output, expectedModules, { evidence = false } = {}) {
+  const normalized = output.replace(/\u001B\[[0-?]*[ -/]*[@-~]/g, "").replaceAll("\r\n", "\n");
+  const expected = new Set(expectedModules);
+  const states = new Map(expectedModules.map((name) => [name, "unknown"]));
+  let contradictory = false;
+  for (const rawLine of normalized.split("\n")) {
+    const line = rawLine.trim();
+    const match = /^(?:Cache hit for ([A-Za-z0-9._-]+), skipping build|Building module ([A-Za-z0-9._-]+) in \/[^\0]*)(?:\.)?$/.exec(line);
+    if (!match) continue;
+    const name = match[1] ?? match[2];
+    if (!expected.has(name)) continue;
+    const status = line.startsWith("Cache hit") ? "cached" : "executed";
+    const previous = states.get(name);
+    if (previous !== "unknown" && previous !== status) contradictory = true;
+    states.set(name, previous === "unknown" || previous === status ? status : "unknown");
+  }
+  const modules = expectedModules.map((name) => ({ name, status: states.get(name) }));
+  const firstExecuted = modules.findIndex(({ status }) => status === "executed");
+  return {
+    mode: evidence ? "disabled-for-evidence" : "enabled",
+    modules,
+    observationComplete: !contradictory && modules.every(({ status }) => status !== "unknown"),
+    firstInvalidatedModule: firstExecuted >= 0 && modules.slice(0, firstExecuted).every(({ status }) => status === "cached")
+      ? modules[firstExecuted].name
+      : null,
+  };
+}
+
+function cacheReport({ namespace, inputs, cacheRoot, timings, evidence, refCommits, selectedProfiles, builderOutput, expectedModules, payload, output, bundleCache }) {
   const namespaceRoot = path.join(cacheRoot, namespace);
   const pnpmPath = path.join(namespaceRoot, "pnpm-report.json");
   const sccachePath = path.join(namespaceRoot, "sccache-stats.json");
@@ -836,23 +1456,24 @@ function cacheReport({ namespace, inputs, cacheRoot, timings, evidence, refCommi
     schema: cacheSchema,
     namespace,
     namespaceInputs: inputs,
-    modules: { frontend: pnpm ? "executed" : "cached", desktop: sccache ? "executed" : "cached" },
+    moduleCache: parseFlatpakModuleCacheOutput(builderOutput, expectedModules, { evidence }),
     pnpm: pnpm ?? { status: "module-cached" },
     sccache: sccache ?? { status: "module-cached" },
     timings,
     selectedProfiles,
-    payload: digestBuildPayload(path.join(buildDir, "files")),
+    payload,
     refCommits,
+    output,
+    bundleCache,
     errors: [],
   };
 }
 
 async function main() {
   const startedAt = performance.now();
-  const packageOptions = parsePackageOptions(process.argv.slice(2), { platform: "linux" });
+  const packageOptions = parsePackageOptions(packageArguments(), { platform: "linux" });
   const selectedProfiles = packageOptions.flatpakProfiles;
   const bundlePlan = flatpakBundlePlan({ selectedProfiles });
-  cleanupFlatpakBundleOutputs({ bundlePlan });
   const skipBundle = packageOptions.noBundle || process.env.FLATPAK_NO_BUNDLE === "1";
   const evidence = process.env.FLATPAK_CACHE_EVIDENCE === "1";
   if (process.arch !== "x64") {
@@ -870,6 +1491,8 @@ async function main() {
   const { stateRoot, cacheRoot } = resolveCacheRoots();
   const stateDir = path.join(stateRoot, namespace.name);
   const namespaceRoot = path.join(cacheRoot, namespace.name);
+  const outputStatePath = flatpakOutputStatePath(stateDir);
+  const bundleStatePath = flatpakBundleStatePath(stateDir);
   mkdirSync(stateDir, { recursive: true });
   mkdirSync(namespaceRoot, { recursive: true });
   rmSync(path.join(namespaceRoot, "pnpm-report.json"), { force: true });
@@ -879,7 +1502,7 @@ async function main() {
   run(process.execPath, [
     path.join("scripts", "generate-flatpak-sources.mjs"),
     ...packageOptionsToGeneratorArgs(packageOptions),
-  ]);
+  ], { env: { SOURCE_DATE_EPOCH: sourceDateEpoch } });
   normalizeGeneratedModelBundleManifest({ sourceDateEpoch });
   const frontendGitRef = resolveFrontendGitRef();
   const installedBuildInfo = writeBuildInfoFile(flatpakVersionInfoPath, { workspaceRoot });
@@ -892,11 +1515,32 @@ async function main() {
   const manifestPath = generatedManifestPath(packageOptions, cacheRoot, namespace.name, frontendGitRef);
   const sourceSeconds = (performance.now() - sourceStartedAt) / 1_000;
 
+  const reportPath = process.env.FLATPAK_CACHE_REPORT_PATH ?? path.join(flatpakRoot, "generated", "cache-report.json");
+  const existingPayload = existsSync(path.join(buildDir, "files"))
+    ? digestBuildPayload(path.join(buildDir, "files"))
+    : undefined;
+  let preBuilderRefCommits;
+  try {
+    preBuilderRefCommits = verifyFlatpakOutputRefs({ selectedProfiles });
+  } catch {
+    preBuilderRefCommits = undefined;
+  }
+  let outputState = selectPreservedFlatpakOutputState({
+    statePath: outputStatePath,
+    namespace: namespace.name,
+    selectedProfiles,
+    refCommits: preBuilderRefCommits,
+    checkoutPayload: existingPayload,
+    evidence,
+  });
+  const preserveOutputRefs = outputState !== null;
+
   checkCommand(
     "flatpak-builder",
     "Install flatpak-builder and the Flathub runtimes before running pnpm package:linux:flatpak.",
   );
   checkCommand("flatpak", "Install flatpak before running pnpm package:linux:flatpak.");
+  const flatpakVersion = commandVersion("flatpak");
 
   const builderArgs = [
     "--force-clean",
@@ -911,10 +1555,43 @@ async function main() {
     manifestPath,
   ];
   if (evidence) builderArgs.unshift("--disable-cache");
+  if (preserveOutputRefs) builderArgs.unshift("--require-changes");
   const builderStartedAt = performance.now();
-  reconcileFlatpakOutputRefs();
-  run("flatpak-builder", builderArgs);
+  if (!preserveOutputRefs) reconcileFlatpakOutputRefs();
+  const builderOutput = await runAndTee("flatpak-builder", builderArgs);
   const refCommits = verifyFlatpakOutputRefs({ selectedProfiles });
+  let payload;
+  let checkoutSize;
+  let output;
+  if (preserveOutputRefs && equalJson(preBuilderRefCommits, refCommits)) {
+    const stateErrors = validateFlatpakOutputState(outputState, { namespace: namespace.name, selectedProfiles, refCommits });
+    if (stateErrors.length > 0) {
+      throw new Error(`Flatpak output state contradicted preserved refs: ${stateErrors.join(" ")}`);
+    }
+    payload = outputState.payload;
+    checkoutSize = outputState.checkoutSize;
+    output = {
+      mode: "preserved-unchanged",
+      observationComplete: true,
+      payloadObservationSource: "output-state",
+    };
+  } else {
+    payload = digestBuildPayload(path.join(buildDir, "files"));
+    checkoutSize = flatpakSizeReport({ includeBundle: false });
+    output = {
+      mode: "exported",
+      observationComplete: true,
+      payloadObservationSource: "checkout",
+    };
+  }
+  writeFlatpakOutputState({
+    statePath: outputStatePath,
+    namespace: namespace.name,
+    selectedProfiles,
+    payload,
+    refCommits,
+    checkoutSize,
+  });
   const report = cacheReport({
     namespace: namespace.name,
     inputs: namespace.inputs,
@@ -922,13 +1599,19 @@ async function main() {
     evidence,
     refCommits,
     selectedProfiles,
+    builderOutput,
+    payload,
+    output,
+    bundleCache: skipBundle
+      ? { mode: "not-requested", observationComplete: true, entries: [], firstRebuiltArtifact: null }
+      : { mode: evidence ? "disabled-for-evidence" : "enabled", observationComplete: false, entries: [], firstRebuiltArtifact: null },
+    expectedModules: expectedFlatpakModuleOrder(readFileSync(manifestPath, "utf8")),
     timings: {
       sourceGenerationSeconds: Number(sourceSeconds.toFixed(3)),
       builderSeconds: Number(((performance.now() - builderStartedAt) / 1_000).toFixed(3)),
       elapsedSeconds: Number(((performance.now() - startedAt) / 1_000).toFixed(3)),
     },
   });
-  const reportPath = process.env.FLATPAK_CACHE_REPORT_PATH ?? path.join(flatpakRoot, "generated", "cache-report.json");
   writeJson(reportPath, report);
   const baselinePath = process.env.FLATPAK_CACHE_BASELINE_REPORT;
   if (baselinePath) {
@@ -938,10 +1621,17 @@ async function main() {
     writeJson(comparisonPath, comparison);
     if (!comparison.equivalent) throw new Error(comparison.errors.join(" "));
   }
+  const crossProfileBaselinePath = process.env.FLATPAK_CACHE_CROSS_PROFILE_BASELINE_REPORT;
+  if (crossProfileBaselinePath) {
+    const comparison = compareCrossProfileCacheReports(readJson(crossProfileBaselinePath), report);
+    const comparisonPath = process.env.FLATPAK_CACHE_CROSS_PROFILE_COMPARISON_REPORT_PATH ??
+      path.join(flatpakRoot, "generated", "cache-cross-profile-comparison-report.json");
+    writeJson(comparisonPath, comparison);
+    if (!comparison.equivalent) throw new Error(comparison.errors.join(" "));
+  }
   if (skipBundle) {
     const sizeReportPath = process.env.FLATPAK_SIZE_REPORT_PATH ?? path.join(flatpakRoot, "generated", "size-report.json");
-    const sizeReport = flatpakSizeReport({ includeBundle: false });
-    sizeReport.selectedProfiles = selectedProfiles;
+    const sizeReport = { ...checkoutSize, selectedProfiles };
     writeJson(sizeReportPath, sizeReport);
     printFlatpakSizeReport(sizeReport);
     process.stdout.write(`Flatpak repo exported to ${repoDir}\n`);
@@ -958,28 +1648,74 @@ async function main() {
     return;
   }
 
-  await withFreshFlatpakBundleOutputs(async () => {
-    await buildFlatpakBundles({ bundlePlan });
+  try {
+    report.bundleCache = await reuseFlatpakBundles({
+      bundlePlan,
+      refCommits,
+      namespace: namespace.name,
+      flatpakVersion,
+      statePath: bundleStatePath,
+      evidence,
+      reportWorkerLimit: true,
+    });
     const sizeReportPath = process.env.FLATPAK_SIZE_REPORT_PATH ?? path.join(flatpakRoot, "generated", "size-report.json");
-    const sizeReport = {
-      ...flatpakSizeReport(),
+    const sizeReport = flatpakBundleSizeReportFromCheckout({
+      checkoutSize,
+      bundle: bundlePlan[0].path,
       selectedProfiles,
       extensionBundles: bundlePlan.slice(1).map((artifact) => flatpakArtifactSizeReport(artifact.path)),
-    };
+    });
     writeJson(sizeReportPath, sizeReport);
     printFlatpakSizeReport(sizeReport);
     enforceFlatpakBundleSize(sizeReport);
     for (const report of sizeReport.extensionBundles) enforceFlatpakBundleSize(report);
-    writeFlatpakChecksums(bundlePlan.map((artifact) => artifact.path));
-  }, { bundlePlan });
+    writeJson(reportPath, report);
+  } catch (error) {
+    if (error.bundleCache) report.bundleCache = error.bundleCache;
+    writeJson(reportPath, report);
+    throw error;
+  }
 
-  for (const artifact of bundlePlan) process.stdout.write(`Flatpak bundle written to ${artifact.path}\n`);
-  process.stdout.write(`Flatpak checksums written to ${sha256SumsPath}\n`);
+  for (const [index, artifact] of bundlePlan.entries()) {
+    const status = report.bundleCache.entries[index].status;
+    process.stdout.write(`Flatpak bundle ${status} at ${artifact.path}\n`);
+  }
+  process.stdout.write(`Flatpak checksums verified at ${sha256SumsPath}\n`);
+}
+
+function runWithPackagingLock() {
+  const lockPath = path.join(workspaceRoot, ".flatpak-builder", "tuneforge-package.lock");
+  const token = randomUUID();
+  mkdirSync(path.dirname(lockPath), { recursive: true });
+  process.stdout.write("Waiting for Flatpak packaging lock...\n");
+  run("flock", ["--verbose", lockPath, process.execPath, __filename, `--flatpak-lock-token=${token}`, ...process.argv.slice(2)], {
+    env: { TUNEFORGE_FLATPAK_LOCK_TOKEN: token },
+  });
+}
+
+function packageArguments() {
+  return isLockedPackagingInvocation() ? process.argv.slice(3) : process.argv.slice(2);
+}
+
+function isLockedPackagingInvocation() {
+  const token = process.env.TUNEFORGE_FLATPAK_LOCK_TOKEN;
+  const marker = process.argv[2];
+  return typeof token === "string" && /^[0-9a-f-]{36}$/.test(token) &&
+    marker === `--flatpak-lock-token=${token}`;
 }
 
 if (process.argv[1] && path.resolve(process.argv[1]) === __filename) {
-  main().catch((error) => {
-    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
-    process.exitCode = 1;
-  });
+  if (isLockedPackagingInvocation()) {
+    main().catch((error) => {
+      process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+      process.exitCode = 1;
+    });
+  } else {
+    try {
+      runWithPackagingLock();
+    } catch (error) {
+      process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+      process.exitCode = 1;
+    }
+  }
 }

--- a/scripts/package-options.mjs
+++ b/scripts/package-options.mjs
@@ -119,6 +119,16 @@ export function packageOptionsEnvironment(options) {
   };
 }
 
+// The frontend only reads the beat-this selector. Keeping the backend and
+// extension selectors out of this environment prevents unrelated profile
+// choices from invalidating the frontend Flatpak module.
+export function frontendPackageOptionsEnvironment(options) {
+  const { beatThis } = validatePackageOptions(options);
+  return {
+    TUNEFORGE_PACKAGE_OPTIONS: JSON.stringify({ beatThis }),
+  };
+}
+
 export function packageOptionsToGeneratorArgs(options) {
   const validated = validatePackageOptions(options);
   const args = [];

--- a/scripts/package-options.test.mjs
+++ b/scripts/package-options.test.mjs
@@ -7,19 +7,24 @@ import {
   assertDefaultCpuTorchClosure,
   assertTorchExtensionProfile,
   markerMatchesFlatpakTarget,
+  flatpakTorchLockPaths,
   mergeLegacyTorchPackageSets,
   parseUvLock,
+  parsePylock,
   partitionTorchExtensionPackages,
   removeObsoleteTorchExtensionOutputs,
   removeUnselectedTorchExtensionOutputs,
   resolvePythonRuntimePackages,
+  resolveNamedPythonPackages,
   selectedTorchExtensionProfileSpecs,
   torchExtensionPairId,
   torchExtensionMarker,
+  assertReviewedTorchExtensionPair,
   TORCH_EXTENSION_PROFILES,
   wheelScore,
 } from "./generate-flatpak-sources.mjs";
 import { manifestWithPackageOptions } from "./package-flatpak.mjs";
+import { refreshTorchLock } from "./refresh-flatpak-torch-locks.mjs";
 import {
   buildFlatpakProfileComponentInventory,
   buildReleaseLicenseInventory,
@@ -37,6 +42,7 @@ import {
   backendSyncArgs,
   normalizeFlatpakProfiles,
   packageOptionsEnvironment,
+  frontendPackageOptionsEnvironment,
   packageOptionsToGeneratorArgs,
   parsePackageOptions,
 } from "./package-options.mjs";
@@ -105,7 +111,7 @@ test("macOS and Flatpak stage the canonical Demucs manifest at the runtime path"
     new URL("../packaging/flatpak/com.tuneforge.desktop.yml", import.meta.url),
     "utf8",
   );
-  assert.match(manifest, /path: \.\.\/\.\.\/packaging\/demucs\/models\.json\n\s+dest: apps\/backend\n\s+dest-filename: demucs-models\.json/);
+  assert.match(manifest, /path: generated\/backend-snapshot\.tar\n\s+archive-type: tar\n\s+strip-components: 0/);
   assert.match(
     manifest,
     /install -Dm644 apps\/backend\/demucs-models\.json \/app\/lib\/tuneforge\/backend\/src\/demucs-models\.json/,
@@ -260,6 +266,10 @@ test("Flatpak package options are scoped to the TuneForge module build environme
   assert.match(
     frontendModule,
     /      env:\n        TUNEFORGE_PACKAGE_OPTIONS: '.*"beatThis":false.*'/,
+  );
+  assert.deepEqual(
+    JSON.parse(frontendPackageOptionsEnvironment(parsePackageOptions(["--no-crema", "--no-lv-chordia", "--nvidia"], { platform: "linux" })).TUNEFORGE_PACKAGE_OPTIONS),
+    { beatThis: true },
   );
   assert.match(manifest, /path: generated\/python-build-requirements\.txt/);
   assert.match(manifest, /-r python-build-requirements\.txt/);
@@ -430,13 +440,35 @@ test("package option parser rejects platform-specific options", () => {
   );
 });
 
-test("Flatpak resolves CPU, NVIDIA, and legacy NVIDIA Torch profiles", () => {
+test("Flatpak reads reviewed CPU and legacy NVIDIA Torch locks without live resolution", () => {
   const generator = readFileSync(new URL("./generate-flatpak-sources.mjs", import.meta.url), "utf8");
 
-  assert.match(generator, /"torch==2\.13\.0\\ntorchaudio==2\.11\.0\\n"/);
-  assert.match(generator, /"--python-version",\n\s+"3\.14"/);
-  assert.match(generator, /"--torch-backend",\n\s+"cpu"/);
-  assert.match(generator, /"--torch-backend",\n\s+"cu126"/);
+  assert.doesNotMatch(generator, /pip",\s+"compile"/);
+  const legacy = parsePylock(readFileSync(flatpakTorchLockPaths["legacy-nvidia"], "utf8"));
+  const cpu = parsePylock(readFileSync(flatpakTorchLockPaths.cpu, "utf8"));
+  const nvidia = resolveNamedPythonPackages(
+    parseUvLock(readFileSync(new URL("../apps/backend/uv.lock", import.meta.url), "utf8")),
+    ["torch", "torchaudio"],
+  );
+  assert.ok(cpu.size > 0);
+  assert.ok(legacy.size > 0);
+  assert.equal(assertReviewedTorchExtensionPair("LegacyNvidia", legacy), TORCH_EXTENSION_PROFILES.LegacyNvidia.pair_id);
+  assert.equal(assertReviewedTorchExtensionPair("Nvidia", nvidia), TORCH_EXTENSION_PROFILES.Nvidia.pair_id);
+});
+
+test("failed Torch lock refresh preserves the reviewed lock bytes", () => {
+  const root = mkdtempSync(path.join(tmpdir(), "tuneforge-torch-refresh-"));
+  const lockPath = path.join(root, "pylock.cpu-torch.toml");
+  writeFileSync(lockPath, "reviewed bytes\n");
+  try {
+    assert.throws(() => refreshTorchLock({ id: "cpu", backend: "cpu", lockPath }, {
+      compile: (_profile, _requirementsPath, temporaryPath) => writeFileSync(temporaryPath,
+        "lock-version = \"1.0\"\n\n[[packages]]\nname = \"torch\"\nversion = \"2.13.0+cpu\"\n\n[[packages]]\nname = \"torchaudio\"\nversion = \"2.11.0+cpu\"\n"),
+    }), /No Linux x86_64-compatible artifact/);
+    assert.equal(readFileSync(lockPath, "utf8"), "reviewed bytes\n");
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
 });
 
 test("Torch extension profiles enforce exact versions, closure, and immutable markers", () => {

--- a/scripts/refresh-flatpak-torch-locks.mjs
+++ b/scripts/refresh-flatpak-torch-locks.mjs
@@ -1,0 +1,67 @@
+import { mkdirSync, readFileSync, renameSync, rmSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import {
+  flatpakTorchLockPaths,
+  validateFlatpakTorchLock,
+} from "./generate-flatpak-sources.mjs";
+
+const __filename = fileURLToPath(import.meta.url);
+const workspaceRoot = path.resolve(path.dirname(__filename), "..");
+const profiles = new Map([
+  ["--cpu", { id: "cpu", backend: "cpu", lockPath: flatpakTorchLockPaths.cpu }],
+  ["--legacy-nvidia", { id: "legacy-nvidia", backend: "cu126", lockPath: flatpakTorchLockPaths["legacy-nvidia"] }],
+]);
+
+function selectedProfiles(argv) {
+  if (argv.length === 0) throw new Error("Select --cpu and/or --legacy-nvidia to refresh reviewed Torch locks.");
+  const selected = [];
+  for (const argument of argv) {
+    const profile = profiles.get(argument);
+    if (!profile) throw new Error(`Unknown Torch lock refresh option: ${argument}`);
+    if (!selected.includes(profile)) selected.push(profile);
+  }
+  return selected;
+}
+
+function compileTorchLock(profile, requirementsPath, temporaryPath) {
+  writeFileSync(requirementsPath, "torch==2.13.0\ntorchaudio==2.11.0\n");
+  const result = spawnSync("uv", [
+    "--quiet", "pip", "compile", requirementsPath,
+    "--python-version", "3.14",
+    "--python-platform", "x86_64-manylinux_2_28",
+    "--torch-backend", profile.backend,
+    "--format", "pylock.toml",
+    "--output-file", temporaryPath,
+    "--no-header", "--no-annotate",
+  ], { cwd: workspaceRoot, stdio: "inherit" });
+  if (result.error?.code === "ENOENT") throw new Error("Required command not found: uv");
+  if (result.status !== 0) throw new Error(`uv exited with status ${result.status}`);
+}
+
+export function refreshTorchLock(profile, { compile = compileTorchLock } = {}) {
+  const directory = path.dirname(profile.lockPath);
+  mkdirSync(directory, { recursive: true });
+  const temporaryPath = path.join(directory, `pylock.${profile.id}-${process.pid}.toml`);
+  const requirementsPath = path.join(directory, `.torch-${profile.id}-${process.pid}.in`);
+  try {
+    compile(profile, requirementsPath, temporaryPath);
+    const { pairId } = validateFlatpakTorchLock(profile.id, readFileSync(temporaryPath, "utf8"));
+    renameSync(temporaryPath, profile.lockPath);
+    process.stdout.write(`Refreshed ${path.relative(workspaceRoot, profile.lockPath)}\n`);
+    if (pairId) process.stdout.write(`Review LegacyNvidia pair ID: ${pairId}\n`);
+  } finally {
+    rmSync(requirementsPath, { force: true });
+    rmSync(temporaryPath, { force: true });
+  }
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === __filename) {
+  try {
+    for (const profile of selectedProfiles(process.argv.slice(2))) refreshTorchLock(profile);
+  } catch (error) {
+    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+    process.exitCode = 1;
+  }
+}


### PR DESCRIPTION
## Summary

- Generate deterministic Flatpak source snapshots and share caches across CPU and NVIDIA profile selections.
- Pin reviewed CPU and legacy NVIDIA Torch inputs, preserve unchanged exports, and report exact cache evidence.
- Verify and reuse unchanged per-ref bundles; rebuild misses with schedulable CPU count minus one workers.
- Closes #496.

## Testing

- `node --test scripts/flatpak-cache.test.mjs`
- `node --test scripts/package-options.test.mjs scripts/flatpak-options.test.mjs`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- Linux full warm build: 13/13 modules cached, output preserved, five bundles reused, zero bundle workers, exit 0 in 58.13 seconds.
