### PR TITLE
chore: prepare v1.4.0 release

### DIFF
--- a/.agents/skills/coordinate-tuneforge-work/SKILL.md
+++ b/.agents/skills/coordinate-tuneforge-work/SKILL.md
@@ -137,11 +137,11 @@ proof of live transport, external-device, or release behavior.
 Use one initial correctness review for implementation, one evidence review for
 research, or one release-safety review for release preparation. Evidence review
 must check methodology, reproducibility, unsupported generalization, licensing,
-and evidence-to-conclusion fit. Release-safety review must check the asset
-contract, provenance, checkpoint authority, manual-only operations, and fail-closed
-gates. Add contract and Product Design review only when applicable. Route reviews
-to Sol High normally, Sol XHigh only for declared high risk, and Sol Max only for
-a focused unresolved critical dispute. Send actionable findings to the original
+and evidence-to-conclusion fit. Release-safety review must check the exact platform
+payload/checksum/signature matrix, provenance, checkpoint authority, manual-only
+operations, and fail-closed gates. Add contract and Product Design review only when
+applicable. Route reviews to Sol High normally, Sol XHigh only for declared high risk,
+and Sol Max only for a focused unresolved critical dispute. Send actionable findings to the original
 worker for one remediation pass, then perform one focused re-review. Stop on
 unresolved critical findings.
 

--- a/.agents/skills/coordinate-tuneforge-work/references/prompt-examples.md
+++ b/.agents/skills/coordinate-tuneforge-work/references/prompt-examples.md
@@ -45,7 +45,7 @@ Symptom and evidence: <observed behavior and supporting evidence>.
 ## Release Preparation
 
 ```text
-Use $coordinate-tuneforge-work to plan release prep for v1.1.0.
+Use $coordinate-tuneforge-work to plan release prep for v<version>.
 ```
 
 ## User-Owned Post-Plan Paths
@@ -66,9 +66,10 @@ After the release-preparation PR is merged, continue the approved release plan
 without granting signing or final-publication authority:
 
 ```text
-Continue v1.1.0 release preparation with $coordinate-tuneforge-work. Pause
-before the signed tag, draft release, Android release APK, and artifact signing
-and upload. Do not sign artifacts or publish the final release.
+Continue v<version> release preparation with $coordinate-tuneforge-work. Pause
+before the signed tag, draft release, Flatpak handoff and verification, Android
+release APK, and artifact signing and upload. Do not sign artifacts or publish
+the final release.
 ```
 
 ### Optional Goal

--- a/.agents/skills/coordinate-tuneforge-work/references/release-prep.md
+++ b/.agents/skills/coordinate-tuneforge-work/references/release-prep.md
@@ -20,19 +20,41 @@ PR and the later tagged-release operations as separate authority scopes.
   only checks actually run and preserve generated release media as uncommitted
   local output.
 
-Standard TuneForge releases upload exactly seven assets, using the release
-version in both binaries:
+From v1.4.0 onward, TuneForge releases require exactly seven payloads:
 
 1. `TuneForge_<version>_aarch64.dmg`
-2. `TuneForge_<version>_aarch64.dmg.asc`
-3. `TuneForge_<version>_android_aarch64_publishable.apk`
-4. `TuneForge_<version>_android_aarch64_publishable.apk.asc`
-5. `SHA256SUMS`
-6. `SHA256SUMS.asc`
-7. `release-key.asc`
+2. `TuneForge_<version>_android_aarch64_publishable.apk`
+3. `Tuneforge_<version>_x86_64.flatpak`
+4. `Tuneforge_<version>_Torch_Nvidia_Core_x86_64.flatpak`
+5. `Tuneforge_<version>_Torch_Nvidia_Runtime_x86_64.flatpak`
+6. `Tuneforge_<version>_Torch_LegacyNvidia_Core_x86_64.flatpak`
+7. `Tuneforge_<version>_Torch_LegacyNvidia_Runtime_x86_64.flatpak`
 
-The ARM64 publishable APK is mandatory for every release. `SHA256SUMS` lists
-only the DMG and APK. For v1.1.0, do not build or upload a Flatpak.
+Every payload has a detached `.asc` signature. The release `SHA256SUMS` covers
+exactly the seven payloads, sorted by basename, and has its own detached
+`SHA256SUMS.asc` signature. `release-key.asc` completes the exact 17 uploaded
+assets. Never reuse the ignored packaging output
+`packaging/flatpak/generated/SHA256SUMS` as the release manifest.
+
+Apply this verification matrix before upload and again to a fresh download:
+every checksum entry must match the payload digest, and every detached `.asc`
+must verify against the approved `release-key.asc` fingerprint.
+
+| Exact payload filename | Provenance | Size | Checksum and signature | License evidence | Architecture / branch | Package or ref identity |
+| --- | --- | --- | --- | --- | --- | --- |
+| `TuneForge_<version>_aarch64.dmg` | Frozen tagged SHA | Recorded, nonzero | Sorted manifest entry + matching `.asc` | Release inventory + notices | `aarch64` / n/a | `TuneForge`, embedded version and git ref |
+| `TuneForge_<version>_android_aarch64_publishable.apk` | Frozen tagged SHA | Recorded, nonzero | Sorted manifest entry + matching `.asc` | Release inventory + notices | `arm64-v8a` / n/a | `com.tuneforge.desktop`, version, release signer |
+| `Tuneforge_<version>_x86_64.flatpak` | Frozen tagged SHA and OSTree commit | Recorded, below 2 GiB | Sorted manifest entry + matching `.asc` | CPU profile inventory + notices | `x86_64` / `stable` | `app/com.tuneforge.desktop/x86_64/stable` |
+| `Tuneforge_<version>_Torch_Nvidia_Core_x86_64.flatpak` | Frozen tagged SHA and OSTree commit | Recorded, below 2 GiB | Sorted manifest entry + matching `.asc` | NVIDIA Core inventory + notices | `x86_64` / `stable` | `runtime/com.tuneforge.desktop.Torch.Stack.Nvidia.Core/x86_64/stable` |
+| `Tuneforge_<version>_Torch_Nvidia_Runtime_x86_64.flatpak` | Frozen tagged SHA and OSTree commit | Recorded, below 2 GiB | Sorted manifest entry + matching `.asc` | NVIDIA Runtime inventory + notices | `x86_64` / `stable` | `runtime/com.tuneforge.desktop.Torch.Stack.Nvidia.Runtime/x86_64/stable` |
+| `Tuneforge_<version>_Torch_LegacyNvidia_Core_x86_64.flatpak` | Frozen tagged SHA and OSTree commit | Recorded, below 2 GiB | Sorted manifest entry + matching `.asc` | LegacyNvidia Core inventory + notices | `x86_64` / `stable` | `runtime/com.tuneforge.desktop.Torch.Stack.LegacyNvidia.Core/x86_64/stable` |
+| `Tuneforge_<version>_Torch_LegacyNvidia_Runtime_x86_64.flatpak` | Frozen tagged SHA and OSTree commit | Recorded, below 2 GiB | Sorted manifest entry + matching `.asc` | LegacyNvidia Runtime inventory + notices | `x86_64` / `stable` | `runtime/com.tuneforge.desktop.Torch.Stack.LegacyNvidia.Runtime/x86_64/stable` |
+
+The DMG, publishable APK, CPU Flatpak, and both Core/Runtime accelerator pairs
+are mandatory. Treat all five Flatpak payloads as release-gated: missing or
+malformed identity/ref, hash, signature, size, license, or provenance evidence
+fails closed. Preserve CPU fallback even when optional accelerator-device
+detection and inference evidence is unavailable.
 
 Create a named temporary staging directory and print its absolute path. Retain
 it through final publication and remote verification. Show its explicit
@@ -41,7 +63,8 @@ cleanup command, but never run cleanup automatically.
 ## Manual Steps and Automation Boundary
 
 Never run artifact-signing commands, `pnpm package:android:release`, or final
-release publication. Never access or automate KeePassXC, inspect private keys
+release publication. The Linux Flatpak build and every packaged-app launch are
+manual handoffs; the user owns launches and app data. Never access or automate KeePassXC, inspect private keys
 or passwords, request secrets in chat, or rely on a cached artifact-signing
 identity. An approved signed-tag command may use the repository-configured Git
 signing identity without accessing KeePassXC or inspecting or exporting key
@@ -61,7 +84,8 @@ for the actions after that stop. Merge authority is always separate.
 1. Require the release-preparation PR merged with green CI. Refresh the local
    checkout, require a clean worktree, and prove `HEAD == origin/main`.
 2. Freeze the release commit SHA. Verify version sources, dated changelog, tag
-   absence, and release readiness from that exact commit.
+   absence, the seven-payload/17-asset contract, and release readiness from
+   that exact commit.
 3. Stop. Show the exact signed annotated-tag command and await fresh explicit
    approval.
 4. After approval, create the signed annotated tag, then verify its signature,
@@ -73,10 +97,16 @@ for the actions after that stop. Merge authority is always separate.
 ## Checkpoint 2: Before Draft Release
 
 1. Create the staging directory, `release-notes.md`, and an expected-asset
-   manifest containing the exact seven filenames.
+   manifest containing exactly the seven payload names above, their seven
+   exact `.asc` names, `SHA256SUMS`, `SHA256SUMS.asc`, and `release-key.asc`.
 2. Cover user-visible changes, downloads, installation, checksum/signature
    verification, Android update identity, unsigned/not-notarized macOS status,
-   and known limitations. Keep operational details out of `CHANGELOG.md`.
+   the CPU-only Flatpak runtime gate, optional accelerator evidence, and known
+   limitations. Tell Linux users that Flatpak support is x86_64 only, the CPU
+   app installs first, and accelerator extensions install only as a complete
+   matching Core/Runtime pair. State that FFmpeg remains host-provided and must
+   be available through the Flatpak runtime/extension paths. Keep operational
+   details out of `CHANGELOG.md`.
 3. Stop with the notes preview and exact
    `gh release create v<version> --draft --verify-tag --notes-file ...`
    command; do not run it.
@@ -92,35 +122,49 @@ for the actions after that stop. Merge authority is always separate.
 3. Record manual launch-smoke evidence for the packaged DMG: OS, command,
    artifact hash, launch without dev server, loopback backend, UI/navigation,
    and visible release identity.
-4. Stop before Android signing/build work. Show the five documented release
+4. Hand off the Linux build to a clean x86_64 tagged checkout with no
+   `TUNEFORGE_GIT_REF`, `--model-bundle`, or profile selectors. The manual
+   command is `pnpm package:linux:flatpak`; it must return the five exact
+   Flatpak payloads named above plus sanitized OS, tool versions, command, tag,
+   commit SHA, refs, sizes, hashes, state, checksum, and CPU smoke evidence.
+5. The Flatpak runtime gate installs the CPU app bundle alone in an isolated
+   environment with no accelerator refs, launches without a dev server, and
+   verifies the loopback backend, UI/navigation, and visible `v<version>`
+   identity. Accelerator-device detection and inference evidence is optional
+   and non-blocking; mark it unverified unless tested. Preserve CPU fallback.
+6. Keep all five Flatpak payloads gated so missing or malformed identity/ref,
+   hash, signature, size, license, or provenance evidence fails verification
+   closed. Stop before Android signing/build work only after the DMG, Linux
+   handoff, and CPU smoke evidence pass. Show the five documented release
    environment variables, `pnpm package:android:release`, unset commands, and
    temporary-key cleanup reminder. Do not execute them.
-5. After the manual Android release build supplies the APK, verify version, ARM64 ABI,
+7. After the manual Android release build supplies the APK, verify version, ARM64 ABI,
    non-debuggable/release state, exactly one signer, certificate continuity
    with the prior release, clean-tag provenance, and isolated emulator/device
    smoke evidence.
 
 ## Checkpoint 4: Before Signing and Upload
 
-1. Stage the verified DMG and APK. Generate `SHA256SUMS` over exactly those two
-   files. Confirm these are the only three pre-signing assets and the manifest
-   names the four manual-step signing assets still required.
+1. Stage the seven verified payloads. Generate a new release `SHA256SUMS` over
+   exactly those seven payloads, sorted by basename. Confirm these are exactly
+   the eight pre-signing files and the expected-asset manifest names all 17
+   final assets. Never copy the ignored Flatpak packaging checksum file.
 2. Stop with exact expected filenames and explicit-fingerprint GPG commands.
-   The manual step signs DMG, APK, and `SHA256SUMS`, then exports
-   `release-key.asc`.
+   The manual step creates eight detached signatures—one for each payload and
+   one for `SHA256SUMS`—then exports `release-key.asc`.
 3. In an isolated temporary GPG home, verify the imported public-key
-   fingerprint, three detached signatures, checksums, APK certificate,
-   filenames, and exact asset set. Fail closed on any mismatch or missing
-   evidence.
-4. Upload exactly seven files to the draft only after separate explicit
+   fingerprint, all eight detached signatures, checksums, APK certificate,
+   exact 17-asset set, and every applicable field in the seven-payload matrix.
+   Fail closed on any mismatch or missing evidence.
+4. Upload exactly 17 files to the draft only after separate explicit
    approval. Do not publish it.
 5. Download all draft assets into a separate verification directory and repeat
-   checksum, signature, APK identity, DMG identity, tag provenance, asset-set,
-   and release-note checks against the frozen release SHA.
+   every applicable matrix field, the exact 17-asset-set check, and release-note
+   checks against the frozen release SHA.
 
 ## Failure Recovery and Closure
 
-- Fail closed for a missing DMG/APK, unexpected asset, dirty or mismatched tag
+- Fail closed for a missing payload, unexpected asset, dirty or mismatched tag
   provenance, wrong Android signer, incomplete package/device smoke evidence,
   bad or missing signature, checksum mismatch, or failed fresh download.
 - Preserve the draft and staging directory while investigating. Replace an
@@ -129,6 +173,6 @@ for the actions after that stop. Merge authority is always separate.
 - A manual step publishes the verified draft. After publication, require separate
   GitHub-write authority before posting release evidence, closing the release
   tracker, or closing the milestone.
-- Final closure verifies published tag, release commit, `main`, seven remote
+- Final closure verifies published tag, release commit, `main`, 17 remote
   assets, checksums, signatures, Android certificate, notes, tracker, and
   milestone. Report any intentionally unverified platform behavior.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ download, installation, verification, signature, and publication instructions.
 
 ## [Unreleased]
 
+## [1.4.0] - 2026-09-01
+
 ### Changed
 
 - Upgraded the desktop backend to Python 3.14 and refreshed its dependency graph.
@@ -156,7 +158,8 @@ download, installation, verification, signature, and publication instructions.
 
 - Development used `0.1.0` metadata; `v1.0.0` was the first tagged release.
 
-[Unreleased]: https://github.com/grazzolini/tuneforge/compare/v1.3.0...main
+[Unreleased]: https://github.com/grazzolini/tuneforge/compare/v1.4.0...main
+[1.4.0]: https://github.com/grazzolini/tuneforge/compare/v1.3.0...v1.4.0
 [1.3.0]: https://github.com/grazzolini/tuneforge/compare/v1.2.0...v1.3.0
 [1.2.0]: https://github.com/grazzolini/tuneforge/compare/v1.1.0...v1.2.0
 [1.1.0]: https://github.com/grazzolini/tuneforge/compare/v1.0.1...v1.1.0

--- a/apps/backend/pyproject.toml
+++ b/apps/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tuneforge-backend"
-version = "1.3.0"
+version = "1.4.0"
 description = "Local API and processing backend for TuneForge."
 readme = "README.md"
 requires-python = ">=3.14,<3.15"

--- a/apps/backend/uv.lock
+++ b/apps/backend/uv.lock
@@ -1412,7 +1412,7 @@ wheels = [
 
 [[package]]
 name = "tuneforge-backend"
-version = "1.3.0"
+version = "1.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tuneforge/desktop",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -7120,7 +7120,7 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tuneforge"
-version = "1.3.0"
+version = "1.4.0"
 dependencies = [
  "android_system_properties",
  "base64 0.23.1",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tuneforge"
-version = "1.3.0"
+version = "1.4.0"
 description = "TuneForge desktop shell"
 edition = "2021"
 license = "MIT"

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "TuneForge",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "identifier": "com.tuneforge.desktop",
   "build": {
     "beforeDevCommand": "pnpm --filter @tuneforge/desktop dev",

--- a/apps/desktop/src/App.project-export.test.tsx
+++ b/apps/desktop/src/App.project-export.test.tsx
@@ -60,8 +60,8 @@ function health(defaultExportFormat: string): HealthResponse {
   return {
     name: "TuneForge",
     version: "backend-test-ref",
-    backend_version: { package_version: "1.3.0", git_ref: "backend-test-ref" },
-    frontend_version: { package_version: "1.3.0", git_ref: "frontend-test-ref" },
+    backend_version: { package_version: "1.4.0", git_ref: "backend-test-ref" },
+    frontend_version: { package_version: "1.4.0", git_ref: "frontend-test-ref" },
     status: "ok",
     api_base_url: "http://127.0.0.1:8765/api/v1",
     data_root: "/tmp/tuneforge",

--- a/apps/desktop/src/test/appTestHarness.tsx
+++ b/apps/desktop/src/test/appTestHarness.tsx
@@ -1444,11 +1444,11 @@ const {
     name: "TuneForge",
     version: "backend-test-ref",
     backend_version: {
-      package_version: "1.3.0",
+      package_version: "1.4.0",
       git_ref: "backend-test-ref",
     },
     frontend_version: {
-      package_version: "1.3.0",
+      package_version: "1.4.0",
       git_ref: "frontend-test-ref",
     },
     status: "ok",

--- a/docs/PACKAGING.md
+++ b/docs/PACKAGING.md
@@ -38,26 +38,54 @@ After the tag checkpoint stop and fresh explicit tag-signing approval, automatio
 annotated `v<version>` tag and must verify its signature, annotation, target, and release commit.
 Require separate draft-release authority before creating a draft GitHub Release for that tag. Build
 each intended artifact from a clean checkout of the tag without a `TUNEFORGE_GIT_REF` override.
-TuneForge's current release contract requires exactly seven uploaded assets:
+From v1.4.0 onward, TuneForge's release contract requires exactly seven payloads:
 
-- Apple Silicon `TuneForge_<version>_aarch64.dmg` and its detached `.asc` signature;
-- publishable ARM64 `TuneForge_<version>_android_aarch64_publishable.apk` and its detached `.asc`
-  signature;
-- `SHA256SUMS`, containing only the DMG and APK, and its detached `.asc` signature;
-- armored public `release-key.asc` matching the signing fingerprint.
+- Apple Silicon `TuneForge_<version>_aarch64.dmg`;
+- publishable ARM64 `TuneForge_<version>_android_aarch64_publishable.apk`;
+- CPU `Tuneforge_<version>_x86_64.flatpak`;
+- `Tuneforge_<version>_Torch_Nvidia_Core_x86_64.flatpak`;
+- `Tuneforge_<version>_Torch_Nvidia_Runtime_x86_64.flatpak`;
+- `Tuneforge_<version>_Torch_LegacyNvidia_Core_x86_64.flatpak`;
+- `Tuneforge_<version>_Torch_LegacyNvidia_Runtime_x86_64.flatpak`.
 
-Both the DMG and publishable APK are mandatory. Manual steps run
-`pnpm package:android:release` with the externally managed release key, create all detached
+Every payload has a detached `.asc` signature. A newly generated release `SHA256SUMS` covers
+exactly those seven payloads sorted by basename; it also has a detached `SHA256SUMS.asc` signature.
+Armored `release-key.asc` matching the signing fingerprint completes the exact 17 uploaded assets.
+Never reuse the ignored `packaging/flatpak/generated/SHA256SUMS` as the release manifest.
+
+Use this seven-payload verification matrix before upload and again after a fresh download:
+every checksum entry must match the payload digest, and every detached `.asc` must verify against
+the approved `release-key.asc` fingerprint.
+
+| Exact payload filename | Provenance | Size | Checksum and signature | License evidence | Architecture / branch | Package or ref identity |
+| --- | --- | --- | --- | --- | --- | --- |
+| `TuneForge_<version>_aarch64.dmg` | Frozen tagged SHA | Recorded, nonzero | Sorted manifest entry + matching `.asc` | Release inventory + notices | `aarch64` / n/a | `TuneForge`, embedded version and git ref |
+| `TuneForge_<version>_android_aarch64_publishable.apk` | Frozen tagged SHA | Recorded, nonzero | Sorted manifest entry + matching `.asc` | Release inventory + notices | `arm64-v8a` / n/a | `com.tuneforge.desktop`, version, release signer |
+| `Tuneforge_<version>_x86_64.flatpak` | Frozen tagged SHA and OSTree commit | Recorded, below 2 GiB | Sorted manifest entry + matching `.asc` | CPU profile inventory + notices | `x86_64` / `stable` | `app/com.tuneforge.desktop/x86_64/stable` |
+| `Tuneforge_<version>_Torch_Nvidia_Core_x86_64.flatpak` | Frozen tagged SHA and OSTree commit | Recorded, below 2 GiB | Sorted manifest entry + matching `.asc` | NVIDIA Core inventory + notices | `x86_64` / `stable` | `runtime/com.tuneforge.desktop.Torch.Stack.Nvidia.Core/x86_64/stable` |
+| `Tuneforge_<version>_Torch_Nvidia_Runtime_x86_64.flatpak` | Frozen tagged SHA and OSTree commit | Recorded, below 2 GiB | Sorted manifest entry + matching `.asc` | NVIDIA Runtime inventory + notices | `x86_64` / `stable` | `runtime/com.tuneforge.desktop.Torch.Stack.Nvidia.Runtime/x86_64/stable` |
+| `Tuneforge_<version>_Torch_LegacyNvidia_Core_x86_64.flatpak` | Frozen tagged SHA and OSTree commit | Recorded, below 2 GiB | Sorted manifest entry + matching `.asc` | LegacyNvidia Core inventory + notices | `x86_64` / `stable` | `runtime/com.tuneforge.desktop.Torch.Stack.LegacyNvidia.Core/x86_64/stable` |
+| `Tuneforge_<version>_Torch_LegacyNvidia_Runtime_x86_64.flatpak` | Frozen tagged SHA and OSTree commit | Recorded, below 2 GiB | Sorted manifest entry + matching `.asc` | LegacyNvidia Runtime inventory + notices | `x86_64` / `stable` | `runtime/com.tuneforge.desktop.Torch.Stack.LegacyNvidia.Runtime/x86_64/stable` |
+
+Public release notes must say that Flatpak support is x86_64 only, the CPU app installs first, and
+an accelerator installs only as a complete matching Core/Runtime pair. FFmpeg remains host-provided
+and must be available through the Flatpak runtime/extension paths; Flatpak never searches host
+`PATH` directly.
+
+All seven payloads are mandatory. Manual steps build the five Flatpaks on Linux, run
+`pnpm package:android:release` with the externally managed release key, create the eight detached
 signatures, export `release-key.asc`, and publish the verified draft. Automation may build the
-unsigned/not-notarized macOS DMG and verify public artifacts. It must never run the Android release
-build or artifact-signing commands. Pushing the verified tag and draft-asset upload each need separate explicit
-authority; final publication remains manual-only. Never move or delete a published tag; roll forward
-with a new version. Operational artifact, installation, checksum, signature, and upload instructions
-belong in the GitHub Release notes.
+unsigned/not-notarized macOS DMG and verify supplied public artifacts. It must never run the Android
+release build, Linux package build, packaged-app launch, or artifact-signing commands. The user owns
+launches and app data. Pushing the verified tag and uploading the 17 draft assets each need separate
+explicit authority; final publication remains manual-only. Never move or delete a published tag;
+roll forward with a new version. Operational artifact, installation, checksum, signature, and
+upload instructions belong in the GitHub Release notes.
 
-Run `pnpm package:mac` only on supported macOS release hosts. Flatpak packaging remains available
-for local or future distribution work on supported Linux hosts, but v1.1.0 neither builds nor uploads
-a Flatpak.
+Run `pnpm package:mac` only on supported macOS release hosts. Build the five Flatpaks from a clean
+x86_64 tagged checkout with no `TUNEFORGE_GIT_REF`, `--model-bundle`, or profile selectors by using
+`pnpm package:linux:flatpak`. The Linux handoff must include sanitized OS and tool versions, command,
+tag, commit SHA, refs, sizes, hashes, state, checksum, and CPU smoke evidence.
 
 Use the artifact-specific checklist for the manual launch smoke.
 
@@ -79,6 +107,18 @@ For the Android APK, install it on an isolated emulator or device and confirm:
 - the UI loads and core navigation is usable;
 - Settings/About release identity is visible.
 
+For the Flatpak runtime gate, create an isolated environment, install only
+`Tuneforge_<version>_x86_64.flatpak`, and confirm no accelerator refs are installed. Then confirm:
+
+- the packaged CPU app launches without a dev server;
+- the bundled FastAPI backend starts and remains bound to `127.0.0.1`;
+- the UI loads, core navigation is usable, and `v<version>` release identity is visible;
+- CPU fallback remains available.
+
+Accelerator-device detection and inference are optional, non-blocking evidence and remain
+unverified unless explicitly tested. All five Flatpak payloads still fail closed on malformed
+identity/ref, hash, signature, size, license, or provenance evidence.
+
 Record release gate evidence with:
 
 - OS and version;
@@ -89,11 +129,18 @@ Record release gate evidence with:
 - launch-smoke checklist source, such as this manual checklist or a named release
   checklist;
 - per-check proof for the applicable platform checklist: macOS packaged launch, bundled FastAPI
-  startup and loopback bind, UI/navigation, and release identity; or Android packaged launch on the
+  startup and loopback bind, UI/navigation, and release identity; Android packaged launch on the
   isolated emulator/device, embedded mobile backend initialization, UI/navigation, and release
-  identity;
+  identity; or isolated CPU-only Flatpak install, absence of accelerator refs, packaged launch,
+  bundled backend loopback bind, UI/navigation, release identity, and CPU fallback;
 - pass/fail result for each package build and launch-smoke check;
 - sanitized notes or log excerpt.
+
+Before upload, stage exactly the seven payloads and a newly generated sorted `SHA256SUMS`, then stop
+for manual creation of eight detached signatures and `release-key.asc`. In an isolated temporary
+GPG home, verify the key fingerprint, exact 17-file set, and every applicable matrix field. After
+separately authorized upload, download all 17 assets into a fresh directory and repeat the complete
+matrix and asset-set verification against the frozen release commit before publication.
 
 Do not collapse launch-smoke evidence to a generic pass. Evidence must avoid user
 paths, audio contents, secrets, and raw private logs. This gate documents package-build

--- a/packages/shared-types/package.json
+++ b/packages/shared-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tuneforge/shared-types",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "private": true,
   "type": "module",
   "exports": {

--- a/packaging/flatpak/com.tuneforge.desktop.metainfo.xml
+++ b/packaging/flatpak/com.tuneforge.desktop.metainfo.xml
@@ -27,6 +27,7 @@
   </categories>
   <content_rating type="oars-1.1" />
   <releases>
+    <release version="1.4.0" date="2026-09-01" />
     <release version="1.3.0" date="2026-08-28" />
     <release version="1.2.0" date="2026-08-24" />
     <release version="1.1.0" date="2026-08-18" />

--- a/scripts/capture-release-media.mjs
+++ b/scripts/capture-release-media.mjs
@@ -1910,11 +1910,11 @@ function healthResponse() {
     name: "TuneForge",
     version: "release-media-fixture",
     backend_version: {
-      package_version: "1.3.0",
+      package_version: "1.4.0",
       git_ref: "release-media-fixture",
     },
     frontend_version: {
-      package_version: "1.3.0",
+      package_version: "1.4.0",
       git_ref: "release-media-fixture",
     },
     status: "ok",


### PR DESCRIPTION
## Summary
- Prepare v1.4.0 release metadata, version fixtures, and generated locks.
- Define the 17-asset release contract with five x86_64 Flatpak payloads.
- Update release coordination and packaging guidance for the manual Linux handoff and CPU-only runtime gate.
- Refs #482.

## Testing
- `pnpm release:check-version`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test` (full retry passed after one non-reproducing backend failure)
- `cd apps/backend && uv run --python 3.14 pytest`
- `cd apps/desktop/src-tauri && cargo check`
- `node scripts/capture-release-media.mjs --run` (generated media inspected; outputs remain uncommitted)
- `node scripts/release-license-inventory.mjs --check` (blocked: Linux Flatpak handoff must generate 16 ignored inventories)
- `git diff --check`
