### PR TITLE
fix: order release gates after tagged builds

### DIFF
--- a/.agents/skills/coordinate-tuneforge-work/SKILL.md
+++ b/.agents/skills/coordinate-tuneforge-work/SKILL.md
@@ -23,6 +23,11 @@ Release preparation adds four narrower stop boundaries. Read
 release-preparation work. Authority for one checkpoint never carries into the
 next checkpoint or authorizes final publication.
 
+Run generated artifact or evidence gates only after the checkpoint that creates
+the tagged artifacts they inspect. Never require build-generated evidence
+before the tag and build identity exist. Those gates still fail closed before
+signing, upload, or publication.
+
 Collaboration mode selection and transitions are user-owned. Never invoke
 `/plan` or `/goal`, change modes, or create or expand a Goal. A Goal is
 optional and does not broaden execution or publication authority.

--- a/.agents/skills/coordinate-tuneforge-work/references/release-prep.md
+++ b/.agents/skills/coordinate-tuneforge-work/references/release-prep.md
@@ -15,10 +15,13 @@ PR and the later tagged-release operations as separate authority scopes.
   lock entries, current version fixtures, and this skill when needed.
 - Regenerate lockfiles with their owning tools. Do not hand-edit generated
   dependency or contract outputs.
-- Require green release-version, license-inventory, lint, typecheck, test,
-  backend, Tauri, and deterministic release-media gates before tagging. Report
-  only checks actually run and preserve generated release media as uncommitted
-  local output.
+- Before tagging, require green release-version, lint, typecheck, test, backend,
+  Tauri, deterministic release-media, and merged-CI gates plus clean current
+  `main`, dated changelog, governed versions, and tag absence. Report only checks
+  actually run and preserve generated release media as uncommitted local output.
+- Build every final payload exactly once from the verified tag. Run generated
+  package and license-evidence gates only after those tagged builds create their
+  inputs, and require them green before signing, upload, or publication.
 
 From v1.4.0 onward, TuneForge releases require exactly seven payloads:
 
@@ -85,7 +88,9 @@ for the actions after that stop. Merge authority is always separate.
    checkout, require a clean worktree, and prove `HEAD == origin/main`.
 2. Freeze the release commit SHA. Verify version sources, dated changelog, tag
    absence, the seven-payload/17-asset contract, and release readiness from
-   that exact commit.
+   that exact commit. Generated package and license inventories are tagged-build
+   outputs, not pre-tag inputs; do not build packages or require those inventories
+   at this checkpoint.
 3. Stop. Show the exact signed annotated-tag command and await fresh explicit
    approval.
 4. After approval, create the signed annotated tag, then verify its signature,
@@ -115,8 +120,10 @@ for the actions after that stop. Merge authority is always separate.
 
 ## Checkpoint 3: Before Android Release APK
 
-1. Require a clean checkout with `HEAD == v<version>^{commit}` and no
-   `TUNEFORGE_GIT_REF` override.
+1. Require each final DMG, five Flatpaks, and APK to be built exactly once from
+   a clean verified-tag checkout with `HEAD == v<version>^{commit}` and no
+   `TUNEFORGE_GIT_REF` override. Perform each build only at its
+   platform-specific or manual step below.
 2. Build and stage the unsigned Apple Silicon DMG. Verify filename, embedded
    package version, and git ref `v<version>-0-g<release-sha8>`.
 3. Record manual launch-smoke evidence for the packaged DMG: OS, command,
@@ -127,28 +134,34 @@ for the actions after that stop. Merge authority is always separate.
    command is `pnpm package:linux:flatpak`; it must return the five exact
    Flatpak payloads named above plus sanitized OS, tool versions, command, tag,
    commit SHA, refs, sizes, hashes, state, checksum, and CPU smoke evidence.
-5. The Flatpak runtime gate installs the CPU app bundle alone in an isolated
+5. After that tagged build creates the ignored profile inventories, run
+   `node scripts/release-license-inventory.mjs --check`. Require exact generated
+   CPU, NVIDIA Core/Runtime, and LegacyNvidia Core/Runtime inventories to pass
+   before progressing to signing or upload.
+6. The Flatpak runtime gate installs the CPU app bundle alone in an isolated
    environment with no accelerator refs, launches without a dev server, and
    verifies the loopback backend, UI/navigation, and visible `v<version>`
    identity. Accelerator-device detection and inference evidence is optional
    and non-blocking; mark it unverified unless tested. Preserve CPU fallback.
-6. Keep all five Flatpak payloads gated so missing or malformed identity/ref,
+7. Keep all five Flatpak payloads gated so missing or malformed identity/ref,
    hash, signature, size, license, or provenance evidence fails verification
    closed. Stop before Android signing/build work only after the DMG, Linux
    handoff, and CPU smoke evidence pass. Show the five documented release
    environment variables, `pnpm package:android:release`, unset commands, and
    temporary-key cleanup reminder. Do not execute them.
-7. After the manual Android release build supplies the APK, verify version, ARM64 ABI,
+8. After the manual Android release build supplies the APK, verify version, ARM64 ABI,
    non-debuggable/release state, exactly one signer, certificate continuity
    with the prior release, clean-tag provenance, and isolated emulator/device
    smoke evidence.
 
 ## Checkpoint 4: Before Signing and Upload
 
-1. Stage the seven verified payloads. Generate a new release `SHA256SUMS` over
-   exactly those seven payloads, sorted by basename. Confirm these are exactly
-   the eight pre-signing files and the expected-asset manifest names all 17
-   final assets. Never copy the ignored Flatpak packaging checksum file.
+1. Require the green tagged-build strict license-inventory result and matrix
+   license evidence, then stage the seven verified payloads. Generate a new
+   release `SHA256SUMS` over exactly those seven payloads, sorted by basename.
+   Confirm these are exactly the eight pre-signing files and the expected-asset
+   manifest names all 17 final assets. Never copy the ignored Flatpak packaging
+   checksum file.
 2. Stop with exact expected filenames and explicit-fingerprint GPG commands.
    The manual step creates eight detached signatures—one for each payload and
    one for `SHA256SUMS`—then exports `release-key.asc`.
@@ -170,6 +183,10 @@ for the actions after that stop. Merge authority is always separate.
 - Preserve the draft and staging directory while investigating. Replace an
   invalid draft asset only with explicit upload authority, then repeat the
   complete fresh-download verification. Never repair a published tag in place.
+- A tagged-build license failure blocks artifacts, signing, upload, and
+  publication; it does not retroactively invalidate tag creation. If correction
+  requires code changes, roll forward to a new version and tag—never move or
+  delete a pushed tag.
 - A manual step publishes the verified draft. After publication, require separate
   GitHub-write authority before posting release evidence, closing the release
   tracker, or closing the milestone.

--- a/docs/PACKAGING.md
+++ b/docs/PACKAGING.md
@@ -27,17 +27,18 @@ Before tagging, verify the release changelog against changes since the previous 
 `[Unreleased]` entries into the dated release section, leave `[Unreleased]` empty, freeze the release
 comparison at `previous-tag...new-tag`, and reset `[Unreleased]` to `new-tag...main`.
 
-Run these checks from the clean final release commit:
+Before tagging, run the version check from the clean final release commit; the normal source gates
+(lint, typecheck, tests, backend, Tauri, deterministic media, and merged CI) must also be green:
 
 ```sh
-node scripts/check-release-version.mjs
-node scripts/release-license-inventory.mjs --check
+pnpm release:check-version
 ```
 
 After the tag checkpoint stop and fresh explicit tag-signing approval, automation may create the signed
 annotated `v<version>` tag and must verify its signature, annotation, target, and release commit.
 Require separate draft-release authority before creating a draft GitHub Release for that tag. Build
-each intended artifact from a clean checkout of the tag without a `TUNEFORGE_GIT_REF` override.
+the DMG, five Flatpaks, and APK exactly once from clean checkouts of the verified tag without a
+`TUNEFORGE_GIT_REF` override. Generated package and license inventories are not pre-tag inputs.
 From v1.4.0 onward, TuneForge's release contract requires exactly seven payloads:
 
 - Apple Silicon `TuneForge_<version>_aarch64.dmg`;
@@ -85,7 +86,12 @@ upload instructions belong in the GitHub Release notes.
 Run `pnpm package:mac` only on supported macOS release hosts. Build the five Flatpaks from a clean
 x86_64 tagged checkout with no `TUNEFORGE_GIT_REF`, `--model-bundle`, or profile selectors by using
 `pnpm package:linux:flatpak`. The Linux handoff must include sanitized OS and tool versions, command,
-tag, commit SHA, refs, sizes, hashes, state, checksum, and CPU smoke evidence.
+tag, commit SHA, refs, sizes, hashes, state, checksum, and CPU smoke evidence. That tagged build
+creates the ignored profile inventories; only then run
+`node scripts/release-license-inventory.mjs --check` and require exact CPU, NVIDIA Core/Runtime, and
+LegacyNvidia Core/Runtime inventory evidence. Failure blocks signing, upload, and publication; it
+does not retroactively block tag creation. If correction needs code changes, roll forward to a new
+version and tag rather than moving or deleting the pushed tag.
 
 Use the artifact-specific checklist for the manual launch smoke.
 


### PR DESCRIPTION
## Summary
- Build every final release payload exactly once from the verified tag.
- Move generated Flatpak license inventory checks after the tagged Linux build.
- Preserve fail-closed signing, upload, publication, and manual-operation boundaries.
- Refs #482.

## Testing
- `pnpm release:check-version`
- `git diff --check`
- Full suite not rerun: release-process documentation and skill instructions only; CI runs `pnpm lint && pnpm typecheck && pnpm test`.
