### PR TITLE
fix: require relocatable Python for macOS packages

### DIFF
--- a/.agents/skills/coordinate-tuneforge-work/references/release-prep.md
+++ b/.agents/skills/coordinate-tuneforge-work/references/release-prep.md
@@ -125,7 +125,8 @@ for the actions after that stop. Merge authority is always separate.
    `TUNEFORGE_GIT_REF` override. Perform each build only at its
    platform-specific or manual step below.
 2. Build and stage the unsigned Apple Silicon DMG. Verify filename, embedded
-   package version, and git ref `v<version>-0-g<release-sha8>`.
+   package version, and git ref `v<version>-0-g<release-sha8>`. Require the
+   configured uv-managed Python runtime and a passing bundle-local staged-runtime probe.
 3. Record manual launch-smoke evidence for the packaged DMG: OS, command,
    artifact hash, launch without dev server, loopback backend, UI/navigation,
    and visible release identity.

--- a/docs/PACKAGING.md
+++ b/docs/PACKAGING.md
@@ -161,6 +161,11 @@ Build the app bundle and DMG with:
 pnpm package:mac
 ```
 
+macOS packaging requires uv-managed Python matching the repository's backend packaging
+configuration. Bundle preparation rejects non-relocatable system or Homebrew layouts, then starts
+the staged interpreter with the launcher's `PYTHONHOME`, `PYTHONPATH`, and library path to prove all
+Python runtime paths remain bundle-local.
+
 Plain macOS packages include ONNX Advanced Chords, beat-this Advanced Beat Analysis, and LV
 Chordia dependencies by default. Package flags independently opt out or opt into explicit model
 bundling:

--- a/scripts/package-options.mjs
+++ b/scripts/package-options.mjs
@@ -156,7 +156,7 @@ export function packageOptionsToGeneratorArgs(options) {
 
 export function backendSyncArgs(options) {
   const validated = validatePackageOptions(options);
-  const args = ["sync", "--python", "3.14", "--all-groups"];
+  const args = ["sync", "--managed-python", "--python", "3.14.7", "--all-groups"];
   if (validated.crema === "onnx") {
     args.push("--extra", "advanced-chords");
   }

--- a/scripts/package-options.test.mjs
+++ b/scripts/package-options.test.mjs
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -32,6 +32,7 @@ import {
 } from "./release-license-inventory.mjs";
 import {
   assertCremaOnnxBundleLayout,
+  assertBundledPythonLayout,
   assertLvChordiaBundleLayout,
   CREMA_ONNX_BUNDLE_RELATIVE_PATHS,
   DEMUCS_MANIFEST_BACKEND_RELATIVE_PATH,
@@ -187,8 +188,9 @@ test("package option parser includes advanced dependencies by default", () => {
   ]);
   assert.deepEqual(backendSyncArgs(options), [
     "sync",
+    "--managed-python",
     "--python",
-    "3.14",
+    "3.14.7",
     "--all-groups",
     "--extra",
     "advanced-chords",
@@ -218,7 +220,9 @@ test("package option parser accepts advanced dependency opt-outs", () => {
   assert.deepEqual(packageOptionsToGeneratorArgs(options), [
     "--no-crema", "--no-beat-this", "--no-lv-chordia", "--cpu", "--nvidia", "--legacy-nvidia",
   ]);
-  assert.deepEqual(backendSyncArgs(options), ["sync", "--python", "3.14", "--all-groups"]);
+  assert.deepEqual(backendSyncArgs(options), [
+    "sync", "--managed-python", "--python", "3.14.7", "--all-groups",
+  ]);
 });
 
 test("Advanced Chords aliases select one ONNX profile and reject enable-disable conflicts", () => {
@@ -232,7 +236,7 @@ test("Advanced Chords aliases select one ONNX profile and reject enable-disable 
   assert.deepEqual(packageOptionsToGeneratorArgs(options), [
     "--crema", "--beat-this", "--lv-chordia", "--cpu", "--nvidia", "--legacy-nvidia",
   ]);
-  assert.deepEqual(backendSyncArgs(options).slice(4, 6), ["--extra", "advanced-chords"]);
+  assert.deepEqual(backendSyncArgs(options).slice(5, 7), ["--extra", "advanced-chords"]);
   assert.throws(
     () => parsePackageOptions(["--crema", "--no-advanced-chords-onnx"], { platform: "mac" }),
     /Conflicting Advanced Chords selectors/,
@@ -362,6 +366,39 @@ test("macOS staged bundle has exactly one LV Chordia checkpoint set or none when
     rmSync(fixture, { recursive: true, force: true });
     mkdirSync(fixture, { recursive: true });
     assert.doesNotThrow(() => assertLvChordiaBundleLayout(fixture, false));
+  } finally {
+    rmSync(fixture, { recursive: true, force: true });
+  }
+});
+
+test("macOS bundled Python layout requires a local interpreter and standard library", () => {
+  const fixture = mkdtempSync(path.join(tmpdir(), "tuneforge-python-layout-"));
+  try {
+    const interpreter = path.join(fixture, "bin", "python3.14");
+    mkdirSync(path.dirname(interpreter), { recursive: true });
+    writeFileSync(interpreter, "fixture");
+    const encodings = path.join(fixture, "lib", "python3.14", "encodings");
+    mkdirSync(encodings, { recursive: true });
+    assert.doesNotThrow(() => assertBundledPythonLayout(fixture));
+
+    rmSync(encodings, { recursive: true });
+    assert.throws(() => assertBundledPythonLayout(fixture), /standard library encodings not found/);
+  } finally {
+    rmSync(fixture, { recursive: true, force: true });
+  }
+});
+
+test("macOS bundled Python layout rejects an interpreter symlink escaping its root", () => {
+  const fixture = mkdtempSync(path.join(tmpdir(), "tuneforge-python-symlink-"));
+  try {
+    const runtime = path.join(fixture, "runtime");
+    const interpreter = path.join(runtime, "bin", "python3.14");
+    mkdirSync(path.dirname(interpreter), { recursive: true });
+    const outside = path.join(fixture, "outside-python");
+    writeFileSync(outside, "fixture");
+    symlinkSync(path.relative(path.dirname(interpreter), outside), interpreter);
+    mkdirSync(path.join(runtime, "lib", "python3.14", "encodings"), { recursive: true });
+    assert.throws(() => assertBundledPythonLayout(runtime), /resolves outside its runtime root/);
   } finally {
     rmSync(fixture, { recursive: true, force: true });
   }
@@ -808,8 +845,9 @@ test("sandbox data is Flatpak-only and does not affect dependency generation bey
   ]);
   assert.deepEqual(backendSyncArgs(options), [
     "sync",
+    "--managed-python",
     "--python",
-    "3.14",
+    "3.14.7",
     "--all-groups",
     "--extra",
     "advanced-chords",

--- a/scripts/prepare-bundle.mjs
+++ b/scripts/prepare-bundle.mjs
@@ -1,7 +1,10 @@
 import {
   cpSync,
   existsSync,
+  lstatSync,
   readFileSync,
+  readlinkSync,
+  realpathSync,
   mkdirSync,
   readdirSync,
   rmSync,
@@ -51,6 +54,30 @@ export const LV_CHORDIA_CHECKPOINT_NAMES = [
 function requirePath(targetPath, description) {
   if (!existsSync(targetPath)) {
     throw new Error(`${description} not found at ${targetPath}`);
+  }
+}
+
+function isWithinRoot(root, candidate) {
+  const relative = path.relative(root, candidate);
+  return relative !== ".." && !relative.startsWith(`..${path.sep}`) && !path.isAbsolute(relative);
+}
+
+export function assertBundledPythonLayout(root) {
+  requirePath(root, "Bundled Python runtime");
+  const resolvedRoot = realpathSync(root);
+  const interpreter = path.join(root, "bin", "python3.14");
+  requirePath(interpreter, "Bundled Python interpreter");
+  if (lstatSync(interpreter).isSymbolicLink() && path.isAbsolute(readlinkSync(interpreter))) {
+    throw new Error(`Bundled Python interpreter symlink must be relative: ${interpreter}`);
+  }
+  if (!isWithinRoot(resolvedRoot, realpathSync(interpreter))) {
+    throw new Error(`Bundled Python interpreter resolves outside its runtime root: ${interpreter}`);
+  }
+
+  const encodings = path.join(root, "lib", "python3.14", "encodings");
+  requirePath(encodings, "Bundled Python standard library encodings");
+  if (!isWithinRoot(resolvedRoot, realpathSync(encodings))) {
+    throw new Error(`Bundled Python standard library resolves outside its runtime root: ${encodings}`);
   }
 }
 
@@ -233,22 +260,42 @@ function stageLvChordiaAssets(options) {
     copyInto(sourceLvChordiaRoot, stagedLvChordiaRoot);
   }
   assertLvChordiaBundleLayout(stagedBackendRoot, options.lvChordia);
-  if (!options.lvChordia) {
-    return;
-  }
+}
+
+function verifyStagedPython(options) {
   const stagedPython = path.join(stagedPythonRoot, "bin", "python3.14");
+  const libraryPaths = [
+    path.join(stagedPythonRoot, "lib"),
+    ...(process.env.LD_LIBRARY_PATH?.split(path.delimiter) ?? []),
+  ];
   run(
     stagedPython,
     [
       "-c",
-      "from app.engines.lv_chordia import lv_chordia_dependency_status; " +
-        "available, reason = lv_chordia_dependency_status(); assert available, reason",
+      [
+        "import encodings, os, sys",
+        "from pathlib import Path",
+        "root = Path(os.environ['PYTHONHOME']).resolve()",
+        "def require_inside(value, label):",
+        "    resolved = Path(value).resolve()",
+        "    assert resolved.is_relative_to(root), f'{label} escapes bundled Python root: {resolved}'",
+        "require_inside(sys.prefix, 'sys.prefix')",
+        "require_inside(sys.base_prefix, 'sys.base_prefix')",
+        "require_inside(sys.executable, 'sys.executable')",
+        "require_inside(encodings.__file__, 'encodings')",
+        ...(options.lvChordia ? [
+          "from app.engines.lv_chordia import lv_chordia_dependency_status",
+          "available, reason = lv_chordia_dependency_status()",
+          "assert available, reason",
+        ] : []),
+      ].join("\n"),
     ],
     {
       cwd: stagedBackendSourceRoot,
       env: {
-        DYLD_LIBRARY_PATH: path.join(stagedPythonRoot, "lib"),
-        PYTHONPATH: `${stagedBackendSourceRoot}${path.delimiter}${stagedSitePackagesRoot}`,
+        LD_LIBRARY_PATH: [...new Set(libraryPaths)].join(path.delimiter),
+        PYTHONHOME: stagedPythonRoot,
+        PYTHONPATH: `${stagedSitePackagesRoot}${path.delimiter}${stagedBackendSourceRoot}`,
       },
     },
   );
@@ -267,6 +314,7 @@ async function main() {
   const pythonHomeBin = parsePythonHome(venvConfigPath);
   const pythonInstallRoot = path.resolve(pythonHomeBin, "..");
   requirePath(pythonInstallRoot, "Bundled Python runtime source");
+  assertBundledPythonLayout(pythonInstallRoot);
 
   rmSync(resourcesRoot, { recursive: true, force: true });
   mkdirSync(resourcesRoot, { recursive: true });
@@ -280,8 +328,10 @@ async function main() {
   mkdirSync(path.join(stagedBackendRoot, "licenses"), { recursive: true });
   copyInto(cremaLicensePath, path.join(stagedBackendRoot, "licenses", path.basename(cremaLicensePath)));
   copyInto(pythonInstallRoot, stagedPythonRoot, { dereference: true });
+  assertBundledPythonLayout(stagedPythonRoot);
   copyInto(sitePackagesRoot, stagedSitePackagesRoot, { filter: shouldIncludeBundledSitePackage });
   stageLvChordiaAssets(packageOptions);
+  verifyStagedPython(packageOptions);
   prepareModelBundle(packageOptions);
   assertCremaOnnxBundleLayout(
     stagedBackendRoot,


### PR DESCRIPTION
## Summary

- require macOS packaging to use the configured uv-managed Python runtime
- reject non-relocatable Python layouts and validate the staged launcher environment
- add runtime-layout fixtures and document the macOS packaging gate
- Closes #519
- Refs #482

## Testing

- `node --test scripts/package-options.test.mjs`
- `pnpm release:check-version`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm package:mac:app`
- `git diff --check`
- user-confirmed macOS package build
