### PR TITLE
fix(desktop): prevent sync evidence export hangs

### DIFF
--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -78,19 +78,31 @@ fn write_settings_snapshot_file(
 }
 
 #[tauri::command]
-fn write_sync_evidence_file(
+async fn write_sync_evidence_file(
     app: AppHandle,
     default_file_name: String,
     contents: String,
 ) -> Result<bool, String> {
-    file_dialog_scope::write_user_selected_json_file(
-        &app,
-        "Export Sync Evidence",
-        default_file_name,
-        "tuneforge-sync-evidence.json",
-        contents,
-        "sync evidence",
-    )
+    dispatch_sync_evidence_write(move || {
+        file_dialog_scope::write_user_selected_json_file(
+            &app,
+            "Export Sync Evidence",
+            default_file_name,
+            "tuneforge-sync-evidence.json",
+            contents,
+            "sync evidence",
+        )
+    })
+    .await
+}
+
+async fn dispatch_sync_evidence_write<F>(write: F) -> Result<bool, String>
+where
+    F: FnOnce() -> Result<bool, String> + Send + 'static,
+{
+    tauri::async_runtime::spawn_blocking(write)
+        .await
+        .map_err(|_| "Sync evidence export worker stopped unexpectedly.".to_string())?
 }
 
 #[cfg(not(target_os = "android"))]
@@ -637,6 +649,42 @@ pub fn run() {
 #[cfg(all(test, not(target_os = "android")))]
 mod tests {
     use super::*;
+
+    #[test]
+    fn sync_evidence_write_dispatches_off_caller_thread_and_maps_results_safely() {
+        let caller_thread = std::thread::current().id();
+        let observed_thread = std::sync::Arc::new(Mutex::new(None));
+        let observed_thread_for_write = observed_thread.clone();
+
+        let exported = tauri::async_runtime::block_on(dispatch_sync_evidence_write(move || {
+            *observed_thread_for_write.lock().expect("observed thread") =
+                Some(std::thread::current().id());
+            Ok(true)
+        }))
+        .expect("export dispatch");
+        assert!(exported);
+        assert_ne!(
+            observed_thread.lock().expect("observed thread").as_ref(),
+            Some(&caller_thread)
+        );
+
+        let cancelled = tauri::async_runtime::block_on(dispatch_sync_evidence_write(|| Ok(false)))
+            .expect("cancel dispatch");
+        assert!(!cancelled);
+
+        let write_error = tauri::async_runtime::block_on(dispatch_sync_evidence_write(|| {
+            Err("bounded write error".to_string())
+        }));
+        assert_eq!(write_error, Err("bounded write error".to_string()));
+
+        let join_error = tauri::async_runtime::block_on(dispatch_sync_evidence_write(
+            || -> Result<bool, String> { panic!("private worker panic details") },
+        ));
+        assert_eq!(
+            join_error,
+            Err("Sync evidence export worker stopped unexpectedly.".to_string())
+        );
+    }
 
     #[test]
     fn append_unique_paths_preserves_order_without_duplicates() {

--- a/apps/desktop/src/App.activity.test.tsx
+++ b/apps/desktop/src/App.activity.test.tsx
@@ -4358,6 +4358,53 @@ describe("Desktop app activity", () => {
     expect(exportButton).toBeEnabled();
   });
 
+  it("shows truthful pending state and blocks duplicate native exports", async () => {
+    const user = userEvent.setup();
+    Object.defineProperty(window, "__TAURI_INTERNALS__", {
+      configurable: true,
+      value: {},
+    });
+    const mockInvoke = getMockInvoke();
+    const defaultInvoke = mockInvoke.getMockImplementation();
+    if (!defaultInvoke) {
+      throw new Error("Mock invoke implementation was not installed.");
+    }
+    let resolveExport: ((saved: boolean) => void) | undefined;
+    const pendingExport = new Promise<boolean>((resolve) => {
+      resolveExport = resolve;
+    });
+    mockInvoke.mockImplementation(async (command: string, args?: Record<string, unknown>) => {
+      if (command === "write_sync_evidence_file") {
+        return pendingExport;
+      }
+      return defaultInvoke(command, args);
+    });
+    setEvidenceSyncResult("native_export_pending");
+
+    try {
+      await openSyncTab(user);
+      const exportButton = screen.getByRole("button", { name: "Export Evidence" });
+      fireEvent.click(exportButton);
+      fireEvent.click(exportButton);
+
+      await waitFor(() => expect(
+        mockInvoke.mock.calls.filter(([command]) => command === "write_sync_evidence_file"),
+      ).toHaveLength(1));
+      const pendingExportButton = screen.getByRole("button", { name: "Exporting…" });
+      expect(pendingExportButton).toBeDisabled();
+      expect(screen.getByRole("button", { name: "Copy Evidence" })).toBeDisabled();
+      expect(screen.getByRole("status")).toHaveTextContent("Exporting sync evidence…");
+      expect(mockClipboardWriteText).not.toHaveBeenCalled();
+
+      await act(async () => resolveExport?.(true));
+      expect(await screen.findByText("Sync evidence exported and copied.")).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "Export Evidence" })).toBeEnabled();
+      expect(screen.queryByText("Exporting sync evidence…")).not.toBeInTheDocument();
+    } finally {
+      mockInvoke.mockImplementation(defaultInvoke);
+    }
+  });
+
   it("exports evidence through the Tauri save command when available", async () => {
     const user = userEvent.setup();
     const browserWriteText = vi.fn().mockResolvedValue(undefined);
@@ -4479,6 +4526,8 @@ describe("Desktop app activity", () => {
       expect(mockClipboardWriteText).not.toHaveBeenCalled();
       expect(screen.queryByText(/Sync evidence exported/)).not.toBeInTheDocument();
       expect(screen.queryByText(/Could not export sync evidence/)).not.toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "Copy Evidence" })).toBeEnabled();
+      expect(screen.getByRole("button", { name: "Export Evidence" })).toBeEnabled();
     } finally {
       mockInvoke.mockImplementation(defaultInvoke);
     }
@@ -4495,9 +4544,14 @@ describe("Desktop app activity", () => {
     if (!defaultInvoke) {
       throw new Error("Mock invoke implementation was not installed.");
     }
+    let writeAttempts = 0;
     mockInvoke.mockImplementation(async (command: string, args?: Record<string, unknown>) => {
       if (command === "write_sync_evidence_file") {
-        throw new Error("Could not write sync evidence file: /Users/test/private/sync.json");
+        writeAttempts += 1;
+        if (writeAttempts === 1) {
+          throw new Error("Could not write sync evidence file: /Users/test/private/sync.json");
+        }
+        return true;
       }
       return defaultInvoke(command, args);
     });
@@ -4529,6 +4583,11 @@ describe("Desktop app activity", () => {
       expect(screen.queryByText(/\/Users\/test\/private/)).not.toBeInTheDocument();
       expect(screen.queryByText(/Sync evidence exported/)).not.toBeInTheDocument();
       expect(mockClipboardWriteText).not.toHaveBeenCalled();
+
+      await user.click(screen.getByRole("button", { name: "Export Evidence" }));
+      expect(await screen.findByText("Sync evidence exported and copied.")).toBeInTheDocument();
+      expect(writeAttempts).toBe(2);
+      expect(mockClipboardWriteText).toHaveBeenCalledOnce();
     } finally {
       mockInvoke.mockImplementation(defaultInvoke);
     }

--- a/apps/desktop/src/features/activity/ActivitySyncPanel.tsx
+++ b/apps/desktop/src/features/activity/ActivitySyncPanel.tsx
@@ -2131,7 +2131,7 @@ export function ActivitySyncPanel() {
   const [syncNowPolling, setSyncNowPolling] = useState(false);
   const [evidenceMessage, setEvidenceMessage] = useState<string | null>(null);
   const [evidenceError, setEvidenceError] = useState<string | null>(null);
-	const [evidenceActionPending, setEvidenceActionPending] = useState(false);
+	const [evidenceActionPending, setEvidenceActionPending] = useState<"copy" | "export" | null>(null);
 	useSyncExternalStore(
 	  subscribePowerInhibition,
 	  getPowerInhibitionVersion,
@@ -2725,7 +2725,7 @@ export function ActivitySyncPanel() {
       return;
     }
     evidenceActionPendingRef.current = true;
-    setEvidenceActionPending(true);
+    setEvidenceActionPending("copy");
     setEvidenceError(null);
     setEvidenceMessage(null);
     const evidence = buildCurrentSyncEvidenceFile();
@@ -2744,7 +2744,7 @@ export function ActivitySyncPanel() {
       setEvidenceError("Could not copy sync evidence. Try again.");
     } finally {
       evidenceActionPendingRef.current = false;
-      setEvidenceActionPending(false);
+      setEvidenceActionPending(null);
     }
   }
 
@@ -2753,7 +2753,7 @@ export function ActivitySyncPanel() {
       return;
     }
     evidenceActionPendingRef.current = true;
-    setEvidenceActionPending(true);
+    setEvidenceActionPending("export");
     setEvidenceError(null);
     setEvidenceMessage(null);
     const evidence = buildCurrentSyncEvidenceFile();
@@ -2791,7 +2791,7 @@ export function ActivitySyncPanel() {
       setEvidenceError("Could not export sync evidence. Choose another location and try again.");
     } finally {
       evidenceActionPendingRef.current = false;
-      setEvidenceActionPending(false);
+      setEvidenceActionPending(null);
     }
   }
 
@@ -2890,7 +2890,7 @@ export function ActivitySyncPanel() {
               ) : null}
               <button
                 className="button button--ghost button--small"
-                disabled={!visibleSyncResult || evidenceActionPending}
+                disabled={!visibleSyncResult || evidenceActionPending !== null}
                 onClick={handleCopySyncEvidence}
                 type="button"
               >
@@ -2898,11 +2898,11 @@ export function ActivitySyncPanel() {
               </button>
               <button
                 className="button button--ghost button--small"
-                disabled={!visibleSyncResult || evidenceActionPending}
+                disabled={!visibleSyncResult || evidenceActionPending !== null}
                 onClick={handleExportSyncEvidence}
                 type="button"
               >
-                Export Evidence
+                {evidenceActionPending === "export" ? "Exporting…" : "Export Evidence"}
               </button>
             </div>
           </div>
@@ -2983,6 +2983,11 @@ export function ActivitySyncPanel() {
           {lastSyncMessage ? (
             <p className="activity-sync-alert" role="status">
               {lastSyncMessage}
+            </p>
+          ) : null}
+          {evidenceActionPending === "export" ? (
+            <p className="activity-sync-alert" role="status">
+              Exporting sync evidence…
             </p>
           ) : null}
           {evidenceMessage ? (


### PR DESCRIPTION
## Summary

- Offload native sync-evidence save dialogs from the Tauri runtime.
- Show export-only pending state while preserving Copy Evidence, quiet cancellation, redacted errors, and retry behavior.
- Closes #506.

## Testing

- `pnpm --filter @tuneforge/desktop lint` — passed.
- `pnpm --filter @tuneforge/desktop typecheck` — passed.
- `pnpm --filter @tuneforge/desktop exec vitest run src/App.activity.test.tsx` — 125 passed.
- `pnpm --filter @tuneforge/desktop test --run` — 827 passed.
- `cargo fmt --manifest-path apps/desktop/src-tauri/Cargo.toml --check` — passed.
- `cargo check --manifest-path apps/desktop/src-tauri/Cargo.toml` — passed.
- `cargo test --manifest-path apps/desktop/src-tauri/Cargo.toml` — 375 passed.
- Native macOS/Linux dialog QA not run because an isolated Tauri/WebView environment was unavailable.
