### PR TITLE
feat(audio): move project cues to native timeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,17 @@ download, installation, verification, signature, and publication instructions.
 
 ## [Unreleased]
 
+### Added
+
+- Moved project count-ins and playback-following metronome cues onto the native audio timeline,
+  with timing-grid-aware spacing and the same short triangle click on native and Web Audio paths.
+
 ### Fixed
 
 - Reduced Android sync reconciliation memory use for libraries with many pending projects.
+- Preserved project playback position across native output changes, rejected stale transport
+  completions, cancelled pending native and Web starts, kept native loop restarts reliable, and
+  rescheduled playback-following metronome cues after tempo changes.
 
 ## [1.4.0] - 2026-09-01
 

--- a/apps/desktop/src-tauri/src/native_audio/mod.rs
+++ b/apps/desktop/src-tauri/src/native_audio/mod.rs
@@ -317,13 +317,35 @@ pub fn audio_play(
     );
     engine.transport.set_diagnostics_generation(generation);
     let position = payload.start_time_seconds;
-    let start_at = payload.start_at_native_us;
+    let metronome_cues = payload.metronome_cues.clone();
+    let precount = payload
+        .precount
+        .as_ref()
+        .map(|value| value.intervals_seconds.clone());
+    if precount.as_ref().is_some_and(|intervals| {
+        intervals.is_empty()
+            || intervals.len() > 8
+            || intervals
+                .iter()
+                .any(|value| !value.is_finite() || *value <= 0.0)
+    }) || (precount.is_some() && payload.start_at_native_us.is_some())
+    {
+        return Err("invalid_precount_schedule".to_string());
+    }
+    let requested_start = payload.start_at_native_us;
     let expected = payload
         .control
         .timeline_revision
         .unwrap_or_else(|| engine.session.snapshot().timeline_revision);
-    if start_at.is_some_and(|deadline| deadline <= timeline::native_time_us()) {
+    if requested_start.is_some_and(|deadline| deadline <= timeline::native_time_us()) {
         return Err("start_deadline_missed".to_string());
+    }
+    if metronome_cues.as_ref().is_some_and(|cues| {
+        cues.iter()
+            .any(|cue| cue.kind != timeline::CueKind::Metronome)
+            || timeline::validate_cues(cues).is_err()
+    }) {
+        return Err("invalid_cue_schedule".to_string());
     }
     if let Err(error) = engine.transport.play(payload) {
         if let Some(event) = engine
@@ -335,14 +357,33 @@ pub fn audio_play(
         return Err(error);
     }
     let timeline = engine.session.timeline();
-    let armed = timeline
-        .lock()
-        .map_err(|_| "timeline_unavailable".to_string())?
-        .arm(expected, position, start_at, timeline::native_time_us());
-    if let Err(code) = armed {
+    let now = timeline::native_time_us();
+    let first_precount = precount.as_ref().map(|_| now.saturating_add(35_000));
+    let source_start = precount
+        .as_ref()
+        .zip(first_precount)
+        .map(|(intervals, first)| {
+            intervals.iter().fold(first, |time, interval| {
+                time.saturating_add((interval * 1_000_000.0) as u64)
+            })
+        })
+        .or(requested_start);
+    let mut timeline = timeline.lock().map_err(|_| "timeline_unavailable")?;
+    if let Err(code) = timeline.arm(expected, position, source_start, now) {
+        drop(timeline);
         engine.transport.pause();
         return Err(code.to_string());
     }
+    let revision = timeline.revision();
+    if let Some(cues) = metronome_cues {
+        timeline.replace_metronome(revision, cues)?;
+    }
+    if let (Some(intervals), Some(first)) = (precount.as_ref(), first_precount) {
+        timeline
+            .schedule_precount(revision, intervals, first)
+            .map_err(str::to_string)?;
+    }
+    drop(timeline);
     engine.emit_session(&app);
     Ok(engine.output_snapshot())
 }
@@ -627,7 +668,14 @@ pub fn audio_schedule_cues(
     payload: session::CueCommand,
 ) -> Result<session::SessionSnapshot, String> {
     let mut engine = state.engine()?;
-    engine.authorize(session::SessionOwner::Cue, &payload.session, false)?;
+    let owner = engine
+        .session
+        .snapshot()
+        .owner
+        .unwrap_or(session::SessionOwner::Cue);
+    if !engine.authorize(owner, &payload.session, false)? {
+        return Ok(engine.session.snapshot());
+    }
     let revision = payload
         .session
         .timeline_revision
@@ -648,10 +696,18 @@ pub fn audio_cancel_cues(
     app: AppHandle,
     state: State<'_, NativeAudioState>,
     payload: Option<session::SessionCommand>,
+    kind: Option<timeline::CueKind>,
 ) -> Result<session::SessionSnapshot, String> {
     let mut engine = state.engine()?;
     let payload = payload.unwrap_or_default();
-    engine.authorize(session::SessionOwner::Cue, &payload, false)?;
+    let owner = engine
+        .session
+        .snapshot()
+        .owner
+        .unwrap_or(session::SessionOwner::Cue);
+    if !engine.authorize(owner, &payload, false)? {
+        return Ok(engine.session.snapshot());
+    }
     let revision = payload
         .timeline_revision
         .unwrap_or_else(|| engine.session.snapshot().timeline_revision);
@@ -660,7 +716,7 @@ pub fn audio_cancel_cues(
         .timeline()
         .lock()
         .map_err(|_| "timeline_unavailable")?
-        .cancel(revision)
+        .cancel(revision, kind)
         .map_err(str::to_string)?;
     engine.emit_session(&app);
     Ok(engine.session.snapshot())
@@ -669,6 +725,86 @@ pub fn audio_cancel_cues(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn duplicate_cue_operations_do_not_mutate_the_timeline() {
+        let mut coordinator = session::SessionCoordinator::new(true, true);
+        let prepare = session::SessionCommand {
+            lease_id: Some("project-playback".into()),
+            operation_id: Some("prepare".into()),
+            ..Default::default()
+        };
+        let session::Acquire::Release { token, lease, .. } =
+            coordinator.begin_acquire(session::SessionOwner::Playback, &prepare)
+        else {
+            panic!()
+        };
+        coordinator
+            .finish_acquire(
+                token,
+                session::SessionOwner::Playback,
+                lease,
+                &prepare,
+                10.0,
+                1.0,
+            )
+            .unwrap();
+        let command = |operation: &str| session::SessionCommand {
+            lease_id: Some("project-playback".into()),
+            generation: Some(1),
+            timeline_revision: Some(1),
+            operation_id: Some(operation.into()),
+        };
+        let cue = timeline::CueRequest {
+            cue_index: 1,
+            position_seconds: 0.001,
+            kind: timeline::CueKind::Metronome,
+            accent: false,
+            gain: 1.0,
+        };
+        assert!(coordinator
+            .authorize(session::SessionOwner::Playback, &command("schedule"), false)
+            .unwrap());
+        coordinator
+            .timeline()
+            .lock()
+            .unwrap()
+            .schedule(1, vec![cue.clone()])
+            .unwrap();
+        assert!(!coordinator
+            .authorize(session::SessionOwner::Playback, &command("schedule"), false)
+            .unwrap());
+        assert!(coordinator
+            .authorize(session::SessionOwner::Playback, &command("cancel"), false)
+            .unwrap());
+        coordinator
+            .timeline()
+            .lock()
+            .unwrap()
+            .cancel(1, None)
+            .unwrap();
+        assert!(coordinator
+            .authorize(
+                session::SessionOwner::Playback,
+                &command("reschedule"),
+                false
+            )
+            .unwrap());
+        coordinator
+            .timeline()
+            .lock()
+            .unwrap()
+            .schedule(1, vec![cue])
+            .unwrap();
+        assert!(!coordinator
+            .authorize(session::SessionOwner::Playback, &command("cancel"), false)
+            .unwrap());
+        let timeline = coordinator.timeline();
+        let mut timeline = timeline.lock().unwrap();
+        timeline.configure_sample_rate(1_000);
+        timeline.arm(1, None, None, 0).unwrap();
+        assert_eq!(timeline.advance(2, 0).cues.len(), 1);
+    }
 
     #[test]
     fn runtime_terminal_report_bridges_before_one_explicit_retry() {

--- a/apps/desktop/src-tauri/src/native_audio/timeline.rs
+++ b/apps/desktop/src-tauri/src/native_audio/timeline.rs
@@ -12,11 +12,27 @@ pub fn native_time_us() -> u64 {
         .min(u128::from(u64::MAX)) as u64
 }
 
-#[derive(Clone, Deserialize)]
+#[derive(Clone, Copy, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CueKind {
+    #[default]
+    Marker,
+    PrecountBeat,
+    PrecountCompletion,
+    Metronome,
+}
+
+#[derive(Clone, Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CueRequest {
     pub cue_index: u32,
     pub position_seconds: f64,
+    #[serde(default)]
+    pub kind: CueKind,
+    #[serde(default)]
+    pub accent: bool,
+    #[serde(default = "default_cue_gain")]
+    pub gain: f32,
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize)]
@@ -25,6 +41,9 @@ pub struct CueEvent {
     pub generation: u64,
     pub revision: u64,
     pub cue_index: u32,
+    pub kind: CueKind,
+    pub accent: bool,
+    pub gain: f32,
     pub scheduled_native_time_us: u64,
     pub actual_native_time_us: u64,
     pub insertion_sequence: u64,
@@ -34,10 +53,19 @@ struct Cue {
     index: u32,
     position: f64,
     sequence: u64,
+    kind: CueKind,
+    accent: bool,
+    gain: f32,
+    native_time: Option<u64>,
+}
+
+pub struct FiredCue {
+    pub event: CueEvent,
+    pub frame_offset: usize,
 }
 
 pub struct Advance {
-    pub cues: Vec<CueEvent>,
+    pub cues: Vec<FiredCue>,
     pub ended: bool,
     pub start_offset: usize,
 }
@@ -151,10 +179,15 @@ impl Timeline {
 
     pub fn set_rate(&mut self, expected_revision: u64, rate: f64) -> Result<(), &'static str> {
         self.require_revision(expected_revision)?;
-        self.rate = normalize_rate(rate);
+        let rate = normalize_rate(rate);
+        if rate == self.rate {
+            return Ok(());
+        }
+        self.rate = rate;
         self.revision = self.revision.wrapping_add(1).max(1);
         self.anchor_time = None;
         self.anchor_position = self.position;
+        self.cues.retain(|cue| cue.native_time.is_some());
         Ok(())
     }
 
@@ -164,12 +197,40 @@ impl Timeline {
         requests: Vec<CueRequest>,
     ) -> Result<(), &'static str> {
         self.require_revision(expected_revision)?;
+        validate_cues(&requests)?;
+        if requests.iter().any(|cue| cue.kind == CueKind::Metronome) {
+            self.cues.retain(|cue| cue.kind != CueKind::Metronome);
+        }
+        self.insert_cues(requests);
+        Ok(())
+    }
+
+    pub fn replace_metronome(
+        &mut self,
+        expected_revision: u64,
+        requests: Vec<CueRequest>,
+    ) -> Result<(), &'static str> {
+        self.require_revision(expected_revision)?;
+        validate_cues(&requests)?;
+        if requests.iter().any(|cue| cue.kind != CueKind::Metronome) {
+            return Err("invalid_cue_schedule");
+        }
+        self.cues.retain(|cue| cue.kind != CueKind::Metronome);
+        self.insert_cues(requests);
+        Ok(())
+    }
+
+    fn insert_cues(&mut self, requests: Vec<CueRequest>) {
         for request in requests {
             self.next_sequence = self.next_sequence.wrapping_add(1);
             self.cues.push(Cue {
                 index: request.cue_index,
                 position: self.clamp(request.position_seconds),
                 sequence: self.next_sequence,
+                kind: request.kind,
+                accent: request.accent,
+                gain: request.gain,
+                native_time: None,
             });
         }
         self.cues.sort_by(|left, right| {
@@ -177,12 +238,47 @@ impl Timeline {
                 .total_cmp(&right.position)
                 .then(left.sequence.cmp(&right.sequence))
         });
+    }
+
+    pub fn schedule_precount(
+        &mut self,
+        expected_revision: u64,
+        intervals: &[f64],
+        first_native_time: u64,
+    ) -> Result<(), &'static str> {
+        self.require_revision(expected_revision)?;
+        if intervals.is_empty()
+            || intervals.len() > 8
+            || intervals
+                .iter()
+                .any(|value| !value.is_finite() || *value <= 0.0)
+        {
+            return Err("invalid_precount_schedule");
+        }
+        let mut native_time = first_native_time;
+        for (index, interval) in intervals.iter().enumerate() {
+            self.push_native_cue(CueKind::PrecountBeat, index as u32, native_time);
+            native_time = native_time.saturating_add((interval * 1_000_000.0) as u64);
+        }
+        self.push_native_cue(
+            CueKind::PrecountCompletion,
+            intervals.len() as u32,
+            native_time,
+        );
         Ok(())
     }
 
-    pub fn cancel(&mut self, expected_revision: u64) -> Result<(), &'static str> {
+    pub fn cancel(
+        &mut self,
+        expected_revision: u64,
+        kind: Option<CueKind>,
+    ) -> Result<(), &'static str> {
         self.require_revision(expected_revision)?;
-        self.cues.clear();
+        if let Some(kind) = kind {
+            self.cues.retain(|cue| cue.kind != kind);
+        } else {
+            self.cues.clear();
+        }
         Ok(())
     }
 
@@ -195,49 +291,76 @@ impl Timeline {
             };
         }
         let frame_us = 1_000_000.0 / f64::from(self.sample_rate);
-        let start_offset = self.start_at.map_or(0, |start| {
-            if start <= callback_time {
-                0
-            } else {
-                (((start - callback_time) as f64 / frame_us).ceil() as usize).min(frames)
-            }
-        });
-        if start_offset == frames {
-            return Advance {
-                cues: Vec::new(),
-                ended: false,
-                start_offset,
-            };
-        }
+        let start_offset = self.start_offset(frames, callback_time);
+        let callback_end = callback_time.saturating_add((frames as f64 * frame_us) as u64);
+        let source_started = start_offset < frames;
         let actual_start = callback_time.saturating_add((start_offset as f64 * frame_us) as u64);
-        self.start_at = None;
-        let anchor = *self.anchor_time.get_or_insert(actual_start);
-        let audible_frames = frames - start_offset;
+        if source_started {
+            self.start_at = None;
+        }
+        let anchor = if source_started {
+            Some(*self.anchor_time.get_or_insert(actual_start))
+        } else {
+            self.anchor_time
+        };
+        let audible_frames = frames.saturating_sub(start_offset);
         let end = self
             .clamp(self.position + audible_frames as f64 * self.rate / f64::from(self.sample_rate));
         let mut due = Vec::new();
-        while self.cues.first().is_some_and(|cue| cue.position <= end) {
-            let cue = self.cues.remove(0);
-            if cue.position < self.position {
+        let mut remaining = Vec::with_capacity(self.cues.len());
+        for cue in self.cues.drain(..) {
+            if cue.native_time.is_none() && cue.position < self.position {
                 continue;
             }
-            let offset_frames = ((cue.position - self.position) * f64::from(self.sample_rate)
-                / self.rate)
-                .ceil()
-                .max(0.0) as u64;
-            let actual = actual_start.saturating_add((offset_frames as f64 * frame_us) as u64);
-            let scheduled = anchor.saturating_add(
-                (((cue.position - self.anchor_position).max(0.0) / self.rate) * 1_000_000.0) as u64,
-            );
-            due.push(CueEvent {
-                generation: self.generation,
-                revision: self.revision,
-                cue_index: cue.index,
-                scheduled_native_time_us: scheduled,
-                actual_native_time_us: actual,
-                insertion_sequence: cue.sequence,
+            let timing = if let Some(scheduled) = cue.native_time {
+                (scheduled < callback_end).then(|| {
+                    let frame = (((scheduled.saturating_sub(callback_time)) as f64 / frame_us)
+                        .ceil() as usize)
+                        .min(frames.saturating_sub(1));
+                    (
+                        scheduled,
+                        callback_time.saturating_add((frame as f64 * frame_us) as u64),
+                        frame,
+                    )
+                })
+            } else if source_started && cue.position >= self.position && cue.position <= end {
+                let frame = start_offset
+                    + (((cue.position - self.position) * f64::from(self.sample_rate) / self.rate)
+                        .ceil() as usize);
+                let frame = frame.min(frames.saturating_sub(1));
+                let scheduled = anchor.unwrap_or(actual_start).saturating_add(
+                    (((cue.position - self.anchor_position).max(0.0) / self.rate) * 1_000_000.0)
+                        as u64,
+                );
+                Some((
+                    scheduled,
+                    actual_start.saturating_add(((frame - start_offset) as f64 * frame_us) as u64),
+                    frame,
+                ))
+            } else {
+                None
+            };
+            let Some((scheduled, actual, frame_offset)) = timing else {
+                remaining.push(cue);
+                continue;
+            };
+            due.push(FiredCue {
+                event: CueEvent {
+                    generation: self.generation,
+                    revision: self.revision,
+                    cue_index: cue.index,
+                    kind: cue.kind,
+                    accent: cue.accent,
+                    gain: cue.gain,
+                    scheduled_native_time_us: scheduled,
+                    actual_native_time_us: actual,
+                    insertion_sequence: cue.sequence,
+                },
+                frame_offset,
             });
         }
+        self.cues = remaining;
+        due.sort_by_key(|cue| (cue.frame_offset, cue.event.insertion_sequence));
         self.position = end;
         let ended = self.duration > 0.0 && self.position >= self.duration;
         if ended {
@@ -248,6 +371,20 @@ impl Timeline {
             ended,
             start_offset,
         }
+    }
+
+    pub fn start_offset(&self, frames: usize, callback_time: u64) -> usize {
+        if !self.running || frames == 0 {
+            return frames;
+        }
+        self.start_at.map_or(0, |start| {
+            let frame_us = 1_000_000.0 / f64::from(self.sample_rate);
+            if start <= callback_time {
+                0
+            } else {
+                (((start - callback_time) as f64 / frame_us).ceil() as usize).min(frames)
+            }
+        })
     }
 
     pub fn revision(&self) -> u64 {
@@ -268,6 +405,19 @@ impl Timeline {
             .ok_or("stale_timeline_revision")
     }
 
+    fn push_native_cue(&mut self, kind: CueKind, index: u32, native_time: u64) {
+        self.next_sequence = self.next_sequence.wrapping_add(1);
+        self.cues.push(Cue {
+            index,
+            position: self.position,
+            sequence: self.next_sequence,
+            kind,
+            accent: false,
+            gain: 1.0,
+            native_time: Some(native_time),
+        });
+    }
+
     fn clamp(&self, value: f64) -> f64 {
         value.max(0.0).min(if self.duration > 0.0 {
             self.duration
@@ -277,12 +427,29 @@ impl Timeline {
     }
 }
 
+fn default_cue_gain() -> f32 {
+    1.0
+}
+
 pub fn normalize_rate(rate: f64) -> f64 {
     if rate.is_finite() && rate > 0.0 {
         rate.clamp(0.25, 4.0)
     } else {
         1.0
     }
+}
+
+pub fn validate_cues(requests: &[CueRequest]) -> Result<(), &'static str> {
+    requests
+        .iter()
+        .any(|request| {
+            !request.position_seconds.is_finite()
+                || request.position_seconds < 0.0
+                || !request.gain.is_finite()
+                || !(0.0..=1.0).contains(&request.gain)
+        })
+        .then_some(())
+        .map_or(Ok(()), |_| Err("invalid_cue_schedule"))
 }
 
 #[cfg(test)]
@@ -317,6 +484,30 @@ mod tests {
     }
 
     #[test]
+    fn same_rate_preserves_cues_changed_rate_and_advance_discard_position_cues() {
+        let mut timeline = timeline();
+        let cue = |index, position| CueRequest {
+            cue_index: index,
+            position_seconds: position,
+            kind: CueKind::Metronome,
+            accent: false,
+            gain: 1.0,
+        };
+        timeline.schedule(1, vec![cue(1, 0.5)]).unwrap();
+        timeline.set_rate(1, 1.0).unwrap();
+        assert_eq!(timeline.revision(), 1);
+        timeline.arm(1, None, None, 0).unwrap();
+        assert_eq!(timeline.advance(600, 0).cues.len(), 1);
+
+        timeline.schedule(1, vec![cue(2, 0.8)]).unwrap();
+        timeline.set_rate(1, 2.0).unwrap();
+        assert_eq!(timeline.revision(), 2);
+        assert!(timeline.advance(200, 600_000).cues.is_empty());
+        timeline.schedule(2, vec![cue(3, 0.1)]).unwrap();
+        assert!(timeline.advance(10, 800_000).cues.is_empty());
+    }
+
+    #[test]
     fn cues_are_sample_aligned_stable_and_cancel_on_discontinuity() {
         let mut timeline = timeline();
         timeline
@@ -326,10 +517,16 @@ mod tests {
                     CueRequest {
                         cue_index: 2,
                         position_seconds: 0.002,
+                        kind: CueKind::Marker,
+                        accent: false,
+                        gain: 1.0,
                     },
                     CueRequest {
                         cue_index: 1,
                         position_seconds: 0.002,
+                        kind: CueKind::Marker,
+                        accent: false,
+                        gain: 1.0,
                     },
                 ],
             )
@@ -339,17 +536,20 @@ mod tests {
         assert_eq!(
             events
                 .iter()
-                .map(|event| event.cue_index)
+                .map(|event| event.event.cue_index)
                 .collect::<Vec<_>>(),
             [2, 1]
         );
-        assert_eq!(events[0].actual_native_time_us, 3_000);
+        assert_eq!(events[0].event.actual_native_time_us, 3_000);
         timeline
             .schedule(
                 1,
                 vec![CueRequest {
                     cue_index: 3,
                     position_seconds: 1.0,
+                    kind: CueKind::Marker,
+                    accent: false,
+                    gain: 1.0,
                 }],
             )
             .unwrap();
@@ -372,5 +572,121 @@ mod tests {
         timeline.stop();
         timeline.advance(100, 3_000);
         assert_eq!(timeline.position(), 0.0);
+    }
+
+    #[test]
+    fn precount_completes_on_the_source_start_sample() {
+        let mut timeline = timeline();
+        timeline.arm(1, None, Some(4_000), 100).unwrap();
+        timeline
+            .schedule_precount(1, &[0.001, 0.002], 1_000)
+            .unwrap();
+        timeline
+            .schedule(
+                1,
+                vec![CueRequest {
+                    cue_index: 3,
+                    position_seconds: 0.0,
+                    kind: CueKind::Metronome,
+                    accent: true,
+                    gain: 0.8,
+                }],
+            )
+            .unwrap();
+        let advance = timeline.advance(4, 1_000);
+        assert_eq!(advance.start_offset, 3);
+        assert_eq!(timeline.position(), 0.001);
+        assert_eq!(
+            advance
+                .cues
+                .iter()
+                .map(|cue| (cue.event.kind, cue.frame_offset))
+                .collect::<Vec<_>>(),
+            [
+                (CueKind::PrecountBeat, 0),
+                (CueKind::PrecountBeat, 1),
+                (CueKind::PrecountCompletion, 3),
+                (CueKind::Metronome, 3)
+            ]
+        );
+    }
+
+    #[test]
+    fn replacement_metronome_cues_align_fresh_start_and_resume() {
+        let mut timeline = timeline();
+        let cue = |index, position| CueRequest {
+            cue_index: index,
+            position_seconds: position,
+            kind: CueKind::Metronome,
+            accent: false,
+            gain: 1.0,
+        };
+        timeline.schedule(1, vec![cue(1, 0.0)]).unwrap();
+        timeline.arm(1, Some(2.0), None, 0).unwrap();
+        let revision = timeline.revision();
+        timeline.schedule(revision, vec![cue(2, 2.0)]).unwrap();
+        let fresh = timeline.advance(1, 0);
+        assert_eq!((fresh.start_offset, fresh.cues[0].frame_offset), (0, 0));
+        assert_eq!(fresh.cues[0].event.cue_index, 2);
+
+        timeline.pause();
+        let position = timeline.position();
+        timeline.arm(revision, None, None, 1_000).unwrap();
+        timeline.cancel(revision, Some(CueKind::Metronome)).unwrap();
+        timeline.schedule(revision, vec![cue(3, position)]).unwrap();
+        let resumed = timeline.advance(1, 1_000);
+        assert_eq!((resumed.start_offset, resumed.cues[0].frame_offset), (0, 0));
+
+        timeline
+            .schedule(revision, vec![cue(4, position + 0.1)])
+            .unwrap();
+        timeline.replace_metronome(revision, Vec::new()).unwrap();
+        assert!(timeline.advance(200, 2_000).cues.is_empty());
+    }
+
+    #[test]
+    fn play_cue_validation_rejects_invalid_plans() {
+        assert_eq!(
+            validate_cues(&[CueRequest {
+                cue_index: 0,
+                position_seconds: f64::NAN,
+                kind: CueKind::Metronome,
+                accent: false,
+                gain: 1.0,
+            }]),
+            Err("invalid_cue_schedule")
+        );
+    }
+
+    #[test]
+    fn metronome_cancellation_preserves_markers_and_rejects_stale_revision() {
+        let mut timeline = timeline();
+        timeline
+            .schedule(
+                1,
+                vec![
+                    CueRequest {
+                        cue_index: 1,
+                        position_seconds: 0.001,
+                        kind: CueKind::Marker,
+                        accent: false,
+                        gain: 1.0,
+                    },
+                    CueRequest {
+                        cue_index: 2,
+                        position_seconds: 0.001,
+                        kind: CueKind::Metronome,
+                        accent: true,
+                        gain: 0.4,
+                    },
+                ],
+            )
+            .unwrap();
+        timeline.cancel(1, Some(CueKind::Metronome)).unwrap();
+        assert_eq!(timeline.cancel(0, None), Err("stale_timeline_revision"));
+        timeline.arm(1, None, None, 100).unwrap();
+        let cues = timeline.advance(2, 1_000).cues;
+        assert_eq!(cues.len(), 1);
+        assert_eq!(cues[0].event.kind, CueKind::Marker);
     }
 }

--- a/apps/desktop/src-tauri/src/native_audio/transport.rs
+++ b/apps/desktop/src-tauri/src/native_audio/transport.rs
@@ -36,7 +36,7 @@ use super::{
     diagnostics::{self, DiagnosticCheckpoint, DiagnosticSafeCode},
     mixer::{AudioLaneRequest, AudioLaneRole, EffectiveAudioLane},
     session::{RuntimeReport, RuntimeReportKind, SessionCommand, SessionOwner},
-    timeline::{self, Timeline},
+    timeline::{self, CueRequest, Timeline},
     AudioCapabilities,
 };
 
@@ -59,6 +59,9 @@ const CLICK_DURATION_SECONDS: f64 = 0.032;
 const CLICK_ACCENT_DURATION_SECONDS: f64 = 0.045;
 const CLICK_FREQUENCY_HZ: f64 = 1175.0;
 const CLICK_ACCENT_FREQUENCY_HZ: f64 = 1760.0;
+const PRECOUNT_FREQUENCY_HZ: f64 = 760.0;
+const PRECOUNT_ATTACK_SECONDS: f64 = 0.002;
+const PRECOUNT_DURATION_SECONDS: f64 = 0.045;
 #[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
 const STREAM_CHUNK_FRAMES: usize = 2048;
 #[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
@@ -105,6 +108,14 @@ pub struct AudioPlayRequest {
     #[serde(default, flatten)]
     pub control: SessionCommand,
     pub start_at_native_us: Option<u64>,
+    pub precount: Option<AudioPrecountRequest>,
+    pub metronome_cues: Option<Vec<CueRequest>>,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AudioPrecountRequest {
+    pub intervals_seconds: Vec<f64>,
 }
 
 #[derive(Clone, Debug, Deserialize)]
@@ -417,6 +428,14 @@ struct PlaybackShared {
     report_sender: mpsc::SyncSender<RuntimeReport>,
     pending_cues: VecDeque<timeline::CueEvent>,
     terminal_reported: bool,
+    cue_voices: Vec<CueVoice>,
+}
+
+struct CueVoice {
+    phase: usize,
+    frames: usize,
+    frequency: f64,
+    gain: f32,
 }
 
 impl PlaybackShared {
@@ -1534,17 +1553,89 @@ fn playback_lanes_drained(lanes: &[PlaybackLane]) -> bool {
         })
 }
 
-fn advance_timeline(shared: &mut PlaybackShared, frames: usize) -> (usize, bool) {
+fn advance_timeline(
+    shared: &mut PlaybackShared,
+    frames: usize,
+    callback_time: u64,
+) -> (usize, bool, Vec<timeline::FiredCue>) {
     if shared.status != TransportStatus::Playing || shared.buffering {
-        return (frames, false);
+        return (frames, false, Vec::new());
     }
     let Ok(mut timeline) = shared.timeline.lock() else {
-        return (frames, false);
+        return (frames, false, Vec::new());
     };
-    let advance = timeline.advance(frames, timeline::native_time_us());
+    let advance = timeline.advance(frames, callback_time);
     shared.position_seconds = timeline.position();
-    shared.pending_cues.extend(advance.cues);
-    (advance.start_offset, advance.ended)
+    let fired = advance.cues;
+    shared
+        .pending_cues
+        .extend(fired.iter().map(|cue| cue.event.clone()));
+    (advance.start_offset, advance.ended, fired)
+}
+
+fn timeline_start_offset(shared: &PlaybackShared, frames: usize, callback_time: u64) -> usize {
+    shared.timeline.lock().map_or(frames, |timeline| {
+        timeline.start_offset(frames, callback_time)
+    })
+}
+
+fn cue_frame_sample(shared: &mut PlaybackShared) -> f32 {
+    let sample_rate = f64::from(shared.sample_rate);
+    let sample = shared
+        .cue_voices
+        .iter()
+        .map(|voice| {
+            let progress = voice.phase as f64 / voice.frames as f64;
+            let cycle = voice.frequency * voice.phase as f64 / sample_rate;
+            let metronome = voice.frequency != PRECOUNT_FREQUENCY_HZ;
+            let wave = if metronome {
+                if cycle.fract() < 0.5 {
+                    1.0
+                } else {
+                    -1.0
+                }
+            } else {
+                1.0 - 4.0 * (cycle.fract() - 0.5).abs()
+            };
+            let attack_seconds = if metronome {
+                0.004
+            } else {
+                PRECOUNT_ATTACK_SECONDS
+            };
+            let attack = (attack_seconds * sample_rate / voice.frames as f64).min(1.0);
+            let exponent = if progress < attack {
+                1.0 - progress / attack
+            } else {
+                (progress - attack) / (1.0 - attack)
+            };
+            let envelope = 0.0001_f64.powf(exponent);
+            (wave * envelope * f64::from(voice.gain)) as f32
+        })
+        .sum();
+    for voice in &mut shared.cue_voices {
+        voice.phase += 1;
+    }
+    shared.cue_voices.retain(|voice| voice.phase < voice.frames);
+    sample
+}
+
+fn start_cue_voice(shared: &mut PlaybackShared, cue: &timeline::FiredCue) {
+    let (frequency, duration, scale) = match cue.event.kind {
+        timeline::CueKind::PrecountBeat => (PRECOUNT_FREQUENCY_HZ, PRECOUNT_DURATION_SECONDS, 1.0),
+        timeline::CueKind::Metronome if cue.event.accent => (
+            CLICK_ACCENT_FREQUENCY_HZ,
+            CLICK_ACCENT_DURATION_SECONDS,
+            0.42,
+        ),
+        timeline::CueKind::Metronome => (CLICK_FREQUENCY_HZ, CLICK_DURATION_SECONDS, 0.32),
+        _ => return,
+    };
+    shared.cue_voices.push(CueVoice {
+        phase: 0,
+        frames: (f64::from(shared.sample_rate) * duration) as usize,
+        frequency,
+        gain: cue.event.gain * scale,
+    });
 }
 
 #[cfg(test)]
@@ -1553,27 +1644,39 @@ fn render_shared_output(shared: &mut PlaybackShared, output: &mut [f32]) {
         output.fill(0.0);
         return;
     }
+    let callback_time = timeline::native_time_us();
+    let start_offset = timeline_start_offset(shared, output.len() / shared.channels, callback_time);
     if shared.status == TransportStatus::Playing && !shared.buffering {
-        let frame_count = output.len() / shared.channels;
+        let frame_count = output.len() / shared.channels - start_offset;
         let audible_underrun = prepare_lane_scratch(
             shared.diagnostics_generation,
             &mut shared.lanes,
-            output.len(),
+            frame_count * shared.channels,
         );
         update_underrun_state(shared, audible_underrun, frame_count);
     }
-    let (start_offset, ended) = advance_timeline(shared, output.len() / shared.channels);
+    let (start_offset, ended, fired) =
+        advance_timeline(shared, output.len() / shared.channels, callback_time);
     for (frame_index, frame) in output.chunks_mut(shared.channels).enumerate() {
+        fired
+            .iter()
+            .filter(|cue| cue.frame_offset == frame_index)
+            .for_each(|cue| start_cue_voice(shared, cue));
+        let cue_sample = cue_frame_sample(shared);
         if shared.status != TransportStatus::Playing
             || shared.buffering
             || frame_index < start_offset
         {
-            frame.fill(0.0);
+            frame.fill(cue_sample);
             continue;
         }
 
         for (channel, sample) in frame.iter_mut().enumerate() {
-            *sample = mix_shared_frame(shared, channel, frame_index * shared.channels + channel);
+            *sample = mix_shared_frame(
+                shared,
+                channel,
+                (frame_index - start_offset) * shared.channels + channel,
+            ) + cue_sample;
         }
     }
     if shared.diagnostics_generation != 0
@@ -1609,32 +1712,41 @@ where
         }
         return;
     }
+    let callback_time = timeline::native_time_us();
+    let start_offset = timeline_start_offset(shared, output.len() / shared.channels, callback_time);
     if shared.status == TransportStatus::Playing && !shared.buffering {
-        let frame_count = output.len() / shared.channels;
+        let frame_count = output.len() / shared.channels - start_offset;
         let audible_underrun = prepare_lane_scratch(
             shared.diagnostics_generation,
             &mut shared.lanes,
-            output.len(),
+            frame_count * shared.channels,
         );
         update_underrun_state(shared, audible_underrun, frame_count);
     }
+    let (start_offset, ended, fired) =
+        advance_timeline(shared, output.len() / shared.channels, callback_time);
 
     let track_nonzero = shared.diagnostics_generation != 0;
     let mut any_nonzero = false;
-    let (start_offset, ended) = advance_timeline(shared, output.len() / shared.channels);
     for (frame_index, frame) in output.chunks_mut(shared.channels).enumerate() {
+        fired
+            .iter()
+            .filter(|cue| cue.frame_offset == frame_index)
+            .for_each(|cue| start_cue_voice(shared, cue));
+        let cue_sample = cue_frame_sample(shared);
         if shared.status != TransportStatus::Playing
             || shared.buffering
             || frame_index < start_offset
         {
             for sample in frame {
-                *sample = silent;
+                *sample = T::from_sample(cue_sample);
             }
             continue;
         }
 
         for (channel, sample) in frame.iter_mut().enumerate() {
-            let mixed = mix_shared_frame(shared, channel, frame_index * shared.channels + channel);
+            let sample_index = (frame_index - start_offset) * shared.channels + channel;
+            let mixed = mix_shared_frame(shared, channel, sample_index) + cue_sample;
             if track_nonzero {
                 any_nonzero |= mixed.abs() > AUDIBLE_GAIN_FLOOR;
             }
@@ -1728,6 +1840,7 @@ fn start_native_runtime(
         report_sender,
         pending_cues: VecDeque::new(),
         terminal_reported: false,
+        cue_voices: Vec::new(),
     }));
 
     drop(device);
@@ -3018,11 +3131,77 @@ mod tests {
             report_sender,
             pending_cues: VecDeque::new(),
             terminal_reported: false,
+            cue_voices: Vec::new(),
         }
     }
 
     fn push_ring_samples(ring: &Arc<Mutex<RingBuffer>>, samples: &[f32]) {
         assert!(ring.lock().expect("ring lock").push_samples(samples));
+    }
+
+    #[test]
+    fn cue_voices_use_uniform_precount_and_metronome_accent_gain() {
+        let ring = Arc::new(Mutex::new(RingBuffer::new(1_000)));
+        let mut shared = shared_with_lane(ring, 48_000, 1, 1.0);
+        let cue = |kind, accent, gain| timeline::FiredCue {
+            event: timeline::CueEvent {
+                generation: 1,
+                revision: 1,
+                cue_index: 0,
+                kind,
+                accent,
+                gain,
+                scheduled_native_time_us: 1,
+                actual_native_time_us: 1,
+                insertion_sequence: 1,
+            },
+            frame_offset: 0,
+        };
+        start_cue_voice(
+            &mut shared,
+            &cue(timeline::CueKind::PrecountBeat, true, 1.0),
+        );
+        assert_eq!(shared.cue_voices[0].frequency, PRECOUNT_FREQUENCY_HZ);
+        assert_eq!(shared.cue_voices[0].frames, 2_160);
+        assert!(cue_frame_sample(&mut shared).abs() < 0.0002);
+        shared.cue_voices[0].phase = 96;
+        assert!(cue_frame_sample(&mut shared).abs() > 0.8);
+        shared.cue_voices.remove(0);
+        start_cue_voice(&mut shared, &cue(timeline::CueKind::Metronome, true, 0.25));
+        assert_eq!(shared.cue_voices[0].frequency, CLICK_ACCENT_FREQUENCY_HZ);
+        assert_eq!(shared.cue_voices[0].frames, 2_160);
+        assert!((shared.cue_voices[0].gain - 0.105).abs() < f32::EPSILON);
+        assert!(cue_frame_sample(&mut shared).abs() < 0.00002);
+        shared.cue_voices[0].phase = 192;
+        assert!(cue_frame_sample(&mut shared).abs() > 0.1);
+    }
+
+    #[test]
+    fn count_in_renderers_do_not_consume_source_before_start_offset() {
+        let render = |typed: bool| {
+            let ring = Arc::new(Mutex::new(RingBuffer::new(1_000)));
+            push_ring_samples(&ring, &[0.25; 10]);
+            let mut shared = shared_with_lane(ring.clone(), 1_000, 1, 1.0);
+            let now = timeline::native_time_us();
+            shared
+                .timeline
+                .lock()
+                .unwrap()
+                .arm(1, None, Some(now + 1_000_000), now)
+                .unwrap();
+            if typed {
+                let mut output = [1_i16; 10];
+                render_shared_output_typed(&mut shared, &mut output);
+                assert_eq!(output, [0; 10]);
+            } else {
+                let mut output = [1.0; 10];
+                render_shared_output(&mut shared, &mut output);
+                assert_eq!(output, [0.0; 10]);
+            }
+            assert_eq!(ring.lock().unwrap().fill_samples(), 10);
+        };
+        render(false);
+        render(true);
     }
 
     #[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
@@ -3301,6 +3480,8 @@ mod tests {
                 scheduled_start_time_seconds: None,
                 control: SessionCommand::default(),
                 start_at_native_us: None,
+                precount: None,
+                metronome_cues: None,
             })
             .expect_err("reject unavailable runtime");
 
@@ -3345,6 +3526,8 @@ mod tests {
                 scheduled_start_time_seconds: None,
                 control: SessionCommand::default(),
                 start_at_native_us: None,
+                precount: None,
+                metronome_cues: None,
             })
             .expect_err("reject terminal runtime error");
         let snapshot = state.snapshot();
@@ -3676,6 +3859,8 @@ mod tests {
                 scheduled_start_time_seconds: Some(2.0),
                 control: SessionCommand::default(),
                 start_at_native_us: None,
+                precount: None,
+                metronome_cues: None,
             })
             .expect("play");
 
@@ -3881,6 +4066,8 @@ mod tests {
                 scheduled_start_time_seconds: None,
                 control: SessionCommand::default(),
                 start_at_native_us: None,
+                precount: None,
+                metronome_cues: None,
             })
             .expect("restart loop");
         assert_eq!(snapshot.state, "playing");

--- a/apps/desktop/src/App.project-media-controls.test.tsx
+++ b/apps/desktop/src/App.project-media-controls.test.tsx
@@ -5,6 +5,7 @@ import { readPlaybackLiveDiagnostics } from "./lib/playbackDiagnostics";
 import { readBrowserWakeLockStatus } from "./lib/powerInhibition";
 import {
   deferNextMockSystemMediaControlListen,
+  emitMockNativeAudioTerminal,
   emitMockNativePlaybackError,
   emitMockNativePlaybackPosition,
   emitMockSystemMediaPlaybackControl,
@@ -367,6 +368,7 @@ describe("Desktop app project media controls", () => {
   });
 
   it("waits for lazy transport before exposing native fallback media sources", async () => {
+    vi.stubEnv("VITE_TUNEFORGE_FORCE_WEB_AUDIO", "1");
     const transport = deferWebMediaTransport();
     const restoreTauriRuntime = mockTauriRuntime();
     const user = userEvent.setup();
@@ -535,6 +537,7 @@ describe("Desktop app project media controls", () => {
         state: "playing",
       });
     });
+    vi.stubEnv("VITE_TUNEFORGE_FORCE_WEB_AUDIO", "1");
     act(() => {
       emitMockNativePlaybackError({
         sessionId,
@@ -565,6 +568,7 @@ describe("Desktop app project media controls", () => {
   });
 
   it("activates Web Audio system controls only after native play falls back before start", async () => {
+    vi.stubEnv("VITE_TUNEFORGE_FORCE_WEB_AUDIO", "1");
     const restoreTauriRuntime = mockTauriRuntime();
     const user = userEvent.setup();
     setMockNativeAudioState({
@@ -657,6 +661,7 @@ describe("Desktop app project media controls", () => {
     await waitFor(() => expect(screen.getByLabelText("Playback position")).toHaveValue("42"));
 
     const releaseCount = nativePowerProtectionCallCount(false);
+    vi.stubEnv("VITE_TUNEFORGE_FORCE_WEB_AUDIO", "1");
     act(() => {
       emitMockNativePlaybackError({
         sessionId,
@@ -729,7 +734,7 @@ describe("Desktop app project media controls", () => {
     restoreTauriRuntime();
   });
 
-  it("retries native playback once after a failed paused session", async () => {
+  it("prepares once on the first explicit Play after a terminal event", async () => {
     const restoreTauriRuntime = mockTauriRuntime();
     const user = userEvent.setup();
     setMockNativeAudioState({
@@ -748,16 +753,16 @@ describe("Desktop app project media controls", () => {
     await waitForNativeControls();
     const nativePlayCount = invokeCalls("audio_play").length;
     const prepareCount = invokeCalls("audio_prepare_session").length;
-    const sessionId = latestNativeSessionId();
 
     await user.click(screen.getByRole("button", { name: "Pause playback" }));
     await waitFor(() =>
       expect(screen.getByRole("button", { name: "Play playback" })).toBeInTheDocument(),
     );
     act(() => {
-      emitMockNativePlaybackError({
-        sessionId,
-        code: "stream_invalidated",
+      emitMockNativeAudioTerminal({
+        generation: 1,
+        code: "output_stream_failure",
+        nativeTimeUs: 10,
       });
     });
 
@@ -766,9 +771,6 @@ describe("Desktop app project media controls", () => {
       currentPath: "none",
       nativeSessionLaneCount: null,
     });
-    expect(window.localStorage.getItem("tuneforge.playback-native-error")).toBe(
-      "Native playback stream was interrupted.",
-    );
     expect(invokeCalls("audio_play")).toHaveLength(nativePlayCount);
 
     await user.click(screen.getByRole("button", { name: "Play playback" }));
@@ -782,7 +784,7 @@ describe("Desktop app project media controls", () => {
     restoreTauriRuntime();
   });
 
-  it("prepares a fresh native session after a playback command fails", async () => {
+  it("retries a failed native play only after another explicit Play", async () => {
     const restoreTauriRuntime = mockTauriRuntime();
     const user = userEvent.setup();
     const mockInvoke = getMockInvoke();
@@ -813,16 +815,16 @@ describe("Desktop app project media controls", () => {
       await openPlaybackWorkspace(user);
 
       await user.click(screen.getByRole("button", { name: "Play playback" }));
-      const sourceAudio = await waitFor(() => findAudioByArtifactId("art_source"));
-      markAudioReady(sourceAudio);
-      await waitForWebOwnerControls();
+      await waitFor(() =>
+        expect(readPlaybackLiveDiagnostics()).toMatchObject({
+          currentState: "error",
+          currentPath: "none",
+        }),
+      );
+      expect(document.querySelector("audio[src]")).toBeNull();
       const prepareCount = invokeCalls("audio_prepare_session").length;
       const nativePlayCount = invokeCalls("audio_play").length;
 
-      await user.click(screen.getByRole("button", { name: "Pause playback" }));
-      await waitFor(() =>
-        expect(screen.getByRole("button", { name: "Play playback" })).toBeInTheDocument(),
-      );
       await user.click(screen.getByRole("button", { name: "Play playback" }));
       await waitForNativeControls();
 
@@ -997,6 +999,7 @@ describe("Desktop app project media controls", () => {
       expect(hasNativePowerProtection(true)).toBe(false);
 
       const sessionId = latestNativeSessionId();
+      vi.stubEnv("VITE_TUNEFORGE_FORCE_WEB_AUDIO", "1");
       act(() => {
         emitMockNativePlaybackError({
           sessionId,
@@ -1015,7 +1018,7 @@ describe("Desktop app project media controls", () => {
       await Promise.resolve();
       expect(readPlaybackLiveDiagnostics()).toMatchObject({
         currentState: "playing",
-        currentPath: "web-fallback",
+        currentPath: "web-forced",
       });
     } finally {
       nativePlayBlock.release?.();

--- a/apps/desktop/src/App.project-playback-stems.test.tsx
+++ b/apps/desktop/src/App.project-playback-stems.test.tsx
@@ -8,6 +8,7 @@ import {
   getByAriaKeyLabel,
   getMockAudioContexts,
   getMockFetch,
+  getMockInvoke,
   markAudioReady,
   mockCreatePreview,
   mockCreateStems,
@@ -18,6 +19,7 @@ import {
   setDeferredPreviewCompletion,
   setMockAudioContextInitialState,
   setMockAudioSourceStartError,
+  setMockNativeAudioState,
   setProjects,
 } from "./test/appTestHarness";
 import {
@@ -46,6 +48,34 @@ function readStoredProjectPlaybackState() {
 
 function triggerBufferSourceEnded(source: { onended: AudioBufferSourceNode["onended"] }) {
   source.onended?.call(source as unknown as AudioBufferSourceNode, new Event("ended"));
+}
+
+function enableNativePlayback() {
+  Object.defineProperty(window, "__TAURI_INTERNALS__", {
+    configurable: true,
+    value: { invoke: getMockInvoke() },
+  });
+  setMockNativeAudioState({
+    capabilities: {
+      nativePlaybackSupported: true,
+      fallbackRequired: false,
+      fallbackReason: null,
+      backend: "desktop-cpal",
+    },
+  });
+  return () => {
+    delete (window as Window & { __TAURI_INTERNALS__?: unknown }).__TAURI_INTERNALS__;
+  };
+}
+
+function invokeCalls(command: string) {
+  return getMockInvoke().mock.calls.filter(([name]) => name === command);
+}
+
+function nativeControlRevision(command: string, callIndex = 0) {
+  const call = invokeCalls(command)[callIndex];
+  return (call?.[1] as { payload?: { timelineRevision?: number } } | undefined)?.payload
+    ?.timelineRevision;
 }
 
 describe("Desktop app project playback stems", () => {
@@ -973,6 +1003,162 @@ describe("Desktop app project playback stems", () => {
     await waitFor(() => expect(vocalAudio.currentTime).toBeCloseTo(stemStartOffset, 1));
     await waitFor(() => expect(drumsAudio.currentTime).toBeCloseTo(stemStartOffset, 1));
     expect(screen.getByRole("button", { name: "Pause playback" })).toBeInTheDocument();
+  });
+
+  it("serializes native mode handoffs without redundant lane updates", async () => {
+    const restoreTauriRuntime = enableNativePlayback();
+    const user = userEvent.setup();
+    renderApp(["/projects/proj_123"]);
+
+    expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
+    await generateStems(user);
+    await openPlaybackWorkspace(user);
+    await user.click(screen.getByRole("button", { name: "Play playback" }));
+    await waitFor(() => expect(invokeCalls("audio_play")).toHaveLength(1));
+    setPlaybackPosition("32.481");
+    await waitFor(() => expect(invokeCalls("audio_seek")).toHaveLength(1));
+
+    const prepareCount = invokeCalls("audio_prepare_session").length;
+    const stopCount = invokeCalls("audio_stop").length;
+    const laneCount = invokeCalls("audio_set_lanes").length;
+    const stemList = screen.getByRole("group", { name: "Playback stem list" });
+    await user.click(within(stemList).getAllByRole("button", { name: /Vocals/i })[0] as HTMLElement);
+    expect(await screen.findByRole("heading", { name: "Vocals" })).toBeInTheDocument();
+
+    await waitFor(() => expect(invokeCalls("audio_stop")).toHaveLength(stopCount + 1));
+    await waitFor(() => expect(invokeCalls("audio_prepare_session")).toHaveLength(prepareCount + 1));
+    await waitFor(() => expect(invokeCalls("audio_play")).toHaveLength(2));
+    const stemPlayPayload = (invokeCalls("audio_play")[1]?.[1] as {
+      payload?: { startTimeSeconds?: number | null };
+    } | undefined)?.payload;
+    expect(stemPlayPayload?.startTimeSeconds).toBeCloseTo(32.481, 3);
+    expect(invokeCalls("audio_set_lanes")).toHaveLength(laneCount);
+    expect(document.querySelector("audio[src]")).toBeNull();
+
+    const reversePrepareCount = invokeCalls("audio_prepare_session").length;
+    const reverseStopCount = invokeCalls("audio_stop").length;
+    await user.click(screen.getByRole("button", { name: "Full Mix" }));
+    await waitFor(() => expect(invokeCalls("audio_stop")).toHaveLength(reverseStopCount + 1));
+    await waitFor(() =>
+      expect(invokeCalls("audio_prepare_session")).toHaveLength(reversePrepareCount + 1),
+    );
+    await waitFor(() => expect(invokeCalls("audio_play")).toHaveLength(3));
+    expect(invokeCalls("audio_set_lanes")).toHaveLength(laneCount);
+    restoreTauriRuntime();
+  });
+
+  it("keeps a paused native handoff paused after its deferred Play completes", async () => {
+    const restoreTauriRuntime = enableNativePlayback();
+    const invoke = getMockInvoke();
+    const originalInvoke = invoke.getMockImplementation();
+    if (!originalInvoke) {
+      throw new Error("Mock invoke implementation was not installed.");
+    }
+    let releaseHandoffPlay!: () => void;
+    const handoffPlayGate = new Promise<void>((resolve) => {
+      releaseHandoffPlay = resolve;
+    });
+    let handoffPlayRevision: number | undefined;
+    const user = userEvent.setup();
+
+    try {
+      renderApp(["/projects/proj_123"]);
+      expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
+      await generateStems(user);
+      await openPlaybackWorkspace(user);
+      await user.click(screen.getByRole("button", { name: "Play playback" }));
+      await waitFor(() => expect(invokeCalls("audio_play")).toHaveLength(1));
+
+      invoke.mockImplementation(async (command, args) => {
+        if (command === "audio_play") {
+          await handoffPlayGate;
+        }
+        const result = await originalInvoke(command, args);
+        if (command === "audio_play" || command === "audio_stop") {
+          const control = (args as { payload?: { timelineRevision?: number } } | undefined)?.payload;
+          const timelineRevision = (control?.timelineRevision ?? 1) + 1;
+          if (command === "audio_play") {
+            handoffPlayRevision = timelineRevision;
+          }
+          return {
+            ...(result as object),
+            timelineRevision,
+          };
+        }
+        return result;
+      });
+      const stemList = screen.getByRole("group", { name: "Playback stem list" });
+      await user.click(
+        within(stemList).getAllByRole("button", { name: /Vocals/i })[0] as HTMLElement,
+      );
+      await waitFor(() => expect(invokeCalls("audio_play")).toHaveLength(2));
+      expect(screen.getByRole("button", { name: "Pause playback" })).toBeInTheDocument();
+
+      await user.click(screen.getByRole("button", { name: "Pause playback" }));
+      await waitFor(() => expect(screen.getByRole("button", { name: "Play playback" })).toBeInTheDocument());
+      expect(invokeCalls("audio_stop")).toHaveLength(1);
+      expect(screen.getByRole("button", { name: "Play playback" })).toBeInTheDocument();
+
+      releaseHandoffPlay();
+      await waitFor(() => expect(invokeCalls("audio_stop")).toHaveLength(2));
+      expect(nativeControlRevision("audio_stop", 1)).toBe(handoffPlayRevision);
+      expect(screen.getByRole("button", { name: "Play playback" })).toBeInTheDocument();
+      expect(document.querySelector("audio[src]")).toBeNull();
+    } finally {
+      releaseHandoffPlay();
+      invoke.mockImplementation(originalInvoke);
+      restoreTauriRuntime();
+    }
+  });
+
+  it("cancels a native handoff paused while its previous Stop is deferred", async () => {
+    const restoreTauriRuntime = enableNativePlayback();
+    const invoke = getMockInvoke();
+    const originalInvoke = invoke.getMockImplementation();
+    if (!originalInvoke) {
+      throw new Error("Mock invoke implementation was not installed.");
+    }
+    let releaseHandoffStop!: () => void;
+    const handoffStopGate = new Promise<void>((resolve) => {
+      releaseHandoffStop = resolve;
+    });
+    const user = userEvent.setup();
+
+    try {
+      renderApp(["/projects/proj_123"]);
+      expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
+      await generateStems(user);
+      await openPlaybackWorkspace(user);
+      await user.click(screen.getByRole("button", { name: "Play playback" }));
+      await waitFor(() => expect(invokeCalls("audio_play")).toHaveLength(1));
+
+      invoke.mockImplementation(async (command, args) => {
+        if (command === "audio_stop") {
+          await handoffStopGate;
+        }
+        return originalInvoke(command, args);
+      });
+      const stemList = screen.getByRole("group", { name: "Playback stem list" });
+      await user.click(
+        within(stemList).getAllByRole("button", { name: /Vocals/i })[0] as HTMLElement,
+      );
+      await waitFor(() => expect(invokeCalls("audio_stop")).toHaveLength(1));
+      expect(invokeCalls("audio_prepare_session")).toHaveLength(1);
+
+      await user.click(screen.getByRole("button", { name: "Pause playback" }));
+      expect(screen.getByRole("button", { name: "Play playback" })).toBeInTheDocument();
+      releaseHandoffStop();
+
+      await waitFor(() => expect(invokeCalls("audio_prepare_session")).toHaveLength(2));
+      await waitFor(() => expect(invokeCalls("audio_stop")).toHaveLength(2));
+      expect(invokeCalls("audio_play")).toHaveLength(1);
+      expect(screen.getByRole("button", { name: "Play playback" })).toBeInTheDocument();
+      expect(document.querySelector("audio[src]")).toBeNull();
+    } finally {
+      releaseHandoffStop();
+      invoke.mockImplementation(originalInvoke);
+      restoreTauriRuntime();
+    }
   });
 
   it("rewinds stem playback after buffered audio reaches the end", async () => {

--- a/apps/desktop/src/App.project-precount.test.tsx
+++ b/apps/desktop/src/App.project-precount.test.tsx
@@ -7,6 +7,8 @@ import {
   getMockInvoke,
   markAudioReady,
   emitMockNativePlaybackPosition,
+  emitMockNativeAudioCue,
+  emitMockNativeAudioTerminal,
   resetAppTestHarness,
   renderApp,
   setMockNativeAudioState,
@@ -125,6 +127,12 @@ function audioPlayStartTime(callIndex = 0) {
   return payload?.startTimeSeconds ?? null;
 }
 
+function nativeControlRevision(command: string, callIndex = 0) {
+  const call = invokeCalls(command)[callIndex];
+  return (call?.[1] as { payload?: { timelineRevision?: number } } | undefined)?.payload
+    ?.timelineRevision;
+}
+
 function expectPrecountClicksCancelled(
   audioContext: ReturnType<typeof getMockAudioContexts>[number] | undefined,
 ) {
@@ -135,12 +143,28 @@ function expectPrecountClicksCancelled(
   });
 }
 
+type NativeDeferredMetadata = {
+  leaseId?: string;
+  generation?: number;
+  timelineRevision?: number;
+  nativeTimeUs?: number;
+};
+
 function createDeferred<T>(_type?: T) {
   void _type;
-  let resolve: (value: T) => void = () => undefined;
+  let resolve: (value: T & NativeDeferredMetadata) => void = () => undefined;
   let reject: (error: Error) => void = () => undefined;
-  const promise = new Promise<T>((nextResolve, nextReject) => {
-    resolve = nextResolve;
+  const promise = new Promise<T & NativeDeferredMetadata>((nextResolve, nextReject) => {
+    resolve = (value) => {
+      const metadata = value as Record<string, unknown>;
+      nextResolve({
+        ...(value as object),
+        leaseId: metadata.leaseId ?? "project-playback",
+        generation: metadata.generation ?? 1,
+        timelineRevision: metadata.timelineRevision ?? 1,
+        nativeTimeUs: metadata.nativeTimeUs ?? 1,
+      } as T & NativeDeferredMetadata);
+    };
     reject = nextReject;
   });
   return { promise, reject, resolve };
@@ -743,7 +767,12 @@ describe("Desktop app project playback pre-count", () => {
       if (!originalInvoke) {
         throw new Error(`Unhandled invoke command ${command}`);
       }
-      return originalInvoke(command, args);
+      const result = await originalInvoke(command, args);
+      if (command === "audio_stop") {
+        const revision = nativeControlRevision("audio_stop") ?? 1;
+        return { ...(result as object), timelineRevision: revision + 1 };
+      }
+      return result;
     });
 
     await user.click(screen.getByRole("button", { name: "Play playback" }));
@@ -751,7 +780,8 @@ describe("Desktop app project playback pre-count", () => {
     expect(audioPlayStartTime()).toBeCloseTo(18.75, 3);
 
     await user.click(screen.getByRole("button", { name: "Stop playback" }));
-    await waitFor(() => expect(invokeCalls("audio_stop")).toHaveLength(1));
+    await flushMicrotasks();
+    expect(invokeCalls("audio_stop")).toHaveLength(0);
     await waitFor(() =>
       expect(readPlaybackE2ETelemetry()).toMatchObject({
         activePath: "none",
@@ -770,14 +800,18 @@ describe("Desktop app project playback pre-count", () => {
       fallbackReason: null,
       lanes: [],
       bufferHealth: [],
+      timelineRevision: 2,
     });
-    await waitFor(() => expect(invokeCalls("audio_stop")).toHaveLength(2));
+    await waitFor(() => expect(invokeCalls("audio_stop")).toHaveLength(1));
+    expect(nativeControlRevision("audio_stop")).toBe(2);
     expect(readPlaybackE2ETelemetry()).toMatchObject({
       activePath: "none",
       positionSeconds: 0,
       transportState: "stopped",
     });
     expect(screen.getByRole("button", { name: "Play playback" })).toBeInTheDocument();
+    expect(invokeCalls("audio_play")).toHaveLength(1);
+    expect(document.querySelector("audio[src]")).toBeNull();
     if (originalInvoke) {
       invoke.mockImplementation(originalInvoke);
     }
@@ -827,7 +861,12 @@ describe("Desktop app project playback pre-count", () => {
       if (!originalInvoke) {
         throw new Error(`Unhandled invoke command ${command}`);
       }
-      return originalInvoke(command, args);
+      const result = await originalInvoke(command, args);
+      if (command === "audio_stop") {
+        const revision = nativeControlRevision("audio_stop") ?? 1;
+        return { ...(result as object), timelineRevision: revision + 1 };
+      }
+      return result;
     });
 
     await user.click(screen.getByRole("button", { name: "Play playback" }));
@@ -835,7 +874,8 @@ describe("Desktop app project playback pre-count", () => {
     expect(audioPlayStartTime()).toBeCloseTo(18.75, 3);
 
     await user.click(screen.getByRole("button", { name: "Stop playback" }));
-    await waitFor(() => expect(invokeCalls("audio_stop")).toHaveLength(1));
+    await flushMicrotasks();
+    expect(invokeCalls("audio_stop")).toHaveLength(0);
     await waitFor(() =>
       expect(readPlaybackE2ETelemetry()).toMatchObject({
         activePath: "none",
@@ -845,6 +885,22 @@ describe("Desktop app project playback pre-count", () => {
     );
 
     await user.click(screen.getByRole("button", { name: "Play playback" }));
+    await flushMicrotasks();
+    expect(invokeCalls("audio_play")).toHaveLength(1);
+    firstPlayDeferred.resolve({
+      sessionId: latestNativeSessionId(),
+      state: "playing",
+      positionSeconds: 18.75,
+      durationSeconds: 182,
+      playbackRate: 1,
+      nativePlaybackSupported: true,
+      fallbackReason: null,
+      lanes: [],
+      bufferHealth: [],
+      timelineRevision: 2,
+    });
+    await waitFor(() => expect(invokeCalls("audio_stop")).toHaveLength(1));
+    expect(nativeControlRevision("audio_stop")).toBe(2);
     await waitFor(() => expect(invokeCalls("audio_play")).toHaveLength(2));
     expect(audioPlayStartTime(1)).toBe(0);
     secondPlayDeferred.resolve({
@@ -857,17 +913,7 @@ describe("Desktop app project playback pre-count", () => {
       fallbackReason: null,
       lanes: [],
       bufferHealth: [],
-    });
-    firstPlayDeferred.resolve({
-      sessionId: latestNativeSessionId(),
-      state: "playing",
-      positionSeconds: 18.75,
-      durationSeconds: 182,
-      playbackRate: 1,
-      nativePlaybackSupported: true,
-      fallbackReason: null,
-      lanes: [],
-      bufferHealth: [],
+      timelineRevision: 4,
     });
     await waitFor(() =>
       expect(readPlaybackE2ETelemetry()).toMatchObject({
@@ -932,14 +978,20 @@ describe("Desktop app project playback pre-count", () => {
       if (!originalInvoke) {
         throw new Error(`Unhandled invoke command ${command}`);
       }
-      return originalInvoke(command, args);
+      const result = await originalInvoke(command, args);
+      if (command === "audio_stop") {
+        const revision = nativeControlRevision("audio_stop") ?? 1;
+        return { ...(result as object), timelineRevision: revision + 1 };
+      }
+      return result;
     });
 
     await user.click(screen.getByRole("button", { name: "Play playback" }));
     await waitFor(() => expect(invokeCalls("audio_play")).toHaveLength(1));
 
     await user.click(screen.getByRole("button", { name: "Stop playback" }));
-    await waitFor(() => expect(invokeCalls("audio_stop")).toHaveLength(1));
+    await flushMicrotasks();
+    expect(invokeCalls("audio_stop")).toHaveLength(0);
     await waitFor(() =>
       expect(readPlaybackE2ETelemetry()).toMatchObject({
         activePath: "none",
@@ -949,6 +1001,11 @@ describe("Desktop app project playback pre-count", () => {
     );
 
     await user.click(screen.getByRole("button", { name: "Play playback" }));
+    await flushMicrotasks();
+    expect(invokeCalls("audio_play")).toHaveLength(1);
+    firstPlayDeferred.reject(new Error("stale native play failed"));
+    await waitFor(() => expect(invokeCalls("audio_stop")).toHaveLength(1));
+    expect(nativeControlRevision("audio_stop")).toBe(1);
     await waitFor(() => expect(invokeCalls("audio_play")).toHaveLength(2));
     secondPlayDeferred.resolve({
       sessionId: latestNativeSessionId(),
@@ -960,6 +1017,7 @@ describe("Desktop app project playback pre-count", () => {
       fallbackReason: null,
       lanes: [],
       bufferHealth: [],
+      timelineRevision: 3,
     });
     await waitFor(() =>
       expect(readPlaybackE2ETelemetry()).toMatchObject({
@@ -968,8 +1026,6 @@ describe("Desktop app project playback pre-count", () => {
         transportState: "playing",
       }),
     );
-
-    firstPlayDeferred.reject(new Error("stale native play failed"));
     await flushMicrotasks();
     expect(invokeCalls("audio_stop")).toHaveLength(1);
     expect(readPlaybackE2ETelemetry()).toMatchObject({
@@ -981,6 +1037,25 @@ describe("Desktop app project playback pre-count", () => {
     if (originalInvoke) {
       invoke.mockImplementation(originalInvoke);
     }
+    restoreTauriRuntime();
+  });
+
+  it("records terminal cancellation for an active native pre-count", async () => {
+    const restoreTauriRuntime = enableNativePlayback();
+    const user = userEvent.setup();
+    setupTempoAnalysis();
+    renderApp(["/projects/proj_123"]);
+    await screen.findByRole("heading", { name: "Demo Song" });
+    await openPlaybackWorkspace(user);
+    await user.click(screen.getByLabelText("Enable pre-count"));
+    await user.click(screen.getByRole("button", { name: "Play playback" }));
+    await waitFor(() => expect(readPlaybackE2ETelemetry().countIn.active).toBe(true));
+    act(() => emitMockNativeAudioTerminal({
+      generation: 1, code: "output_stream_failure", nativeTimeUs: 3_000_000,
+    }));
+    expect(readPlaybackE2ETelemetry().countIn).toMatchObject({ active: false, lastCancelled: {
+      reason: "unavailable", cancelledAtContextTimeSeconds: 3,
+    } });
     restoreTauriRuntime();
   });
 
@@ -1027,14 +1102,20 @@ describe("Desktop app project playback pre-count", () => {
       if (!originalInvoke) {
         throw new Error(`Unhandled invoke command ${command}`);
       }
-      return originalInvoke(command, args);
+      const result = await originalInvoke(command, args);
+      if (command === "audio_stop") {
+        const revision = nativeControlRevision("audio_stop") ?? 1;
+        return { ...(result as object), timelineRevision: revision + 1 };
+      }
+      return result;
     });
 
     await user.click(screen.getByRole("button", { name: "Play playback" }));
     await waitFor(() => expect(invokeCalls("audio_play")).toHaveLength(1));
 
     await user.click(screen.getByRole("button", { name: "Stop playback" }));
-    await waitFor(() => expect(invokeCalls("audio_stop")).toHaveLength(1));
+    await flushMicrotasks();
+    expect(invokeCalls("audio_stop")).toHaveLength(0);
     await waitFor(() =>
       expect(readPlaybackE2ETelemetry()).toMatchObject({
         activePath: "none",
@@ -1044,8 +1125,8 @@ describe("Desktop app project playback pre-count", () => {
     );
 
     await user.click(screen.getByRole("button", { name: "Play playback" }));
-    await waitFor(() => expect(invokeCalls("audio_play")).toHaveLength(2));
-    expect(audioPlayStartTime(1)).toBe(0);
+    await flushMicrotasks();
+    expect(invokeCalls("audio_play")).toHaveLength(1);
 
     firstPlayDeferred.resolve({
       sessionId: latestNativeSessionId(),
@@ -1057,9 +1138,12 @@ describe("Desktop app project playback pre-count", () => {
       fallbackReason: null,
       lanes: [],
       bufferHealth: [],
+      timelineRevision: 2,
     });
-    await flushMicrotasks();
-    expect(invokeCalls("audio_stop")).toHaveLength(1);
+    await waitFor(() => expect(invokeCalls("audio_stop")).toHaveLength(1));
+    expect(nativeControlRevision("audio_stop")).toBe(2);
+    await waitFor(() => expect(invokeCalls("audio_play")).toHaveLength(2));
+    expect(audioPlayStartTime(1)).toBe(0);
     expect(readPlaybackE2ETelemetry()).toMatchObject({
       activePath: "none",
       positionSeconds: 0,
@@ -1076,6 +1160,7 @@ describe("Desktop app project playback pre-count", () => {
       fallbackReason: null,
       lanes: [],
       bufferHealth: [],
+      timelineRevision: 4,
     });
     await waitFor(() =>
       expect(readPlaybackE2ETelemetry()).toMatchObject({
@@ -1135,14 +1220,20 @@ describe("Desktop app project playback pre-count", () => {
       if (!originalInvoke) {
         throw new Error(`Unhandled invoke command ${command}`);
       }
-      return originalInvoke(command, args);
+      const result = await originalInvoke(command, args);
+      if (command === "audio_stop") {
+        const revision = nativeControlRevision("audio_stop", invokeCalls("audio_stop").length - 1) ?? 1;
+        return { ...(result as object), timelineRevision: revision + 1 };
+      }
+      return result;
     });
 
     await user.click(screen.getByRole("button", { name: "Play playback" }));
     await waitFor(() => expect(invokeCalls("audio_play")).toHaveLength(1));
 
     await user.click(screen.getByRole("button", { name: "Stop playback" }));
-    await waitFor(() => expect(invokeCalls("audio_stop")).toHaveLength(1));
+    await flushMicrotasks();
+    expect(invokeCalls("audio_stop")).toHaveLength(0);
     await waitFor(() =>
       expect(readPlaybackE2ETelemetry()).toMatchObject({
         activePath: "none",
@@ -1152,7 +1243,8 @@ describe("Desktop app project playback pre-count", () => {
     );
 
     await user.click(screen.getByRole("button", { name: "Play playback" }));
-    await waitFor(() => expect(invokeCalls("audio_play")).toHaveLength(2));
+    await flushMicrotasks();
+    expect(invokeCalls("audio_play")).toHaveLength(1);
 
     firstPlayDeferred.resolve({
       sessionId: latestNativeSessionId(),
@@ -1164,12 +1256,15 @@ describe("Desktop app project playback pre-count", () => {
       fallbackReason: null,
       lanes: [],
       bufferHealth: [],
+      timelineRevision: 2,
     });
-    await flushMicrotasks();
-    expect(invokeCalls("audio_stop")).toHaveLength(1);
+    await waitFor(() => expect(invokeCalls("audio_stop")).toHaveLength(1));
+    expect(nativeControlRevision("audio_stop")).toBe(2);
+    await waitFor(() => expect(invokeCalls("audio_play")).toHaveLength(2));
 
     secondPlayDeferred.reject(new Error("native play failed"));
     await waitFor(() => expect(invokeCalls("audio_stop")).toHaveLength(2));
+    expect(nativeControlRevision("audio_stop", 1)).toBe(3);
     expect(readPlaybackE2ETelemetry()).toMatchObject({
       activePath: "none",
       positionSeconds: 0,
@@ -1179,6 +1274,54 @@ describe("Desktop app project playback pre-count", () => {
     if (originalInvoke) {
       invoke.mockImplementation(originalInvoke);
     }
+    restoreTauriRuntime();
+  });
+
+  it("publishes cancellation and blocks late completion when native stop rejects", async () => {
+    const restoreTauriRuntime = enableNativePlayback();
+    const user = userEvent.setup();
+    setupTempoAnalysis();
+    renderApp(["/projects/proj_123"]);
+
+    expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
+    await openPlaybackWorkspace(user);
+    await user.click(screen.getByLabelText("Enable pre-count"));
+    await user.click(screen.getByRole("button", { name: "Play playback" }));
+    await waitFor(() => expect(invokeCalls("audio_play")).toHaveLength(1));
+    expect(readPlaybackE2ETelemetry().countIn.lastScheduled).toMatchObject({
+      activePath: "native", clickCount: 4, scheduledAtContextTimeSeconds: 0.000001,
+    });
+    act(() => emitMockNativeAudioCue({
+      generation: 1, revision: 1, cueIndex: 0, kind: "precount_beat",
+      accent: false, gain: 1, scheduledNativeTimeUs: 1_000_000,
+      actualNativeTimeUs: 1_000_010, insertionSequence: 1,
+    }));
+    expect(readPlaybackE2ETelemetry().countIn.lastScheduled).toMatchObject({
+      firstClickTimeSeconds: 1, playbackStartTimeSeconds: 3,
+    });
+
+    const invoke = getMockInvoke();
+    const originalInvoke = invoke.getMockImplementation();
+    invoke.mockImplementation(async (command, args) => {
+      if (command === "audio_stop") throw new Error("native stop failed");
+      return originalInvoke!(command, args);
+    });
+
+    await user.click(screen.getByRole("button", { name: "Stop playback" }));
+    await waitFor(() => expect(invokeCalls("audio_stop")).toHaveLength(1));
+    expect(readPlaybackE2ETelemetry().countIn.lastCancelled).toMatchObject({
+      reason: "playback-stopped", trigger: "song-start",
+    });
+    expect(readPlaybackE2ETelemetry().countIn.lastCancelled?.cancelledAtContextTimeSeconds)
+      .toEqual(expect.any(Number));
+    act(() => emitMockNativeAudioCue({
+      generation: 1, revision: 1, cueIndex: 4, kind: "precount_completion",
+      accent: false, gain: 1, scheduledNativeTimeUs: 2_000_000,
+      actualNativeTimeUs: 2_000_000, insertionSequence: 5,
+    }));
+    expect(invokeCalls("audio_play")).toHaveLength(1);
+    expect(screen.getByRole("button", { name: "Play playback" })).toBeInTheDocument();
+    invoke.mockImplementation(originalInvoke!);
     restoreTauriRuntime();
   });
 
@@ -1195,34 +1338,28 @@ describe("Desktop app project playback pre-count", () => {
     setPlaybackPosition("24.5");
     await user.click(screen.getByRole("button", { name: "Set loop end" }));
 
-    vi.useFakeTimers();
     fireEvent.click(screen.getByLabelText("Enable loop pre-count"));
     fireEvent.click(screen.getByRole("button", { name: "Play playback" }));
     await flushMicrotasks();
 
-    const audioContext = getMockAudioContexts()[0];
-    expect(audioContext?.createdOscillators).toHaveLength(4);
-    expect(invokeCalls("audio_play")).toHaveLength(0);
-    let telemetry = readPlaybackE2ETelemetry();
-    expect(telemetry.countIn.active).toBe(true);
-    expect(telemetry.countIn.lastScheduled).toMatchObject({
-      startTimeSeconds: 12.25,
-      trigger: "loop-start",
-    });
-
-    await act(async () => {
-      vi.advanceTimersByTime(2035);
-    });
-    await flushMicrotasks();
     expect(invokeCalls("audio_play")).toHaveLength(1);
     expect(audioPlayStartTime()).toBeCloseTo(12.25, 3);
+    expect(invokeCalls("audio_play")[0]?.[1]).toMatchObject({
+      payload: { precount: { intervalsSeconds: [0.5, 0.5, 0.5, 0.5] } },
+    });
+    expect(getMockAudioContexts()).toHaveLength(0);
+    act(() => emitMockNativeAudioCue({
+      generation: 1, revision: 1, cueIndex: 4, kind: "precount_completion",
+      accent: false, gain: 1, scheduledNativeTimeUs: 2_000_000,
+      actualNativeTimeUs: 2_000_000, insertionSequence: 5,
+    }));
     expect(readPlaybackE2ETelemetry()).toMatchObject({
       activePath: "native",
+      countIn: { active: false, lastFired: { firedAtContextTimeSeconds: 2 } },
       positionSeconds: 12.25,
       transportState: "playing",
     });
 
-    const firstSequence = readPlaybackE2ETelemetry().countIn.lastScheduled?.sequence;
     act(() => {
       emitMockNativePlaybackPosition({
         sessionId: latestNativeSessionId(),
@@ -1233,34 +1370,109 @@ describe("Desktop app project playback pre-count", () => {
     });
     await flushMicrotasks();
 
-    expect(
-      getMockAudioContexts().flatMap((context) => context.createdOscillators),
-    ).toHaveLength(8);
     expect(invokeCalls("audio_stop")).toHaveLength(1);
-    expect(invokeCalls("audio_play")).toHaveLength(1);
-    telemetry = readPlaybackE2ETelemetry();
-    expect(telemetry.activePath).toBe("none");
-    expect(telemetry.transportState).toBe("stopped");
-    expect(telemetry.countIn.active).toBe(true);
-    expect(telemetry.countIn.lastScheduled).toMatchObject({
-      startTimeSeconds: 12.25,
-      trigger: "loop-start",
-    });
-    expect(telemetry.countIn.lastScheduled?.sequence).not.toBe(firstSequence);
-
-    await act(async () => {
-      vi.advanceTimersByTime(2035);
-    });
-    await flushMicrotasks();
     expect(invokeCalls("audio_play")).toHaveLength(2);
     expect(audioPlayStartTime(1)).toBeCloseTo(12.25, 3);
+    act(() => emitMockNativeAudioCue({
+      generation: 1, revision: 1, cueIndex: 4, kind: "precount_completion",
+      accent: false, gain: 1, scheduledNativeTimeUs: 4_000_000,
+      actualNativeTimeUs: 4_000_000, insertionSequence: 10,
+    }));
     expect(readPlaybackE2ETelemetry()).toMatchObject({
       activePath: "native",
       positionSeconds: 12.25,
       transportState: "playing",
     });
-    vi.useRealTimers();
     restoreTauriRuntime();
+  }, 15000);
+
+  it("cancels a native wrap pre-count when the active loop is cleared", async () => {
+    const restoreTauriRuntime = enableNativePlayback();
+    const user = userEvent.setup();
+    setupTempoAnalysis();
+    renderApp(["/projects/proj_123"]);
+
+    expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
+    await openPlaybackWorkspace(user);
+    setPlaybackPosition("12.25");
+    await user.click(screen.getByRole("button", { name: "Set loop start" }));
+    setPlaybackPosition("24.5");
+    await user.click(screen.getByRole("button", { name: "Set loop end" }));
+    fireEvent.click(screen.getByLabelText("Enable loop pre-count"));
+    fireEvent.click(screen.getByRole("button", { name: "Play playback" }));
+    await flushMicrotasks();
+    act(() => emitMockNativeAudioCue({
+      generation: 1, revision: 1, cueIndex: 4, kind: "precount_completion",
+      accent: false, gain: 1, scheduledNativeTimeUs: 2_000_000,
+      actualNativeTimeUs: 2_000_000, insertionSequence: 5,
+    }));
+
+    act(() => emitMockNativePlaybackPosition({
+      sessionId: latestNativeSessionId(), positionSeconds: 24.5,
+      durationSeconds: 182, state: "playing",
+    }));
+    await flushMicrotasks();
+    expect(invokeCalls("audio_play")).toHaveLength(2);
+    expect(readPlaybackE2ETelemetry().countIn.active).toBe(true);
+
+    fireEvent.click(screen.getByRole("button", { name: "Clear loop" }));
+    await flushMicrotasks();
+
+    expect(invokeCalls("audio_stop")).toHaveLength(2);
+    expect(invokeCalls("audio_play")).toHaveLength(3);
+    expect(readPlaybackE2ETelemetry()).toMatchObject({
+      activePath: "native",
+      countIn: { active: false, lastCancelled: { trigger: "loop-start" } },
+      loopRange: null,
+      transportState: "playing",
+    });
+    restoreTauriRuntime();
+  }, 15000);
+
+  it("cancels a Web wrap pre-count when the active loop is cleared", async () => {
+    const user = userEvent.setup();
+    setupTempoAnalysis();
+    renderApp(["/projects/proj_123"]);
+
+    expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
+    await openPlaybackWorkspace(user);
+    setPlaybackPosition("12.25");
+    await user.click(screen.getByRole("button", { name: "Set loop start" }));
+    setPlaybackPosition("24.5");
+    await user.click(screen.getByRole("button", { name: "Set loop end" }));
+    const sourceAudio = findAudioByArtifactId("art_source");
+    markAudioReady(sourceAudio);
+    vi.useFakeTimers();
+    fireEvent.click(screen.getByLabelText("Enable loop pre-count"));
+    fireEvent.click(screen.getByRole("button", { name: "Play playback" }));
+    await flushMicrotasks();
+    act(() => vi.advanceTimersByTime(2035));
+    await flushMicrotasks();
+
+    act(() => {
+      sourceAudio.currentTime = 24.5;
+      fireEvent.timeUpdate(sourceAudio);
+    });
+    await flushMicrotasks();
+    expect(readPlaybackE2ETelemetry().countIn.active).toBe(true);
+
+    fireEvent.click(screen.getByRole("button", { name: "Clear loop" }));
+    await flushMicrotasks();
+
+    const audioContext = getMockAudioContexts()[0];
+    expect(audioContext?.createdOscillators).toHaveLength(8);
+    audioContext?.createdOscillators.slice(-4).forEach((oscillator) => {
+      expect(oscillator.stop).toHaveBeenCalledTimes(2);
+      expect(oscillator.disconnect).toHaveBeenCalledTimes(1);
+    });
+    expect(readPlaybackE2ETelemetry()).toMatchObject({
+      activePath: "web-audio",
+      countIn: { active: false, lastCancelled: { trigger: "loop-start" } },
+      loopRange: null,
+      transportState: "playing",
+    });
+    expect(screen.getByRole("button", { name: "Pause playback" })).toBeInTheDocument();
+    vi.useRealTimers();
   }, 15000);
 
   it("uses timing-grid spacing for loop pre-counts when available", async () => {

--- a/apps/desktop/src/App.project-tempo.test.tsx
+++ b/apps/desktop/src/App.project-tempo.test.tsx
@@ -106,6 +106,7 @@ function readPlaybackE2ETelemetry() {
 describe("Desktop app project playback tempo", () => {
   beforeEach(resetAppTestHarness);
   afterEach(() => {
+    vi.unstubAllEnvs();
     delete (window as Window & { __TAURI_INTERNALS__?: unknown }).__TAURI_INTERNALS__;
   });
 
@@ -274,7 +275,7 @@ describe("Desktop app project playback tempo", () => {
     restoreTauriRuntime();
   });
 
-  it("falls back to Web Audio when native play reports an underrun fallback", async () => {
+  it("does not fall back when native play reports an underrun", async () => {
     const restoreTauriRuntime = mockTauriRuntime();
     const user = userEvent.setup();
     setupTempoAnalysis(120);
@@ -299,22 +300,18 @@ describe("Desktop app project playback tempo", () => {
         getMockInvoke().mock.calls.some(([command]) => command === "audio_play"),
       ).toBe(true),
     );
-    await waitFor(() => {
-      expect(findAudioByArtifactId("art_source")).toBeInTheDocument();
-    });
-    const sourceAudio = findAudioByArtifactId("art_source");
-    markAudioReady(sourceAudio);
     await waitFor(() =>
-      expect(getMockAudioContexts().flatMap((context) => context.createdSources)).toHaveLength(1),
+      expect(readPlaybackE2ETelemetry()).toMatchObject({
+        activePath: "none",
+        transportState: "stopped",
+      }),
     );
+    expect(document.querySelector("audio[data-artifact-id='art_source']")).toBeNull();
+    expect(getMockAudioContexts()).toHaveLength(0);
     expect(window.localStorage.getItem("tuneforge.playback-native-error")).toBe(
       "Native playback underrun persisted; falling back to Web Audio.",
     );
-    expect(readPlaybackE2ETelemetry()).toMatchObject({
-      activePath: "web-audio",
-      transportState: "playing",
-    });
-    expect(screen.getByRole("button", { name: "Pause playback" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Play playback" })).toBeInTheDocument();
     restoreTauriRuntime();
   });
 
@@ -368,6 +365,7 @@ describe("Desktop app project playback tempo", () => {
         }),
       );
 
+      vi.stubEnv("VITE_TUNEFORGE_FORCE_WEB_AUDIO", "1");
       emitMockNativePlaybackError({
         sessionId: latestNativeSessionId(),
         code: "output_stream_failure",
@@ -396,7 +394,7 @@ describe("Desktop app project playback tempo", () => {
     }
   });
 
-  it("falls back to Web Audio at the current native time after a runtime underrun error", async () => {
+  it("stops without fallback after a runtime underrun error", async () => {
     const restoreTauriRuntime = mockTauriRuntime();
     const user = userEvent.setup();
     setupTempoAnalysis(120);
@@ -423,17 +421,21 @@ describe("Desktop app project playback tempo", () => {
     );
 
     const sessionId = latestNativeSessionId();
-    emitMockNativePlaybackPosition({
-      sessionId,
-      positionSeconds: 42.25,
-      durationSeconds: 182,
-      state: "playing",
+    act(() => {
+      emitMockNativePlaybackPosition({
+        sessionId,
+        positionSeconds: 42.25,
+        durationSeconds: 182,
+        state: "playing",
+      });
     });
     await waitFor(() => expect(screen.getByLabelText("Playback position")).toHaveValue("42.25"));
 
-    emitMockNativePlaybackError({
-      sessionId: "stale-native-session",
-      code: "output_stream_failure",
+    act(() => {
+      emitMockNativePlaybackError({
+        sessionId: "stale-native-session",
+        code: "output_stream_failure",
+      });
     });
     await waitFor(() => {
       expect(
@@ -442,29 +444,25 @@ describe("Desktop app project playback tempo", () => {
     });
     expect(window.localStorage.getItem("tuneforge.playback-native-error")).toBeNull();
 
-    emitMockNativePlaybackError({
-      sessionId,
-      code: "output_stream_failure",
+    act(() => {
+      emitMockNativePlaybackError({
+        sessionId,
+        code: "output_stream_failure",
+      });
     });
 
-    await waitFor(() => {
-      expect(findAudioByArtifactId("art_source")).toBeInTheDocument();
-    });
-    const sourceAudio = findAudioByArtifactId("art_source");
-    markAudioReady(sourceAudio);
     await waitFor(() =>
-      expect(getMockAudioContexts().flatMap((context) => context.createdSources)).toHaveLength(1),
+      expect(readPlaybackE2ETelemetry()).toMatchObject({
+        activePath: "none",
+        transportState: "stopped",
+      }),
     );
-    expect(getMockAudioContexts().flatMap((context) => context.createdSources)[0]?.start.mock.calls[0]?.[1]).toBeCloseTo(
-      42.25,
-      3,
-    );
+    expect(document.querySelector("audio[data-artifact-id='art_source']")).toBeNull();
+    expect(getMockAudioContexts()).toHaveLength(0);
+    expect(screen.getByLabelText("Playback position")).toHaveValue("42.25");
     expect(window.localStorage.getItem("tuneforge.playback-native-error")).toBe(
       "Native playback output failed.",
     );
-    expect(
-      getMockInvoke().mock.calls.some(([command]) => command === "audio_stop"),
-    ).toBe(true);
     restoreTauriRuntime();
   });
 

--- a/apps/desktop/src/App.tools-metronome.test.tsx
+++ b/apps/desktop/src/App.tools-metronome.test.tsx
@@ -4,16 +4,45 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   advanceMockAnimationFrames,
   findAudioByArtifactId,
+  emitMockNativeAudioCue,
+  emitMockSystemMediaPlaybackControl,
   getMockAudioContexts,
+  getMockInvoke,
   markAudioReady,
   resetAppTestHarness,
   renderApp,
+  setMockNativeAudioState,
   setProjectAnalysis,
   setProjects,
 } from "./test/appTestHarness";
 
 function getMetronomeAudioContext() {
   return getMockAudioContexts().find((context) => context.createdOscillators.length > 0);
+}
+
+function createDeferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((nextResolve) => { resolve = nextResolve; });
+  return { promise, resolve };
+}
+
+function latestNativeSessionId() {
+  const prepareCall = [...getMockInvoke().mock.calls]
+    .reverse()
+    .find(([command]) => command === "audio_prepare_session");
+  const payload = (prepareCall?.[1] as { payload?: { sessionId?: string } } | undefined)?.payload;
+  if (!payload?.sessionId) {
+    throw new Error("Native audio session was not prepared.");
+  }
+  return payload.sessionId;
+}
+
+function readPlaybackE2ETelemetry() {
+  const telemetry = window.__TUNEFORGE_PLAYBACK_E2E__?.read();
+  if (!telemetry) {
+    throw new Error("Playback E2E telemetry bridge was not exposed.");
+  }
+  return telemetry;
 }
 
 const timingAnalysis = {
@@ -232,6 +261,230 @@ describe("Desktop app tools metronome", () => {
         ) ?? [];
       expect(frequencies).toContain(1760);
     });
+  });
+
+  it("schedules normal-Tauri follow cues with the project control tuple", async () => {
+    (window as Window & { __TAURI_INTERNALS__?: unknown }).__TAURI_INTERNALS__ = {};
+    setMockNativeAudioState({ capabilities: {
+      nativePlaybackSupported: true, fallbackRequired: false,
+      fallbackReason: null, backend: "desktop-cpal",
+    } });
+    setProjectAnalysis("proj_123", timingAnalysis);
+    const user = userEvent.setup();
+    renderApp(["/projects/proj_123"]);
+    expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
+    await user.click(screen.getByRole("tab", { name: "Playback" }));
+    await user.click(screen.getByRole("button", { name: "Play playback" }));
+    await waitFor(() => expect(getMockInvoke().mock.calls.some(([name]) => name === "audio_play")).toBe(true));
+    await user.click(screen.getByRole("link", { name: "Tools" }));
+    await user.click(await screen.findByRole("tab", { name: "Metronome" }));
+    await user.click(screen.getByLabelText("Follow project playback"));
+    await waitFor(() => {
+      expect(getMockInvoke().mock.calls.some(([name]) => name === "audio_get_session_snapshot")).toBe(true);
+      const call = getMockInvoke().mock.calls.find(([name]) => name === "audio_schedule_cues");
+      const payload = (call?.[1] as { payload?: { cues?: unknown[] } })?.payload;
+      expect(payload).toMatchObject({
+        leaseId: "project-playback", generation: 1, timelineRevision: 1,
+      });
+      expect(payload?.cues?.[0]).toMatchObject({
+        kind: "metronome", positionSeconds: 0, accent: true, gain: 0.8,
+      });
+    });
+    expect(getMockAudioContexts()).toHaveLength(0);
+    act(() => emitMockNativeAudioCue({
+      generation: 1, revision: 1, cueIndex: 0, kind: "metronome",
+      accent: true, gain: 0.8, scheduledNativeTimeUs: 10,
+      actualNativeTimeUs: 10, insertionSequence: 1,
+    }));
+    const initialPlayCount = getMockInvoke().mock.calls.filter(([name]) => name === "audio_play").length;
+    act(() => emitMockSystemMediaPlaybackControl({ action: "pause" }));
+    await waitFor(() => expect(getMockInvoke().mock.calls.some(([name]) => name === "audio_pause")).toBe(true));
+    act(() => emitMockSystemMediaPlaybackControl({ action: "play" }));
+    await waitFor(() => expect(getMockInvoke().mock.calls.filter(([name]) => name === "audio_play")).toHaveLength(initialPlayCount + 1));
+    expect(getMockInvoke().mock.calls.filter(([name]) => name === "audio_schedule_cues")).toHaveLength(1);
+    const resumeCalls = getMockInvoke().mock.calls.filter(([name]) => name === "audio_play");
+    const resumePayload = (resumeCalls[resumeCalls.length - 1]?.[1] as {
+      payload?: { startTimeSeconds?: number | null; metronomeCues?: Array<{ positionSeconds: number }> };
+    })?.payload;
+    expect(resumePayload?.startTimeSeconds).toBe(0);
+    expect(resumePayload?.metronomeCues?.[0]?.positionSeconds).toBe(0);
+
+    let scheduleCount = 1;
+    await user.clear(screen.getByLabelText("Tempo BPM"));
+    await user.type(screen.getByLabelText("Tempo BPM"), "90{Enter}");
+    await waitFor(() => expect(getMockInvoke().mock.calls.filter(([name]) => name === "audio_schedule_cues").length).toBeGreaterThan(scheduleCount));
+    scheduleCount = getMockInvoke().mock.calls.filter(([name]) => name === "audio_schedule_cues").length;
+    fireEvent.change(screen.getByLabelText("Beats per bar"), { target: { value: "3" } });
+    await waitFor(() => expect(getMockInvoke().mock.calls.filter(([name]) => name === "audio_schedule_cues").length).toBeGreaterThan(scheduleCount));
+    scheduleCount = getMockInvoke().mock.calls.filter(([name]) => name === "audio_schedule_cues").length;
+    await user.click(screen.getByLabelText("Accent first beat"));
+    await waitFor(() => expect(getMockInvoke().mock.calls.filter(([name]) => name === "audio_schedule_cues").length).toBeGreaterThan(scheduleCount));
+    scheduleCount = getMockInvoke().mock.calls.filter(([name]) => name === "audio_schedule_cues").length;
+    fireEvent.change(screen.getByLabelText("Metronome volume"), { target: { value: "0.42" } });
+    await waitFor(() => expect(getMockInvoke().mock.calls.filter(([name]) => name === "audio_schedule_cues").length).toBeGreaterThan(scheduleCount));
+    const replacement = [...getMockInvoke().mock.calls].reverse().find(([name]) => name === "audio_schedule_cues");
+    expect((replacement?.[1] as { payload?: { cues?: Array<{ accent: boolean; gain: number }> } })
+      ?.payload?.cues?.[0]).toMatchObject({ accent: false, gain: 0.42 });
+
+    await user.click(screen.getByLabelText("Follow project playback"));
+    await waitFor(() => expect(getMockInvoke().mock.calls.some(([name, args]) =>
+      name === "audio_cancel_cues" && (args as { kind?: string })?.kind === "metronome",
+    )).toBe(true));
+    const [schedule, cancel] = ["audio_schedule_cues", "audio_cancel_cues"].map((name) =>
+      (getMockInvoke().mock.calls.find(([command]) => command === name)?.[1] as {
+        payload?: { operationId?: string };
+      })?.payload?.operationId,
+    );
+    expect(cancel).not.toBe(schedule);
+    act(() => emitMockSystemMediaPlaybackControl({ action: "pause" }));
+    await waitFor(() => expect(getMockInvoke().mock.calls.filter(([name]) => name === "audio_pause")).toHaveLength(2));
+    act(() => emitMockSystemMediaPlaybackControl({ action: "play" }));
+    await waitFor(() => expect(getMockInvoke().mock.calls.filter(([name]) => name === "audio_play")).toHaveLength(initialPlayCount + 2));
+    const disabledCalls = getMockInvoke().mock.calls.filter(([name]) => name === "audio_play");
+    expect((disabledCalls[disabledCalls.length - 1]?.[1] as {
+      payload?: { metronomeCues?: unknown };
+    })?.payload?.metronomeCues).toBeUndefined();
+    delete (window as Window & { __TAURI_INTERNALS__?: unknown }).__TAURI_INTERNALS__;
+  });
+
+  it("replaces followed cues from the authoritative completed native seek position", async () => {
+    (window as Window & { __TAURI_INTERNALS__?: unknown }).__TAURI_INTERNALS__ = {};
+    setMockNativeAudioState({ capabilities: {
+      nativePlaybackSupported: true, fallbackRequired: false,
+      fallbackReason: null, backend: "desktop-cpal",
+    } });
+    setProjectAnalysis("proj_123", timingAnalysis);
+    const user = userEvent.setup();
+    renderApp(["/projects/proj_123"]);
+    await screen.findByRole("heading", { name: "Demo Song" });
+    await user.click(screen.getByRole("tab", { name: "Playback" }));
+    await user.click(screen.getByRole("button", { name: "Play playback" }));
+    await user.click(screen.getByRole("link", { name: "Tools" }));
+    await user.click(await screen.findByRole("tab", { name: "Metronome" }));
+    await user.click(screen.getByLabelText("Follow project playback"));
+    await waitFor(() => expect(getMockInvoke().mock.calls.some(([name]) => name === "audio_schedule_cues")).toBe(true));
+    await user.click(screen.getByRole("link", { name: "Open Demo Song project" }));
+    await user.click(screen.getByRole("tab", { name: "Playback" }));
+
+    const invoke = getMockInvoke();
+    const originalInvoke = invoke.getMockImplementation();
+    const preparedSessionId = latestNativeSessionId();
+    let authoritativePosition = 0.48;
+    invoke.mockImplementation(async (command, args) => command === "audio_seek" ? {
+      sessionId: preparedSessionId, state: "playing", positionSeconds: authoritativePosition,
+      durationSeconds: 182, playbackRate: 1, nativePlaybackSupported: true,
+      fallbackReason: null, lanes: [], bufferHealth: [], leaseId: "project-playback",
+      generation: 1, timelineRevision: 2, nativeTimeUs: 10,
+    } : originalInvoke!(command, args));
+    const beforeSeek = invoke.mock.calls.filter(([name]) => name === "audio_schedule_cues").length;
+    fireEvent.change(screen.getByLabelText("Playback position"), { target: { value: "0.2" } });
+    await waitFor(() => expect(invoke.mock.calls.filter(([name]) => name === "audio_schedule_cues")).toHaveLength(beforeSeek + 1));
+    const replacement = [...invoke.mock.calls].reverse().find(([name]) => name === "audio_schedule_cues");
+    const replacementPayload = (replacement?.[1] as {
+      payload?: { timelineRevision?: number; cues?: Array<{ positionSeconds: number }> };
+    })?.payload;
+    expect(replacementPayload?.timelineRevision).toBe(2);
+    expect(replacementPayload?.cues?.[0]?.positionSeconds).toBe(0.48);
+    authoritativePosition = 2;
+    const beforeEmptySeek = invoke.mock.calls.filter(([name]) => name === "audio_cancel_cues").length;
+    fireEvent.change(screen.getByLabelText("Playback position"), { target: { value: "0.3" } });
+    await waitFor(() => expect(invoke.mock.calls.filter(([name]) => name === "audio_cancel_cues")).toHaveLength(beforeEmptySeek + 1));
+    const cancel = [...invoke.mock.calls].reverse().find(([name]) => name === "audio_cancel_cues");
+    expect(cancel?.[1]).toMatchObject({ kind: "metronome", payload: { timelineRevision: 2 } });
+    delete (window as Window & { __TAURI_INTERNALS__?: unknown }).__TAURI_INTERNALS__;
+  });
+
+  it("ignores a native seek snapshot from a mismatched session", async () => {
+    (window as Window & { __TAURI_INTERNALS__?: unknown }).__TAURI_INTERNALS__ = {};
+    setMockNativeAudioState({ capabilities: {
+      nativePlaybackSupported: true, fallbackRequired: false,
+      fallbackReason: null, backend: "desktop-cpal",
+    } });
+    setProjectAnalysis("proj_123", timingAnalysis);
+    const user = userEvent.setup();
+    renderApp(["/projects/proj_123"]);
+    await screen.findByRole("heading", { name: "Demo Song" });
+    await user.click(screen.getByRole("tab", { name: "Playback" }));
+    await user.click(screen.getByRole("button", { name: "Play playback" }));
+    await user.click(screen.getByRole("link", { name: "Tools" }));
+    await user.click(await screen.findByRole("tab", { name: "Metronome" }));
+    await user.click(screen.getByLabelText("Follow project playback"));
+    await waitFor(() => expect(getMockInvoke().mock.calls.some(([name]) => name === "audio_schedule_cues")).toBe(true));
+    await user.click(screen.getByRole("link", { name: "Open Demo Song project" }));
+    await user.click(screen.getByRole("tab", { name: "Playback" }));
+
+    const invoke = getMockInvoke();
+    const originalInvoke = invoke.getMockImplementation();
+    invoke.mockImplementation(async (command, args) => command === "audio_seek" ? {
+      sessionId: "mismatched-session", state: "playing", positionSeconds: 48,
+      durationSeconds: 182, playbackRate: 1, nativePlaybackSupported: true,
+      fallbackReason: null, lanes: [], bufferHealth: [], leaseId: "project-playback",
+      generation: 1, timelineRevision: 2, nativeTimeUs: 10,
+    } : originalInvoke!(command, args));
+    const scheduleCount = invoke.mock.calls.filter(([name]) => name === "audio_schedule_cues").length;
+    const cancelCount = invoke.mock.calls.filter(([name]) => name === "audio_cancel_cues").length;
+    fireEvent.change(screen.getByLabelText("Playback position"), { target: { value: "0.2" } });
+    await waitFor(() => expect(invoke.mock.calls.filter(([name]) => name === "audio_seek")).toHaveLength(1));
+    await act(async () => Promise.resolve());
+
+    expect(invoke.mock.calls.filter(([name]) => name === "audio_schedule_cues")).toHaveLength(scheduleCount);
+    expect(invoke.mock.calls.filter(([name]) => name === "audio_cancel_cues")).toHaveLength(cancelCount);
+    expect(readPlaybackE2ETelemetry().positionSeconds).not.toBe(48);
+    delete (window as Window & { __TAURI_INTERNALS__?: unknown }).__TAURI_INTERNALS__;
+  });
+
+  it("ignores stale follow scheduling and cleanup snapshots across reactivation", async () => {
+    (window as Window & { __TAURI_INTERNALS__?: unknown }).__TAURI_INTERNALS__ = {};
+    setMockNativeAudioState({ capabilities: {
+      nativePlaybackSupported: true, fallbackRequired: false,
+      fallbackReason: null, backend: "desktop-cpal",
+    } });
+    setProjectAnalysis("proj_123", timingAnalysis);
+    const user = userEvent.setup();
+    renderApp(["/projects/proj_123"]);
+    await screen.findByRole("heading", { name: "Demo Song" });
+    await user.click(screen.getByRole("tab", { name: "Playback" }));
+    await user.click(screen.getByRole("button", { name: "Play playback" }));
+    await user.click(screen.getByRole("link", { name: "Tools" }));
+    await user.click(await screen.findByRole("tab", { name: "Metronome" }));
+
+    const snapshot = {
+      status: "output" as const, owner: "playback" as const, leaseId: "project-playback",
+      generation: 1, timelineRevision: 1, nativeTimeUs: 1, positionSeconds: 0,
+      playbackRate: 1, availabilityReason: null, terminalDiagnostic: null,
+    };
+    const staleSchedule = createDeferred<typeof snapshot>();
+    const staleCleanup = createDeferred<typeof snapshot>();
+    const currentSchedule = createDeferred<typeof snapshot>();
+    const snapshotPromises = [staleSchedule.promise, staleCleanup.promise, currentSchedule.promise];
+    let snapshotCallCount = 0;
+    const invoke = getMockInvoke();
+    const originalInvoke = invoke.getMockImplementation();
+    invoke.mockImplementation(async (command, args) => {
+      if (command === "audio_get_session_snapshot" && snapshotCallCount < snapshotPromises.length) {
+        return snapshotPromises[snapshotCallCount++];
+      }
+      return originalInvoke!(command, args);
+    });
+
+    await user.click(screen.getByLabelText("Follow project playback"));
+    await waitFor(() => expect(snapshotCallCount).toBe(1));
+    await user.click(screen.getByLabelText("Follow project playback"));
+    await waitFor(() => expect(snapshotCallCount).toBe(2));
+    await act(async () => { staleSchedule.resolve(snapshot); });
+    expect(invoke.mock.calls.filter(([name]) => name === "audio_schedule_cues")).toHaveLength(0);
+
+    await user.click(screen.getByLabelText("Follow project playback"));
+    await waitFor(() => expect(snapshotCallCount).toBe(3));
+    await act(async () => { currentSchedule.resolve(snapshot); });
+    await waitFor(() => expect(invoke.mock.calls.filter(([name]) => name === "audio_schedule_cues")).toHaveLength(1));
+    await act(async () => { staleCleanup.resolve(snapshot); });
+    expect(invoke.mock.calls.filter(([name]) => name === "audio_cancel_cues")).toHaveLength(0);
+
+    invoke.mockImplementation(originalInvoke!);
+    await user.click(screen.getByLabelText("Follow project playback"));
+    await waitFor(() => expect(invoke.mock.calls.filter(([name]) => name === "audio_cancel_cues")).toHaveLength(1));
+    delete (window as Window & { __TAURI_INTERNALS__?: unknown }).__TAURI_INTERNALS__;
   });
 
   it("keeps synced metronome armed when opening the playback project page", async () => {

--- a/apps/desktop/src/features/projects/hooks/useProjectViewModel.ts
+++ b/apps/desktop/src/features/projects/hooks/useProjectViewModel.ts
@@ -297,6 +297,7 @@ export function useProjectViewModel() {
     seekTo,
     stopPlayback,
     togglePlayback,
+    updateActiveLoopRange,
   } = usePlayback();
   const {
     defaultPlaybackDisplayMode,
@@ -1451,6 +1452,7 @@ export function useProjectViewModel() {
         loopAlignmentMode,
         analysisTimingGrid,
       );
+      updateActiveLoopRange?.(nextLoopRange);
       setLoopRange(nextLoopRange);
       setPendingLoopStartSeconds(null);
       setLoopStatusMessage("Loop set");
@@ -1459,6 +1461,7 @@ export function useProjectViewModel() {
     }
 
     if (loopRange) {
+      updateActiveLoopRange?.(null);
       setLoopRange(null);
       setLoopStatusMessage("Loop cleared");
       return;

--- a/apps/desktop/src/features/projects/playback-context.ts
+++ b/apps/desktop/src/features/projects/playback-context.ts
@@ -1,4 +1,5 @@
 import { createContext, useContext } from "react";
+import type { NativeAudioCue, NativeAudioSessionSnapshot } from "../../lib/nativeAudio";
 import type { AnalysisTimingGrid } from "../../lib/timingGrid";
 import type { ChordDictionaryFollowProjectContext } from "./chordDictionaryFollowContext";
 import type { PlaybackLoopRange, StemControlState } from "./projectPlaybackState";
@@ -45,6 +46,10 @@ export type PlaybackContextValue = {
   primeWebAudioForGesture: () => Promise<void>;
   getPlaybackSnapshot: () => PlaybackSnapshot;
   registerProjectSession: (session: ProjectPlaybackSession) => void;
+  updateActiveLoopRange?: (range: PlaybackLoopRange | null) => void;
+  updateFollowedMetronomeCues?: (
+    cues: NativeAudioCue[],
+  ) => Promise<NativeAudioSessionSnapshot | null>;
   togglePlayback: () => Promise<void>;
   playPlayback: () => Promise<void>;
   pausePlayback: () => void;

--- a/apps/desktop/src/features/projects/playback.race-regressions.test.tsx
+++ b/apps/desktop/src/features/projects/playback.race-regressions.test.tsx
@@ -1,0 +1,895 @@
+import {
+  emitMockNativeAudioCue,
+  emitMockNativePlaybackPosition,
+  getMockAudioContexts,
+  getMockFetch,
+  getMockInvoke,
+  markAudioReady,
+  mockListen,
+  resetAppTestHarness,
+  setMockNativeAudioState,
+} from "../../test/appTestHarness";
+import { act, cleanup, render, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { PlaybackProvider } from "./playback";
+import {
+  usePlayback,
+  type PlaybackContextValue,
+  type ProjectPlaybackSession,
+} from "./playback-context";
+import { MetronomeProvider } from "../tools/metronome";
+import {
+  useMetronome,
+  type MetronomeContextValue,
+} from "../tools/metronome-context";
+
+let playback: PlaybackContextValue;
+let metronome: MetronomeContextValue;
+
+function Harness() {
+  playback = usePlayback();
+  return null;
+}
+
+function MetronomeHarness() {
+  metronome = useMetronome();
+  return null;
+}
+
+function session(
+  overrides: Partial<ProjectPlaybackSession> = {},
+): ProjectPlaybackSession {
+  return {
+    projectId: "synthetic",
+    projectName: "Synthetic",
+    stageTitle: "Source",
+    stageSummary: "Source",
+    selectedPlaybackArtifactId: "sine",
+    isStemPlayback: false,
+    playbackArtifactIds: ["sine"],
+    artifactPathsById: { sine: "/tmp/synthetic.wav" },
+    artifactFormatsById: { sine: "wav" },
+    visibleStemArtifactIds: [],
+    stemControls: {},
+    durationHintSeconds: 30,
+    precountEnabled: false,
+    precountLoopEnabled: false,
+    precountClickCount: 4,
+    precountTempoBpm: 120,
+    tempoOriginalBpm: 120,
+    tempoTargetBpm: 120,
+    timingGrid: null,
+    loopRange: null,
+    chordDictionaryFollowProject: null,
+    ...overrides,
+  };
+}
+
+function bufferedSession(
+  overrides: Partial<ProjectPlaybackSession> = {},
+): ProjectPlaybackSession {
+  return session({
+    selectedPlaybackArtifactId: "stem",
+    isStemPlayback: true,
+    playbackArtifactIds: ["stem"],
+    artifactPathsById: { stem: "/tmp/stem.wav" },
+    artifactFormatsById: { stem: "wav" },
+    visibleStemArtifactIds: ["stem"],
+    stemControls: { stem: { muted: false, solo: false } },
+    ...overrides,
+  });
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((nextResolve) => {
+    resolve = nextResolve;
+  });
+  return { promise, resolve };
+}
+
+async function flush() {
+  await act(async () => {
+    for (let index = 0; index < 30; index += 1) {
+      await Promise.resolve();
+    }
+  });
+}
+
+async function setup(targetSession = session()) {
+  render(
+    <PlaybackProvider>
+      <Harness />
+    </PlaybackProvider>,
+  );
+  act(() => playback.registerProjectSession(targetSession));
+  await flush();
+}
+
+function calls(command: string) {
+  return getMockInvoke().mock.calls.filter(([name]) => name === command);
+}
+
+beforeEach(() => {
+  resetAppTestHarness();
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllEnvs();
+  delete (window as Window & { __TAURI_INTERNALS__?: unknown }).__TAURI_INTERNALS__;
+  vi.restoreAllMocks();
+});
+
+function enableNativePlayback() {
+  Object.defineProperty(window, "__TAURI_INTERNALS__", {
+    configurable: true,
+    value: {},
+  });
+  setMockNativeAudioState({
+    capabilities: {
+      nativePlaybackSupported: true,
+      availabilityReason: null,
+      backend: "desktop-cpal",
+    },
+  });
+}
+
+describe("native playback race regressions", () => {
+  for (const action of ["stop", "pause"] as const) {
+    it(`${action} waits for an in-flight native seek revision`, async () => {
+      enableNativePlayback();
+      await setup();
+      await act(async () => playback.playPlayback());
+      const invoke = getMockInvoke();
+      const originalInvoke = invoke.getMockImplementation()!;
+      const pendingSeek = deferred<Record<string, unknown>>();
+      let revision = 1;
+      const rejected: string[] = [];
+      let actualState = "playing";
+
+      invoke.mockImplementation(async (command, args) => {
+        const control = ((args as { payload?: Record<string, unknown>; control?: Record<string, unknown> })
+          ?.payload ?? (args as { control?: Record<string, unknown> })?.control);
+        if (
+          ["audio_seek", "audio_pause", "audio_stop"].includes(command) &&
+          control?.timelineRevision !== revision
+        ) {
+          rejected.push(command);
+          throw new Error("stale_timeline_revision");
+        }
+        const result = await originalInvoke(command, args);
+        if (command === "audio_seek") {
+          revision += 1;
+          return pendingSeek.promise;
+        }
+        if (command === "audio_pause" || command === "audio_stop") {
+          actualState = command === "audio_pause" ? "paused" : "stopped";
+          revision += 1;
+          return { ...(result as object), timelineRevision: revision };
+        }
+        return result;
+      });
+
+      act(() => playback.seekTo(12));
+      await flush();
+      act(() => {
+        if (action === "stop") playback.stopPlayback();
+        else playback.pausePlayback();
+      });
+      await flush();
+      expect(calls(action === "stop" ? "audio_stop" : "audio_pause")).toHaveLength(0);
+      await act(async () => {
+        pendingSeek.resolve({
+          sessionId: "synthetic:native:sine",
+          state: "playing",
+          positionSeconds: 12,
+          durationSeconds: 30,
+          playbackRate: 1,
+          nativePlaybackSupported: true,
+          availabilityReason: null,
+          lanes: [],
+          bufferHealth: [],
+          leaseId: "project-playback",
+          generation: 1,
+          timelineRevision: 2,
+          nativeTimeUs: 1,
+        });
+      });
+      await flush();
+
+      expect(rejected).toEqual([]);
+      expect(actualState).toBe(action === "stop" ? "stopped" : "paused");
+    });
+  }
+
+  it("keeps Pause queued when a later seek supersedes its UI intent", async () => {
+    enableNativePlayback();
+    await setup();
+    await act(async () => playback.playPlayback());
+    const invoke = getMockInvoke();
+    const originalInvoke = invoke.getMockImplementation()!;
+    const firstSeek = deferred<Record<string, unknown>>();
+    let revision = 1;
+    const rejected: string[] = [];
+
+    invoke.mockImplementation(async (command, args) => {
+      const payload = (args as { payload?: Record<string, unknown> })?.payload;
+      if (
+        ["audio_seek", "audio_pause"].includes(command) &&
+        payload?.timelineRevision !== revision
+      ) {
+        rejected.push(command);
+        throw new Error("stale_timeline_revision");
+      }
+      const result = await originalInvoke(command, args);
+      if (command === "audio_seek") {
+        revision += 1;
+        if (revision === 2) return firstSeek.promise;
+      }
+      if (command === "audio_pause") {
+        revision += 1;
+      }
+      return result && typeof result === "object" && "timelineRevision" in result
+        ? { ...result, timelineRevision: revision }
+        : result;
+    });
+
+    act(() => playback.seekTo(8));
+    await flush();
+    act(() => playback.pausePlayback());
+    act(() => playback.seekTo(12));
+    await flush();
+    await act(async () => {
+      firstSeek.resolve({
+        sessionId: "synthetic:native:sine",
+        state: "playing",
+        positionSeconds: 8,
+        durationSeconds: 30,
+        playbackRate: 1,
+        nativePlaybackSupported: true,
+        availabilityReason: null,
+        lanes: [],
+        bufferHealth: [],
+        leaseId: "project-playback",
+        generation: 1,
+        timelineRevision: 2,
+        nativeTimeUs: 1,
+      });
+    });
+    await flush();
+
+    expect(rejected).toEqual([]);
+    expect(calls("audio_pause")).toHaveLength(1);
+    expect(playback.isPlaying).toBe(false);
+  });
+
+  it("restores playing state when the current native Pause is rejected", async () => {
+    enableNativePlayback();
+    await setup();
+    await act(async () => playback.playPlayback());
+    const invoke = getMockInvoke();
+    const originalInvoke = invoke.getMockImplementation()!;
+    invoke.mockImplementation(async (command, args) => {
+      if (command === "audio_pause") throw new Error("output_stream_failure");
+      return originalInvoke(command, args);
+    });
+
+    act(() => playback.pausePlayback());
+    await flush();
+
+    expect(calls("audio_pause")).toHaveLength(1);
+    expect(calls("audio_stop")).toHaveLength(0);
+    expect(playback.isPlaying).toBe(true);
+  });
+
+  it("uses each completed native revision across rapid seeks", async () => {
+    enableNativePlayback();
+    await setup();
+    await act(async () => playback.playPlayback());
+    const invoke = getMockInvoke();
+    const originalInvoke = invoke.getMockImplementation()!;
+    const firstSeek = deferred<Record<string, unknown>>();
+    let revision = 1;
+    const rejected: string[] = [];
+
+    invoke.mockImplementation(async (command, args) => {
+      if (command !== "audio_seek") return originalInvoke(command, args);
+      const control = (args as { payload: { timelineRevision: number; timeSeconds: number } }).payload;
+      if (control.timelineRevision !== revision) {
+        rejected.push(command);
+        throw new Error("stale_timeline_revision");
+      }
+      await originalInvoke(command, args);
+      revision += 1;
+      const snapshot = {
+        sessionId: "synthetic:native:sine",
+        state: "playing",
+        positionSeconds: control.timeSeconds,
+        durationSeconds: 30,
+        playbackRate: 1,
+        nativePlaybackSupported: true,
+        availabilityReason: null,
+        lanes: [],
+        bufferHealth: [],
+        leaseId: "project-playback",
+        generation: 1,
+        timelineRevision: revision,
+        nativeTimeUs: 1,
+      };
+      return revision === 2 ? firstSeek.promise : snapshot;
+    });
+
+    act(() => playback.seekTo(12));
+    await flush();
+    act(() => playback.seekTo(14));
+    await flush();
+    await act(async () => {
+      firstSeek.resolve({
+        sessionId: "synthetic:native:sine",
+        state: "playing",
+        positionSeconds: 12,
+        durationSeconds: 30,
+        playbackRate: 1,
+        nativePlaybackSupported: true,
+        availabilityReason: null,
+        lanes: [],
+        bufferHealth: [],
+        leaseId: "project-playback",
+        generation: 1,
+        timelineRevision: 2,
+        nativeTimeUs: 1,
+      });
+    });
+    await flush();
+
+    expect(rejected).toEqual([]);
+    expect(calls("audio_seek")).toHaveLength(2);
+    expect(playback.playbackTimeSeconds).toBe(14);
+  });
+
+  it("bounds repeated loop-boundary seeks without reusing an obsolete revision", async () => {
+    enableNativePlayback();
+    await setup(session({ loopRange: { startSeconds: 5, endSeconds: 10 } }));
+    await act(async () => playback.playPlayback());
+    const invoke = getMockInvoke();
+    const originalInvoke = invoke.getMockImplementation()!;
+    const firstSeek = deferred<Record<string, unknown>>();
+    let revision = 1;
+    const rejected: number[] = [];
+
+    invoke.mockImplementation(async (command, args) => {
+      if (command !== "audio_seek") return originalInvoke(command, args);
+      const control = (args as { payload: { timelineRevision: number; timeSeconds: number } }).payload;
+      if (control.timelineRevision !== revision) {
+        rejected.push(control.timelineRevision);
+        throw new Error("stale_timeline_revision");
+      }
+      const result = await originalInvoke(command, args);
+      revision += 1;
+      const snapshot = { ...(result as object), timelineRevision: revision };
+      return revision === 2 ? firstSeek.promise : snapshot;
+    });
+
+    const boundary = {
+      sessionId: "synthetic:native:sine",
+      state: "playing" as const,
+      positionSeconds: 10,
+      durationSeconds: 30,
+      playbackRate: 1,
+    };
+    act(() => emitMockNativePlaybackPosition(boundary));
+    await flush();
+    act(() => emitMockNativePlaybackPosition(boundary));
+    await flush();
+    expect(calls("audio_seek")).toHaveLength(1);
+    await act(async () => {
+      firstSeek.resolve({
+        sessionId: boundary.sessionId,
+        state: "playing",
+        positionSeconds: 5,
+        durationSeconds: 30,
+        playbackRate: 1,
+        nativePlaybackSupported: true,
+        availabilityReason: null,
+        lanes: [],
+        bufferHealth: [],
+        leaseId: "project-playback",
+        generation: 1,
+        timelineRevision: 2,
+        nativeTimeUs: 1,
+      });
+    });
+    await flush();
+
+    expect(rejected).toEqual([]);
+    expect(calls("audio_seek").length).toBeLessThanOrEqual(2);
+    expect(playback.isPlaying).toBe(true);
+  });
+
+  it("sends an owner-scoped safety Stop after a native command failure", async () => {
+    enableNativePlayback();
+    await setup();
+    await act(async () => playback.playPlayback());
+    const invoke = getMockInvoke();
+    const originalInvoke = invoke.getMockImplementation()!;
+    let transportStopped = false;
+    invoke.mockImplementation(async (command, args) => {
+      if (command === "audio_seek") {
+        throw new Error("output_stream_failure");
+      }
+      const result = await originalInvoke(command, args);
+      if (command === "audio_stop") {
+        transportStopped = true;
+      }
+      return result;
+    });
+
+    act(() => playback.seekTo(12));
+    await flush();
+
+    expect(calls("audio_stop")).toHaveLength(1);
+    expect(transportStopped).toBe(true);
+    expect(playback.isPlaying).toBe(false);
+    expect(playback.playbackTimeSeconds).toBe(12);
+  });
+
+  for (const action of ["stop", "pause", "seek"] as const) {
+    it(`${action} supersedes native playback preparation`, async () => {
+      enableNativePlayback();
+      await setup();
+      const invoke = getMockInvoke();
+      const originalInvoke = invoke.getMockImplementation()!;
+      const preparation = deferred<Record<string, unknown>>();
+      let prepared: unknown;
+      invoke.mockImplementation(async (command, args) => {
+        const result = await originalInvoke(command, args);
+        if (command === "audio_prepare_session") {
+          prepared = result;
+          return preparation.promise;
+        }
+        return result;
+      });
+
+      let play!: Promise<void>;
+      act(() => {
+        play = playback.playPlayback();
+      });
+      await flush();
+      act(() => {
+        if (action === "stop") playback.stopPlayback();
+        else if (action === "pause") playback.pausePlayback();
+        else playback.seekTo(12);
+      });
+      await act(async () => {
+        preparation.resolve(prepared as Record<string, unknown>);
+        await play;
+      });
+      await flush();
+
+      expect(calls("audio_play")).toHaveLength(0);
+      expect(calls("audio_stop")).toHaveLength(1);
+      expect(playback.playbackTimeSeconds).toBe(action === "seek" ? 12 : 0);
+    });
+  }
+
+  for (const precountEnabled of [false, true]) {
+    it(`does not accept a Play reply after seek${precountEnabled ? " with count-in" : ""}`, async () => {
+      enableNativePlayback();
+      await setup(session({ precountEnabled }));
+      const invoke = getMockInvoke();
+      const originalInvoke = invoke.getMockImplementation()!;
+      const pendingPlay = deferred<Record<string, unknown>>();
+      let played: Record<string, unknown> | undefined;
+      invoke.mockImplementation(async (command, args) => {
+        const result = await originalInvoke(command, args);
+        if (command === "audio_play") {
+          played = result as Record<string, unknown>;
+          return pendingPlay.promise;
+        }
+        return result;
+      });
+
+      let play!: Promise<void>;
+      act(() => {
+        play = playback.playPlayback();
+      });
+      await flush();
+      act(() => playback.seekTo(12));
+      await act(async () => {
+        pendingPlay.resolve(played!);
+        await play;
+      });
+      await flush();
+
+      expect(calls("audio_stop")).toHaveLength(1);
+      expect(playback.playbackTimeSeconds).toBe(12);
+      expect(playback.isPlaying).toBe(false);
+      expect(playback.isPrecounting).toBe(false);
+    });
+  }
+
+  it("accepts a correlated count-in completion before Play resolves", async () => {
+    enableNativePlayback();
+    await setup(session({ precountEnabled: true }));
+    const invoke = getMockInvoke();
+    const originalInvoke = invoke.getMockImplementation()!;
+    const pendingPlay = deferred<Record<string, unknown>>();
+    let played: Record<string, unknown> | undefined;
+    invoke.mockImplementation(async (command, args) => {
+      const result = await originalInvoke(command, args);
+      if (command === "audio_play") {
+        played = result as Record<string, unknown>;
+        return pendingPlay.promise;
+      }
+      return result;
+    });
+
+    let play!: Promise<void>;
+    act(() => {
+      play = playback.playPlayback();
+    });
+    await flush();
+    act(() => emitMockNativeAudioCue({
+      kind: "precount_completion",
+      generation: played?.generation,
+      revision: played?.timelineRevision,
+      cueIndex: 4,
+      scheduledNativeTimeUs: 2_035_000,
+      actualNativeTimeUs: 2_035_000,
+      insertionSequence: 5,
+      accent: false,
+      gain: 1,
+    }));
+    await act(async () => {
+      pendingPlay.resolve(played!);
+      await play;
+    });
+    await flush();
+
+    expect(playback.isPrecounting).toBe(false);
+    expect(playback.isPlaying).toBe(true);
+  });
+
+  it("restarts a native EOF loop after stopped then ended events", async () => {
+    enableNativePlayback();
+    await setup(session({ loopRange: { startSeconds: 5, endSeconds: 30 } }));
+    await act(async () => playback.playPlayback());
+    const snapshot = await getMockInvoke()("audio_get_snapshot") as Record<string, unknown>;
+    const ended = { ...snapshot, state: "stopped", positionSeconds: 30 };
+
+    act(() => {
+      emitMockNativePlaybackPosition(ended as Parameters<typeof emitMockNativePlaybackPosition>[0]);
+    });
+    const listener = mockListen.mock.calls
+      .find(([name]) => name === "audio://ended")?.[1];
+    act(() => listener?.({ event: "audio://ended", id: 1, payload: ended }));
+    await flush();
+
+    expect(calls("audio_play")).toHaveLength(2);
+  });
+
+  it("restarts a native EOF loop with loop count-in and followed metronome active", async () => {
+    enableNativePlayback();
+    render(
+      <PlaybackProvider>
+        <Harness />
+        <MetronomeProvider>
+          <MetronomeHarness />
+        </MetronomeProvider>
+      </PlaybackProvider>,
+    );
+    act(() => playback.registerProjectSession(session({
+      loopRange: { startSeconds: 5, endSeconds: 30 },
+      precountEnabled: false,
+      precountLoopEnabled: true,
+    })));
+    await flush();
+    await act(async () => playback.playPlayback());
+    await act(async () => metronome.setFollowPlaybackEnabled(true));
+    const snapshot = await getMockInvoke()("audio_get_snapshot") as Record<string, unknown>;
+    const ended = { ...snapshot, state: "stopped", positionSeconds: 30 };
+
+    act(() => {
+      emitMockNativePlaybackPosition(ended as Parameters<typeof emitMockNativePlaybackPosition>[0]);
+    });
+    const listener = mockListen.mock.calls
+      .find(([name]) => name === "audio://ended")?.[1];
+    act(() => listener?.({ event: "audio://ended", id: 1, payload: ended }));
+    await flush();
+
+    expect(calls("audio_play")).toHaveLength(2);
+    const replay = calls("audio_play")[1]?.[1] as {
+      payload?: { precount?: { intervalsSeconds?: number[] } | null };
+    } | undefined;
+    expect(replay?.payload?.precount?.intervalsSeconds).toHaveLength(4);
+    expect(metronome.isRunning).toBe(true);
+  });
+
+  it("stops old native ownership when switching projects", async () => {
+    enableNativePlayback();
+    await setup();
+    await act(async () => playback.playPlayback());
+    act(() => playback.registerProjectSession(session({ projectId: "second" })));
+    await flush();
+    act(() => emitMockNativePlaybackPosition({
+      sessionId: "synthetic:native:sine",
+      state: "playing",
+      positionSeconds: 9,
+      durationSeconds: 30,
+    }));
+    await flush();
+
+    expect(calls("audio_stop")).toHaveLength(1);
+    expect(playback.session?.projectId).toBe("second");
+    expect(playback.isPlaying).toBe(false);
+    expect(playback.playbackTimeSeconds).toBe(0);
+  });
+
+  it("ignores a late project-A ended event after project B is registered", async () => {
+    enableNativePlayback();
+    await setup();
+    await act(async () => playback.playPlayback());
+    const endedA = {
+      ...(await getMockInvoke()("audio_get_snapshot") as Record<string, unknown>),
+      state: "stopped",
+      positionSeconds: 30,
+    };
+    act(() => playback.registerProjectSession(session({
+      projectId: "second",
+      loopRange: { startSeconds: 5, endSeconds: 30 },
+      precountLoopEnabled: true,
+    })));
+    await flush();
+    const playCount = calls("audio_play").length;
+    const listener = mockListen.mock.calls
+      .find(([name]) => name === "audio://ended")?.[1];
+    act(() => listener?.({ event: "audio://ended", id: 1, payload: endedA }));
+    await flush();
+
+    expect(calls("audio_play")).toHaveLength(playCount);
+    expect(playback.session?.projectId).toBe("second");
+    expect(playback.isPrecounting).toBe(false);
+    expect(playback.isPlaying).toBe(false);
+  });
+
+  it("does not let a late project prepare replace newer native ownership", async () => {
+    enableNativePlayback();
+    await setup();
+    const invoke = getMockInvoke();
+    const originalInvoke = invoke.getMockImplementation()!;
+    const pendingPrepare = deferred<Record<string, unknown>>();
+    let firstPrepare = true;
+    let preparedA: Record<string, unknown> | undefined;
+    let playedB: Record<string, unknown> | undefined;
+    let activeGeneration = 1;
+
+    invoke.mockImplementation(async (command, args) => {
+      const payload = (args as { payload?: Record<string, unknown> } | undefined)?.payload;
+      if (
+        ["audio_play", "audio_pause", "audio_stop", "audio_seek"].includes(command) &&
+        payload?.generation !== activeGeneration
+      ) {
+        throw new Error("stale_generation");
+      }
+      const result = await originalInvoke(command, args) as Record<string, unknown>;
+      if (command === "audio_prepare_session" && firstPrepare) {
+        firstPrepare = false;
+        preparedA = result;
+        return pendingPrepare.promise;
+      }
+      if (command === "audio_play" && result.sessionId !== preparedA?.sessionId) {
+        playedB = result;
+      }
+      return result;
+    });
+
+    let playingA!: Promise<void>;
+    act(() => {
+      playingA = playback.playPlayback();
+    });
+    await flush();
+    expect(preparedA).toBeDefined();
+
+    activeGeneration = 2;
+    setMockNativeAudioState({
+      snapshot: { generation: 2, timelineRevision: 1, nativeTimeUs: 2 },
+    });
+    act(() => playback.registerProjectSession(session({
+      projectId: "second",
+      selectedPlaybackArtifactId: "sine-two",
+      playbackArtifactIds: ["sine-two"],
+      artifactPathsById: { "sine-two": "/tmp/synthetic-two.wav" },
+      artifactFormatsById: { "sine-two": "wav" },
+    })));
+    await act(async () => playback.playPlayback());
+    await flush();
+    expect(playedB).toBeDefined();
+    expect(playback.isPlaying).toBe(true);
+    const stopCount = calls("audio_stop").length;
+
+    await act(async () => {
+      pendingPrepare.resolve(preparedA!);
+      await playingA;
+    });
+    await flush();
+    expect(calls("audio_stop")).toHaveLength(stopCount);
+    act(() => emitMockNativePlaybackPosition({
+      ...(playedB as Parameters<typeof emitMockNativePlaybackPosition>[0]),
+      state: "playing",
+      positionSeconds: 9,
+      durationSeconds: 30,
+    }));
+    await flush();
+
+    expect(playback.playbackTimeSeconds).toBe(9);
+    expect(playback.isPlaying).toBe(true);
+    const pauseCount = calls("audio_pause").length;
+    act(() => playback.pausePlayback());
+    await flush();
+    const pause = calls("audio_pause")[pauseCount]?.[1] as {
+      payload?: { generation?: number; timelineRevision?: number };
+    } | undefined;
+    expect(pause?.payload).toMatchObject({
+      generation: playedB?.generation,
+      timelineRevision: playedB?.timelineRevision,
+    });
+  });
+});
+
+describe("buffered Web playback race regressions", () => {
+  for (const action of ["stop", "pause", "seek"] as const) {
+    it(`${action} cancels pending buffer preparation`, async () => {
+      const response = deferred<Response>();
+      getMockFetch().mockImplementationOnce(() => response.promise);
+      await setup(bufferedSession());
+      let play!: Promise<void>;
+      act(() => {
+        play = playback.playPlayback();
+      });
+      await flush();
+      act(() => {
+        if (action === "stop") playback.stopPlayback();
+        else if (action === "pause") playback.pausePlayback();
+        else playback.seekTo(12);
+      });
+      await act(async () => {
+        response.resolve(new Response(new ArrayBuffer(8), { status: 200 }));
+        await play;
+      });
+      await flush();
+
+      expect(getMockAudioContexts().flatMap((context) => context.createdSources)).toHaveLength(0);
+      expect(playback.isPlaying).toBe(false);
+      expect(playback.playbackTimeSeconds).toBe(action === "seek" ? 12 : 0);
+    });
+  }
+
+  for (const action of ["stop", "pause", "seek"] as const) {
+    it(`${action} cancels pending count-in buffer preparation`, async () => {
+      const response = deferred<Response>();
+      getMockFetch().mockImplementationOnce(() => response.promise);
+      await setup(bufferedSession({ precountEnabled: true }));
+      let play!: Promise<void>;
+      act(() => {
+        play = playback.playPlayback();
+      });
+      await flush();
+      act(() => {
+        if (action === "stop") playback.stopPlayback();
+        else if (action === "pause") playback.pausePlayback();
+        else playback.seekTo(12);
+      });
+      await act(async () => {
+        response.resolve(new Response(new ArrayBuffer(8), { status: 200 }));
+        await play;
+      });
+      await flush();
+
+      expect(playback.isPrecounting).toBe(false);
+      expect(playback.isPlaying).toBe(false);
+      expect(playback.playbackTimeSeconds).toBe(action === "seek" ? 12 : 0);
+      expect(getMockAudioContexts().flatMap((context) => context.createdSources)).toHaveLength(0);
+    });
+  }
+
+  it("forced Web later start remains stopped after deferred buffer preparation", async () => {
+    vi.stubEnv("VITE_TUNEFORGE_FORCE_WEB_AUDIO", "1");
+    enableNativePlayback();
+    render(
+      <PlaybackProvider>
+        <Harness />
+      </PlaybackProvider>,
+    );
+    act(() => playback.registerProjectSession(bufferedSession()));
+    await flush();
+    let initialPlay!: Promise<void>;
+    act(() => {
+      initialPlay = playback.playPlayback();
+    });
+    const initialAudio = await waitFor(() => {
+      const element = document.querySelector("audio[src]") as HTMLAudioElement | null;
+      expect(element).not.toBeNull();
+      return element!;
+    });
+    markAudioReady(initialAudio, 30);
+    await act(async () => initialPlay);
+    await flush();
+    expect(playback.isPlaying).toBe(true);
+    act(() => playback.stopPlayback());
+
+    const response = deferred<Response>();
+    getMockFetch().mockImplementationOnce(() => response.promise);
+    act(() => playback.registerProjectSession(bufferedSession({
+      projectId: "second",
+      selectedPlaybackArtifactId: "stem-two",
+      playbackArtifactIds: ["stem-two"],
+      artifactPathsById: { "stem-two": "/tmp/stem-two.wav" },
+      artifactFormatsById: { "stem-two": "wav" },
+      visibleStemArtifactIds: ["stem-two"],
+      stemControls: { "stem-two": { muted: false, solo: false } },
+    })));
+    await flush();
+    let pendingPlay!: Promise<void>;
+    act(() => {
+      pendingPlay = playback.playPlayback();
+    });
+    await flush();
+    act(() => playback.stopPlayback());
+    await act(async () => {
+      response.resolve(new Response(new ArrayBuffer(8), { status: 200 }));
+      await pendingPlay;
+    });
+    await flush();
+
+    expect(playback.isPlaying).toBe(false);
+    expect(getMockAudioContexts().flatMap((context) => context.createdSources)).toHaveLength(1);
+  });
+
+});
+
+describe("followed native metronome races", () => {
+  it("restores followed cues after a native tempo mutation", async () => {
+    enableNativePlayback();
+    let cueCount = 0;
+    let playbackRate = 1;
+    let timelineRevision = 1;
+    const invoke = getMockInvoke();
+    const originalInvoke = invoke.getMockImplementation()!;
+    invoke.mockImplementation(async (command, args) => {
+      const payload = (args as { payload?: Record<string, unknown> })?.payload;
+      const result = await originalInvoke(command, args);
+      if (command === "audio_schedule_cues") {
+        cueCount = (payload?.cues as unknown[]).length;
+      }
+      if (command === "audio_set_lanes" && payload?.playbackRate !== playbackRate) {
+        playbackRate = Number(payload?.playbackRate);
+        timelineRevision += 1;
+        cueCount = 0;
+      }
+      return result && typeof result === "object" && "timelineRevision" in result
+        ? { ...result, timelineRevision }
+        : result;
+    });
+
+    render(
+      <PlaybackProvider>
+        <Harness />
+        <MetronomeProvider>
+          <MetronomeHarness />
+        </MetronomeProvider>
+      </PlaybackProvider>,
+    );
+    act(() => playback.registerProjectSession(session()));
+    await flush();
+    await act(async () => playback.playPlayback());
+    await act(async () => metronome.setFollowPlaybackEnabled(true));
+    await flush();
+    expect(cueCount).toBeGreaterThan(0);
+
+    act(() => playback.registerProjectSession(session({ tempoTargetBpm: 90 })));
+    await flush();
+
+    expect(cueCount).toBeGreaterThan(0);
+  });
+});

--- a/apps/desktop/src/features/projects/playback.test.tsx
+++ b/apps/desktop/src/features/projects/playback.test.tsx
@@ -475,6 +475,10 @@ describe("PlaybackProvider", () => {
         id: 1,
         payload: {
           sessionId: "proj_123:native:art_source",
+          leaseId: "project-playback",
+          generation: 1,
+          timelineRevision: 1,
+          nativeTimeUs: 1,
           state: "stopped",
           positionSeconds: 0,
           durationSeconds: 182,

--- a/apps/desktop/src/features/projects/playback.tsx
+++ b/apps/desktop/src/features/projects/playback.tsx
@@ -8,19 +8,28 @@ import {
 } from "react";
 import { api } from "../../lib/api";
 import {
+  cancelNativeAudioCues,
   getNativeAudioCapabilities,
   getNativeAudioSnapshot,
   isWebAudioBackendForced,
+  listenNativeAudioCues,
   listenNativeAudioEnded,
   listenNativeAudioErrors,
   listenNativeAudioPositions,
+  listenNativeAudioTerminal,
+  nativePlayCueProvider,
   pauseNativeAudio,
   playNativeAudio,
   prepareNativeAudioSession,
+  scheduleNativeAudioCues,
   seekNativeAudio,
   setNativeAudioLanes,
   stopNativeAudio,
+  type NativeAudioCue,
+  type NativeAudioCueEvent,
   type NativeAudioLaneRequest,
+  type NativeAudioSessionControl,
+  type NativeAudioSessionSnapshot,
   type NativeAudioSnapshot,
 } from "../../lib/nativeAudio";
 import {
@@ -102,6 +111,7 @@ type ActivePrecount = {
   clickHandles: PrecountClaveClickHandle[];
   context: AudioContext;
   ownsContext: boolean;
+  loopEpoch: number | null;
   sequence: number;
   signature: string;
   telemetry: PlaybackE2ECountInEvent;
@@ -119,8 +129,25 @@ type NativePlaybackState = {
   blockedSessionSignature: string | null;
   preparePromise: Promise<boolean> | null;
   prepareSignature: string | null;
+  prepareToken: object | null;
   sessionSignature: string | null;
   playbackSignature: string | null;
+  generation: number | null;
+  timelineRevision: number | null;
+  operationSequence: number;
+};
+
+type NativeOutputMutationTag = {
+  epoch: number;
+  generation: number;
+  playbackSignature: string;
+  sessionSignature: string;
+};
+
+type NativeOutputAuthority = {
+  generation: number;
+  sessionSignature: string;
+  timelineRevision: number;
 };
 
 type PendingWebPlayback = {
@@ -169,27 +196,27 @@ function playbackTelemetryTransportState(
 
 function playbackCountInCancelledEvent(
   schedule: PlaybackE2ECountInSchedule,
-  context: AudioContext,
+  cancelledAtContextTimeSeconds: number | null,
   reason: PlaybackE2ECountInCancelReason,
 ): PlaybackE2ECountInCancelled {
   return {
     sequence: schedule.sequence,
     trigger: schedule.trigger,
     playbackStartTimeSeconds: schedule.playbackStartTimeSeconds,
-    cancelledAtContextTimeSeconds: context.state === "closed" ? null : context.currentTime,
+    cancelledAtContextTimeSeconds,
     reason,
   };
 }
 
 function playbackCountInFiredEvent(
   schedule: PlaybackE2ECountInSchedule,
-  context: AudioContext,
+  firedAtContextTimeSeconds: number | null,
 ): PlaybackE2ECountInFired {
   return {
     sequence: schedule.sequence,
     trigger: schedule.trigger,
     playbackStartTimeSeconds: schedule.playbackStartTimeSeconds,
-    firedAtContextTimeSeconds: context.state === "closed" ? null : context.currentTime,
+    firedAtContextTimeSeconds,
   };
 }
 
@@ -373,16 +400,38 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
     blockedSessionSignature: null,
     preparePromise: null,
     prepareSignature: null,
+    prepareToken: null,
     sessionSignature: null,
     playbackSignature: null,
+    generation: null,
+    timelineRevision: null,
+    operationSequence: 0,
   });
+  const nativePrecountRef = useRef<{
+    generation: number;
+    revision: number;
+    clockOriginSeconds: number;
+    loopEpoch: number | null;
+    telemetry: PlaybackE2ECountInEvent;
+  } | null>(null);
   const nativeStopPromiseRef = useRef<Promise<void> | null>(null);
   const nativeControlGenerationRef = useRef(0);
+  const nativeOutputMutationEpochRef = useRef(0);
+  const nativeOutputMutationTailRef = useRef<Promise<void>>(Promise.resolve());
+  const nativeOutputAuthorityRef = useRef<NativeOutputAuthority | null>(null);
+  const pendingNativeLaneMutationRef = useRef<{
+    promise: Promise<NativeAudioSnapshot | null>;
+    session: ProjectPlaybackSession;
+    started: boolean;
+  } | null>(null);
   const pendingNativePlayRef = useRef<{
     generation: number;
     sessionSignature: string;
     playbackSignature: string;
     stopOnFailure: boolean;
+    stopRequested: boolean;
+    hasPrecount: boolean;
+    precountCompletion: NativeAudioCueEvent | null;
   } | null>(null);
   const pendingNativePauseRef = useRef<{
     generation: number;
@@ -397,6 +446,7 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
   const webMediaSourcesEnabledRef = useRef(initialWebMediaSourcesEnabled);
   const pendingTransitionRef = useRef<PendingTransition | null>(null);
   const pendingTransitionCompletionIdRef = useRef<number | null>(null);
+  const playbackIntentEpochRef = useRef(0);
   const transitionCounterRef = useRef(0);
   const allowFreshPlaybackRef = useRef(true);
   const sessionRef = useRef<ProjectPlaybackSession | null>(null);
@@ -412,6 +462,7 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
     lastFired: null,
     lastCancelled: null,
   });
+  const loopEpochRef = useRef(0);
   const [session, setSession] = useState<ProjectPlaybackSession | null>(null);
   const [playbackTimeSeconds, setPlaybackTimeSecondsState] = useState(0);
   const [playbackDurationSeconds, setPlaybackDurationSecondsState] = useState(0);
@@ -528,6 +579,31 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
     snapshot: NativeAudioSnapshot,
     overrides: PlaybackE2ETelemetryOverrides = {},
   ) {
+    if (
+      typeof snapshot.generation !== "number" ||
+      typeof snapshot.timelineRevision !== "number"
+    ) {
+      throw new Error("Native session metadata is unavailable.");
+    }
+    const currentGeneration = nativePlaybackRef.current.generation;
+    const currentRevision = nativePlaybackRef.current.timelineRevision;
+    if (
+      (currentGeneration !== null && snapshot.generation !== currentGeneration) ||
+      (currentRevision !== null &&
+        snapshot.generation === currentGeneration &&
+        snapshot.timelineRevision < currentRevision) ||
+      (nativePlaybackRef.current.sessionSignature !== null &&
+        snapshot.sessionId !== nativePlaybackRef.current.sessionSignature)
+    ) {
+      return false;
+    }
+    nativePlaybackRef.current.generation = snapshot.generation;
+    nativePlaybackRef.current.timelineRevision = snapshot.timelineRevision;
+    nativeOutputAuthorityRef.current = {
+      generation: snapshot.generation,
+      sessionSignature: snapshot.sessionId!,
+      timelineRevision: snapshot.timelineRevision,
+    };
     nativeSnapshotRef.current = snapshot;
     updateNativePlaybackDiagnostics(snapshot);
     writePlaybackE2ETelemetry({
@@ -538,7 +614,233 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
       transportState: snapshot.state,
       ...overrides,
     });
+    return true;
   });
+
+  function nativeControl(includeRevision = true) {
+    const authority = nativeOutputAuthorityRef.current;
+    if (!authority) {
+      throw new Error("Native session metadata is unavailable.");
+    }
+    const native = nativePlaybackRef.current;
+    native.operationSequence += 1;
+    return {
+      leaseId: "project-playback",
+      operationId: `project-playback-${native.operationSequence}`,
+      generation: authority.generation,
+      ...(includeRevision ? { timelineRevision: authority.timelineRevision } : {}),
+    };
+  }
+
+  function invalidateNativeOutputMutations() {
+    nativeOutputMutationEpochRef.current += 1;
+  }
+
+  function nativeOutputMutationTag(): NativeOutputMutationTag | null {
+    const native = nativePlaybackRef.current;
+    const activeSession = sessionRef.current;
+    if (
+      native.generation === null ||
+      !native.sessionSignature ||
+      !activeSession ||
+      nativeSessionSignature(activeSession) !== native.sessionSignature
+    ) {
+      return null;
+    }
+    return {
+      epoch: nativeOutputMutationEpochRef.current,
+      generation: native.generation,
+      playbackSignature: playbackSignature(activeSession),
+      sessionSignature: native.sessionSignature,
+    };
+  }
+
+  function nativeOutputOwnerTag(): NativeOutputMutationTag | null {
+    const authority = nativeOutputAuthorityRef.current;
+    if (!authority) {
+      return null;
+    }
+    return {
+      epoch: nativeOutputMutationEpochRef.current,
+      generation: authority.generation,
+      playbackSignature: "",
+      sessionSignature: authority.sessionSignature,
+    };
+  }
+
+  function nativeOutputMutationIsCurrent(tag: NativeOutputMutationTag) {
+    return (
+      nativeOutputMutationEpochRef.current === tag.epoch &&
+      nativePlaybackRef.current.generation === tag.generation &&
+      nativePlaybackRef.current.sessionSignature === tag.sessionSignature &&
+      nativeSessionSignature(sessionRef.current) === tag.sessionSignature &&
+      playbackSignature(sessionRef.current) === tag.playbackSignature
+    );
+  }
+
+  function nativeOutputMutationOwnerIsCurrent(tag: NativeOutputMutationTag) {
+    const authority = nativeOutputAuthorityRef.current;
+    return (
+      authority?.generation === tag.generation &&
+      authority.sessionSignature === tag.sessionSignature
+    );
+  }
+
+  const enqueueNativeOutputMutation = useStableCallback(function enqueueNativeOutputMutation(
+    execute: (control: NativeAudioSessionControl) => Promise<NativeAudioSnapshot>,
+    { allowStaleIntent = false }: { allowStaleIntent?: boolean } = {},
+  ) {
+    const tag = allowStaleIntent ? nativeOutputOwnerTag() : nativeOutputMutationTag();
+    let resolveResult!: (snapshot: NativeAudioSnapshot | null) => void;
+    let rejectResult!: (error: unknown) => void;
+    const result = new Promise<NativeAudioSnapshot | null>((resolve, reject) => {
+      resolveResult = resolve;
+      rejectResult = reject;
+    });
+    const previous = nativeOutputMutationTailRef.current;
+    const run = async () => {
+      if (
+        !tag ||
+        !(allowStaleIntent
+          ? nativeOutputMutationOwnerIsCurrent(tag)
+          : nativeOutputMutationIsCurrent(tag))
+      ) {
+        resolveResult(null);
+        return;
+      }
+      let snapshot: NativeAudioSnapshot;
+      try {
+        snapshot = await execute(nativeControl());
+      } catch (error) {
+        if (
+          allowStaleIntent
+            ? nativeOutputMutationOwnerIsCurrent(tag)
+            : nativeOutputMutationIsCurrent(tag)
+        ) {
+          rejectResult(error);
+        } else {
+          resolveResult(null);
+        }
+        return;
+      }
+      if (
+        nativeOutputMutationOwnerIsCurrent(tag) &&
+        snapshot.sessionId === tag.sessionSignature &&
+        snapshot.generation === tag.generation &&
+        typeof snapshot.timelineRevision === "number" &&
+        snapshot.timelineRevision >=
+          (nativeOutputAuthorityRef.current?.timelineRevision ?? 0)
+      ) {
+        nativeOutputAuthorityRef.current = {
+          generation: snapshot.generation,
+          sessionSignature: snapshot.sessionId,
+          timelineRevision: snapshot.timelineRevision,
+        };
+        if (
+          nativePlaybackRef.current.generation === snapshot.generation &&
+          nativePlaybackRef.current.sessionSignature === snapshot.sessionId
+        ) {
+          nativePlaybackRef.current.timelineRevision = snapshot.timelineRevision;
+        }
+      }
+      // Stale callers may still need the returned transport state to issue a
+      // safety stop, but only recordNativeSnapshot may accept it into state.
+      resolveResult(snapshot);
+    };
+    const queued = previous
+      .catch(() => undefined)
+      .then(run);
+    const settled = queued.then(() => undefined, () => undefined);
+    nativeOutputMutationTailRef.current = settled;
+    return result;
+  });
+
+  const enqueueNativeLaneMutation = useStableCallback(function enqueueNativeLaneMutation(
+    targetSession: ProjectPlaybackSession,
+  ) {
+    const pending = pendingNativeLaneMutationRef.current;
+    if (
+      pending &&
+      !pending.started &&
+      playbackSignature(pending.session) === playbackSignature(targetSession)
+    ) {
+      pending.session = targetSession;
+      return pending.promise;
+    }
+    const entry = {
+      promise: Promise.resolve<NativeAudioSnapshot | null>(null),
+      session: targetSession,
+      started: false,
+    };
+    entry.promise = enqueueNativeOutputMutation((control) => {
+      entry.started = true;
+      return setNativeAudioLanes(nativeLaneUpdateForSession(entry.session), control);
+    }).finally(() => {
+      if (pendingNativeLaneMutationRef.current === entry) {
+        pendingNativeLaneMutationRef.current = null;
+      }
+    });
+    pendingNativeLaneMutationRef.current = entry;
+    return entry.promise;
+  });
+
+  const updateFollowedMetronomeCues = useStableCallback(
+    function updateFollowedMetronomeCues(cues: NativeAudioCue[]) {
+      const tag = nativeOutputMutationTag();
+      let resolveResult!: (snapshot: NativeAudioSessionSnapshot | null) => void;
+      let rejectResult!: (error: unknown) => void;
+      const result = new Promise<NativeAudioSessionSnapshot | null>((resolve, reject) => {
+        resolveResult = resolve;
+        rejectResult = reject;
+      });
+      const previous = nativeOutputMutationTailRef.current;
+      const run = async () => {
+        if (!tag || !nativeOutputMutationIsCurrent(tag)) {
+          resolveResult(null);
+          return;
+        }
+        let snapshot: NativeAudioSessionSnapshot;
+        try {
+          const control = nativeControl();
+          snapshot = await (cues.length
+            ? scheduleNativeAudioCues({ ...control, cues })
+            : cancelNativeAudioCues(control, "metronome"));
+        } catch (error) {
+          if (nativeOutputMutationIsCurrent(tag)) {
+            rejectResult(error);
+          } else {
+            resolveResult(null);
+          }
+          return;
+        }
+        if (
+          !nativeOutputMutationOwnerIsCurrent(tag) ||
+          snapshot.leaseId !== "project-playback" ||
+          snapshot.generation !== tag.generation ||
+          snapshot.timelineRevision <
+            (nativeOutputAuthorityRef.current?.timelineRevision ?? 0)
+        ) {
+          resolveResult(null);
+          return;
+        }
+        nativeOutputAuthorityRef.current = {
+          generation: snapshot.generation,
+          sessionSignature: tag.sessionSignature,
+          timelineRevision: snapshot.timelineRevision,
+        };
+        if (
+          nativePlaybackRef.current.generation === snapshot.generation &&
+          nativePlaybackRef.current.sessionSignature === tag.sessionSignature
+        ) {
+          nativePlaybackRef.current.timelineRevision = snapshot.timelineRevision;
+        }
+        resolveResult(snapshot);
+      };
+      const queued = previous.catch(() => undefined).then(run);
+      nativeOutputMutationTailRef.current = queued.then(() => undefined, () => undefined);
+      return result;
+    },
+  );
 
   const clearPlaybackControlBackend = useCallback(() => {
     setPlaybackControlBackend("none");
@@ -712,13 +1014,19 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
   });
 
   const requestNativeStop = useStableCallback(function requestNativeStop() {
+    if (nativeStopPromiseRef.current) return nativeStopPromiseRef.current;
+    invalidateNativeOutputMutations();
     nativeControlGenerationRef.current += 1;
     pendingNativePauseRef.current = null;
     const stopTelemetryGeneration = playbackTelemetryGenerationRef.current;
     const stoppedSessionSignature = nativePlaybackRef.current.sessionSignature;
-    const stopPromise = stopNativeAudio()
+    const stopPromise = enqueueNativeOutputMutation(
+      (control) => stopNativeAudio(control),
+      { allowStaleIntent: true },
+    )
       .then((snapshot) => {
         if (
+          !snapshot ||
           nativeStopPromiseRef.current !== stopPromise ||
           playbackTelemetryGenerationRef.current !== stopTelemetryGeneration ||
           nativePlaybackRef.current.sessionSignature !== stoppedSessionSignature ||
@@ -751,6 +1059,34 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
     getRenderedMediaElements(targetSession).forEach((element) => element.pause());
   });
 
+  const completeNativePrecount = useStableCallback(function completeNativePrecount(
+    cue: NativeAudioCueEvent,
+  ) {
+    const active = nativePrecountRef.current;
+    if (
+      !active ||
+      cue.kind !== "precount_completion" ||
+      cue.generation !== active.generation ||
+      cue.revision !== active.revision ||
+      (active.loopEpoch !== null && active.loopEpoch !== loopEpochRef.current)
+    ) {
+      return false;
+    }
+    countInTelemetryRef.current = {
+      ...countInTelemetryRef.current,
+      active: false,
+      lastFired: playbackCountInFiredEvent(
+        active.telemetry,
+        cue.actualNativeTimeUs / 1_000_000,
+      ),
+    };
+    nativePrecountRef.current = null;
+    setIsPrecounting(false);
+    setIsPlaying(true);
+    markPlaybackConfirmed({ backend: "native", detail: nativeBackendRef.current });
+    return true;
+  });
+
   const ensureNativePlaybackSession = useStableCallback(async function ensureNativePlaybackSession(
     targetSession: ProjectPlaybackSession,
   ) {
@@ -766,7 +1102,10 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
       await nativeStopPromiseRef.current;
     }
     if (nativePlaybackRef.current.sessionSignature === sessionSignature) {
-      const snapshot = await setNativeAudioLanes(nativeLaneUpdateForSession(targetSession));
+      const snapshot = await enqueueNativeLaneMutation(targetSession);
+      if (!snapshot) {
+        return false;
+      }
       recordNativeSnapshot(snapshot);
       return true;
     }
@@ -778,8 +1117,10 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
     ) {
       const prepared = await pendingPrepare.preparePromise;
       if (prepared && nativePlaybackRef.current.sessionSignature === sessionSignature) {
-        const snapshot = await setNativeAudioLanes(nativeLaneUpdateForSession(targetSession));
-        recordNativeSnapshot(snapshot);
+        const snapshot = await enqueueNativeLaneMutation(targetSession);
+        if (snapshot) {
+          recordNativeSnapshot(snapshot);
+        }
       }
       return prepared;
     }
@@ -788,13 +1129,39 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
       await nativeStopPromiseRef.current;
     }
 
+    const prepareToken = {};
     const preparePromise = (async () => {
       const preparedSession = await prepareNativeAudioSession({
+        leaseId: "project-playback",
+        operationId: `project-playback-${++nativePlaybackRef.current.operationSequence}`,
         sessionId: sessionSignature,
         durationSeconds: targetSession.durationHintSeconds || null,
         playbackRate: playbackRateForSession(targetSession),
         lanes,
       });
+      if (
+        typeof preparedSession.generation !== "number" ||
+        typeof preparedSession.timelineRevision !== "number"
+      ) {
+        throw new Error("Native session metadata is unavailable.");
+      }
+      const latestSession = sessionRef.current;
+      const currentNative = nativePlaybackRef.current;
+      if (
+        currentNative.prepareToken !== prepareToken ||
+        currentNative.prepareSignature !== sessionSignature ||
+        !latestSession ||
+        nativeSessionSignature(latestSession) !== sessionSignature
+      ) {
+        return false;
+      }
+      nativePlaybackRef.current.generation = preparedSession.generation;
+      nativePlaybackRef.current.timelineRevision = preparedSession.timelineRevision;
+      nativeOutputAuthorityRef.current = {
+        generation: preparedSession.generation,
+        sessionSignature,
+        timelineRevision: preparedSession.timelineRevision,
+      };
       if (!preparedSession.nativePlaybackSupported) {
         if (nativePlaybackRef.current.prepareSignature === sessionSignature) {
           nativePlaybackRef.current = {
@@ -820,13 +1187,6 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
         }
         return false;
       }
-      const currentNative = nativePlaybackRef.current;
-      if (currentNative.prepareSignature !== sessionSignature) {
-        if (!currentNative.active && !currentNative.prepareSignature) {
-          void requestNativeStop();
-        }
-        return false;
-      }
       nativePlaybackRef.current = {
         ...currentNative,
         active: false,
@@ -835,6 +1195,7 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
         prepareSignature: null,
         sessionSignature,
         playbackSignature: null,
+        prepareToken: null,
       };
       return true;
     })();
@@ -843,14 +1204,11 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
       ...nativePlaybackRef.current,
       preparePromise,
       prepareSignature: sessionSignature,
+      prepareToken,
     };
 
     try {
       const prepared = await preparePromise;
-      if (prepared && nativePlaybackRef.current.sessionSignature === sessionSignature) {
-        const snapshot = await setNativeAudioLanes(nativeLaneUpdateForSession(targetSession));
-        recordNativeSnapshot(snapshot);
-      }
       return prepared;
     } catch (error) {
       if (
@@ -872,6 +1230,9 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
   const tryStartNativePlayback = useStableCallback(async function tryStartNativePlayback(
     targetSession: ProjectPlaybackSession,
     timeSeconds: number,
+    precount?: number[],
+    precountLoopEpoch: number | null = null,
+    shouldContinue?: () => boolean,
   ) {
     pendingNativePauseRef.current = null;
     markPlaybackStarting("native");
@@ -886,8 +1247,21 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
     } | null = null;
     try {
       if (!(await ensureNativePlaybackSession(targetSession))) {
+        const latestSession = sessionRef.current;
+        if (
+          !latestSession ||
+          nativeSessionSignature(latestSession) !== sessionSignature ||
+          (shouldContinue && !shouldContinue())
+        ) {
+          return true;
+        }
         clearPlaybackControlBackend();
         return false;
+      }
+      if (shouldContinue && !shouldContinue()) {
+        void requestNativeStop();
+        markNativePlaybackInactive();
+        return true;
       }
       const latestSession = sessionRef.current;
       if (
@@ -904,8 +1278,7 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
         }
         return false;
       }
-      const lanesSnapshot = await setNativeAudioLanes(nativeLaneUpdateForSession(latestSession));
-      recordNativeSnapshot(lanesSnapshot);
+      invalidateNativeOutputMutations();
       const playGeneration = nativeControlGenerationRef.current + 1;
       nativeControlGenerationRef.current = playGeneration;
       const playPlaybackSignature = playbackSignature(latestSession);
@@ -919,6 +1292,9 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
         sessionSignature,
         playbackSignature: playPlaybackSignature,
         stopOnFailure: false,
+        stopRequested: false,
+        hasPrecount: Boolean(precount),
+        precountCompletion: null,
       };
       const playbackAudioContext = stemAudioContextRef.current;
       stemAudioContextRef.current = null;
@@ -927,13 +1303,30 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
       if (playbackAudioContext && playbackAudioContext.state !== "closed") {
         await playbackAudioContext.close();
       }
+      if (shouldContinue && !shouldContinue()) {
+        void requestNativeStop();
+        markNativePlaybackInactive();
+        return true;
+      }
       let snapshot: NativeAudioSnapshot;
       try {
-        snapshot = await playNativeAudio({
-          startTimeSeconds: wasNativeActive
-            ? null
-            : clampTime(timeSeconds, latestSession.durationHintSeconds || 0),
-        });
+        const startTimeSeconds = wasNativeActive
+          ? null : clampTime(timeSeconds, latestSession.durationHintSeconds || 0);
+        const result = await enqueueNativeOutputMutation((control) =>
+          playNativeAudio({
+            ...control,
+            startTimeSeconds,
+            precount: precount ? { intervalsSeconds: precount } : null,
+            metronomeCues: nativePlayCueProvider.current?.(startTimeSeconds ?? timeSeconds),
+          }),
+        );
+        if (!result) {
+          if (pendingNativePlayRef.current?.generation === playGeneration) {
+            pendingNativePlayRef.current = null;
+          }
+          return true;
+        }
+        snapshot = result;
       } catch (error) {
         const pendingNativePlay = pendingNativePlayRef.current;
         if (pendingNativePlay?.generation === playGeneration) {
@@ -944,6 +1337,12 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
         }
         throw error;
       }
+      const completedPendingPlay =
+        pendingNativePlayRef.current?.generation === playGeneration
+          ? pendingNativePlayRef.current
+          : null;
+      const earlyPrecountCompletion = completedPendingPlay?.precountCompletion ?? null;
+      const stopAlreadyRequested = completedPendingPlay?.stopRequested === true;
       if (pendingNativePlayRef.current?.generation === playGeneration) {
         pendingNativePlayRef.current = null;
       }
@@ -953,7 +1352,8 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
         nativePlaybackRef.current.sessionSignature !== sessionSignature ||
         !currentSession ||
         nativeSessionSignature(currentSession) !== sessionSignature ||
-        playbackSignature(currentSession) !== playPlaybackSignature
+        playbackSignature(currentSession) !== playPlaybackSignature ||
+        (shouldContinue && !shouldContinue())
       ) {
         const newerNativePlaybackCurrent =
           currentSession &&
@@ -977,7 +1377,8 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
           snapshot.nativePlaybackSupported &&
           snapshot.state === "playing" &&
           !newerNativePlaybackCurrent &&
-          !newerPendingNativePlaybackCurrent
+          !newerPendingNativePlaybackCurrent &&
+          !stopAlreadyRequested
         ) {
           void requestNativeStop();
         }
@@ -1026,17 +1427,51 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
       });
       if (snapshot.sessionId === sessionSignature && snapshot.state === "playing") {
         setPlaybackControlBackend("native");
-        setIsPlaying(true);
-        markPlaybackConfirmed({
-          backend: "native",
-          detail: nativeBackendRef.current,
-        });
+        if (precount) {
+          if (typeof snapshot.nativeTimeUs !== "number") throw new Error("Native timing metadata is unavailable.");
+          const scheduledAtContextTimeSeconds = snapshot.nativeTimeUs / 1_000_000;
+          const firstClickTimeSeconds = scheduledAtContextTimeSeconds + PRECOUNT_START_DELAY_SECONDS;
+          const telemetry: PlaybackE2ECountInEvent = {
+            clickCount: precount.length, activePath: "native", scheduledAtContextTimeSeconds,
+            firstClickTimeSeconds, sequence: precountSequenceRef.current,
+            playbackStartTimeSeconds: firstClickTimeSeconds + precount.reduce((sum, value) => sum + value, 0),
+            startTimeSeconds: timeSeconds, tempoBpm: latestSession.precountTempoBpm!,
+            trigger: Math.abs(timeSeconds) <= SEEK_TOLERANCE_SECONDS ? "song-start" : "loop-start",
+          };
+          nativePrecountRef.current = {
+            generation: snapshot.generation!,
+            revision: snapshot.timelineRevision!,
+            clockOriginSeconds: scheduledAtContextTimeSeconds - performance.now() / 1000,
+            loopEpoch: precountLoopEpoch,
+            telemetry,
+          };
+          countInTelemetryRef.current = { ...countInTelemetryRef.current, active: true, lastScheduled: telemetry };
+          setIsPrecounting(true);
+          setIsPlaying(false);
+          if (
+            earlyPrecountCompletion &&
+            earlyPrecountCompletion.generation === snapshot.generation &&
+            earlyPrecountCompletion.revision === snapshot.timelineRevision
+          ) {
+            completeNativePrecount(earlyPrecountCompletion);
+          }
+        } else {
+          setIsPlaying(true);
+          markPlaybackConfirmed({ backend: "native", detail: nativeBackendRef.current });
+        }
       } else {
         markPlaybackStarting("native");
       }
       return true;
     } catch (error) {
       const currentSession = sessionRef.current;
+      if (
+        !currentSession ||
+        nativeSessionSignature(currentSession) !== sessionSignature ||
+        (shouldContinue && !shouldContinue())
+      ) {
+        return true;
+      }
       if (
         playAttempt &&
         (nativeControlGenerationRef.current !== playAttempt.generation ||
@@ -1139,7 +1574,9 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
     reason: PlaybackE2ECountInCancelReason,
   ) {
     const activePrecount = activePrecountRef.current;
+    const nativePrecount = nativePrecountRef.current;
     activePrecountRef.current = null;
+    nativePrecountRef.current = null;
     precountSequenceRef.current += 1;
     if (activePrecount) {
       countInTelemetryRef.current = {
@@ -1147,12 +1584,21 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
         active: false,
         lastCancelled: playbackCountInCancelledEvent(
           activePrecount.telemetry,
-          activePrecount.context,
+          activePrecount.context.state === "closed" ? null : activePrecount.context.currentTime,
           reason,
         ),
       };
     }
+    if (nativePrecount) {
+      countInTelemetryRef.current = { ...countInTelemetryRef.current, active: false, lastCancelled:
+        playbackCountInCancelledEvent(nativePrecount.telemetry, nativePrecount.clockOriginSeconds + performance.now() / 1000, reason) };
+    }
     setIsPrecounting(false);
+
+    if (nativePrecount) {
+      markNativePlaybackInactive();
+      void requestNativeStop();
+    }
 
     if (!activePrecount) {
       return;
@@ -1169,6 +1615,39 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
     }
     if (activePrecount.context.state !== "closed") {
       void activePrecount.context.close().catch(() => undefined);
+    }
+  });
+
+  const updateActiveLoopRange = useStableCallback(function updateActiveLoopRange(
+    loopRange: ProjectPlaybackSession["loopRange"],
+  ) {
+    const nextLoopEpoch = loopEpochRef.current + 1;
+    loopEpochRef.current = nextLoopEpoch;
+    invalidateNativeOutputMutations();
+    nativeControlGenerationRef.current += 1;
+    const shouldResumeLoopPlayback =
+      loopRange === null &&
+      (activePrecountRef.current?.telemetry.trigger === "loop-start" ||
+        nativePrecountRef.current?.telemetry.trigger === "loop-start");
+    cancelPrecount("superseded");
+    const activeSession = sessionRef.current;
+    if (!activeSession) {
+      return;
+    }
+    const nextSession = { ...activeSession, loopRange };
+    sessionRef.current = nextSession;
+    setSession(nextSession);
+    writePlaybackE2ETelemetry({ loopRange: getPlayableLoopRange(nextSession) });
+    if (shouldResumeLoopPlayback) {
+      const pendingStop = nativeStopPromiseRef.current ?? Promise.resolve();
+      void pendingStop.then(() => {
+        if (
+          loopEpochRef.current === nextLoopEpoch &&
+          sessionRef.current?.loopRange === null
+        ) {
+          void playPlaybackImmediately();
+        }
+      });
     }
   });
 
@@ -1397,7 +1876,10 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
     }
   });
 
-  const prepareStemPlaybackState = useStableCallback(async function prepareStemPlaybackState(targetSession: ProjectPlaybackSession) {
+  const prepareStemPlaybackState = useStableCallback(async function prepareStemPlaybackState(
+    targetSession: ProjectPlaybackSession,
+    shouldContinue?: () => boolean,
+  ) {
     const signature = playbackSignature(targetSession);
     const existingPlaybackState = stemPlaybackRef.current;
     if (existingPlaybackState?.signature === signature) {
@@ -1417,6 +1899,12 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
     }
 
     const buffers = await getStemBuffers(artifactIds);
+    if (
+      (shouldContinue && !shouldContinue()) ||
+      playbackSignature(sessionRef.current) !== signature
+    ) {
+      return null;
+    }
     const durationSeconds = Math.max(
       targetSession.durationHintSeconds || 0,
       ...Object.values(buffers).map((buffer) => buffer.duration || 0),
@@ -1450,18 +1938,24 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
     targetSession: ProjectPlaybackSession,
     timeSeconds: number,
     scheduledStartTimeSeconds?: number,
-    { fadeIn = false }: { fadeIn?: boolean } = {},
+    {
+      fadeIn = false,
+      shouldContinue,
+    }: { fadeIn?: boolean; shouldContinue?: () => boolean } = {},
   ) {
     if (!canUseBufferedClock(targetSession)) {
       return false;
     }
 
-    const targetPlaybackState = await prepareStemPlaybackState(targetSession);
+    const targetPlaybackState = await prepareStemPlaybackState(targetSession, shouldContinue);
     if (!targetPlaybackState) {
       return false;
     }
 
-    if (stemPlaybackRef.current !== targetPlaybackState) {
+    if (
+      stemPlaybackRef.current !== targetPlaybackState ||
+      (shouldContinue && !shouldContinue())
+    ) {
       return false;
     }
 
@@ -1472,6 +1966,12 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
       disposeStemPlaybackState();
       markWebPlaybackStartResult(false);
       setIsPlaying(false);
+      return false;
+    }
+    if (
+      stemPlaybackRef.current !== targetPlaybackState ||
+      (shouldContinue && !shouldContinue())
+    ) {
       return false;
     }
     stopStemSources(targetPlaybackState, false);
@@ -1686,8 +2186,12 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
       nativePlaybackRef.current.active &&
       nativePlaybackRef.current.sessionSignature === nativeSessionSignature(targetSession)
     ) {
-      void setNativeAudioLanes(nativeLaneUpdateForSession(targetSession))
-        .then((snapshot) => recordNativeSnapshot(snapshot))
+      void enqueueNativeLaneMutation(targetSession)
+        .then((snapshot) => {
+          if (snapshot) {
+            recordNativeSnapshot(snapshot);
+          }
+        })
         .catch((error) => {
           rememberNativePlaybackError(playbackErrorMessage(error));
         });
@@ -1745,6 +2249,51 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
     return nextTime;
   });
 
+  const requestNativeSeek = useStableCallback(async function requestNativeSeek(
+    targetSession: ProjectPlaybackSession,
+    timeSeconds: number,
+  ) {
+    const seekGeneration = nativeControlGenerationRef.current + 1;
+    nativeControlGenerationRef.current = seekGeneration;
+    const seekSessionSignature = nativePlaybackRef.current.sessionSignature;
+    try {
+      const snapshot = await enqueueNativeOutputMutation((control) =>
+        seekNativeAudio({ ...control, timeSeconds }),
+      );
+      if (
+        !snapshot ||
+        nativeControlGenerationRef.current !== seekGeneration ||
+        nativePlaybackRef.current.sessionSignature !== seekSessionSignature ||
+        playbackSignature(sessionRef.current) !== playbackSignature(targetSession)
+      ) {
+        return null;
+      }
+      if (!recordNativeSnapshot(snapshot, {
+        activePath: "native",
+        transportState: snapshot.state,
+      })) {
+        return null;
+      }
+      setPlaybackTimeSeconds(snapshot.positionSeconds);
+      const cues = nativePlayCueProvider.current?.(snapshot.positionSeconds);
+      if (cues) {
+        void updateFollowedMetronomeCues(cues).catch(() => undefined);
+      }
+      return snapshot;
+    } catch {
+      if (
+        nativeControlGenerationRef.current === seekGeneration &&
+        nativePlaybackRef.current.sessionSignature === seekSessionSignature
+      ) {
+        void requestNativeStop();
+        markNativePlaybackInactive();
+        clearPlaybackControlBackend();
+        setIsPlaying(false);
+      }
+      return null;
+    }
+  });
+
   const restartLoopIfNeeded = useStableCallback(function restartLoopIfNeeded(
     targetSession: ProjectPlaybackSession | null,
     timeSeconds: number,
@@ -1766,6 +2315,13 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
       return false;
     }
 
+    const loopEpoch = ++loopEpochRef.current;
+    const targetSignature = playbackSignature(targetSession);
+    const loopIsCurrent = () =>
+      loopEpochRef.current === loopEpoch &&
+      playbackSignature(sessionRef.current) === targetSignature &&
+      getPlayableLoopRange(sessionRef.current) !== null;
+
     void (async () => {
       if (
         targetSession &&
@@ -1775,7 +2331,10 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
         targetSession.precountTempoBpm > 0
       ) {
         if (nativePlaybackRef.current.active) {
-          void requestNativeStop();
+          await requestNativeStop();
+          if (!loopIsCurrent()) {
+            return;
+          }
           markNativePlaybackInactive();
         }
         if (stemPlaybackRef.current) {
@@ -1791,6 +2350,7 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
         clearPlaybackControlBackend();
         setIsPlaying(false);
         if (
+          loopIsCurrent() &&
           await startPrecountThenPlayback(targetSession, loopRange.startSeconds, {
             loopWrap: true,
           })
@@ -1798,10 +2358,26 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
           return;
         }
       }
+      if (!loopIsCurrent()) {
+        return;
+      }
+      if (targetSession && nativePlaybackRef.current.active) {
+        invalidateNativeOutputMutations();
+        const snapshot = await requestNativeSeek(targetSession, loopRange.startSeconds);
+        if (!snapshot || !loopIsCurrent()) {
+          return;
+        }
+        if (snapshot.state === "stopped" && isPlayingRef.current) {
+          await playPlaybackImmediately({ forceStartAtZero: true });
+        }
+        return;
+      }
       seekTo(loopRange.startSeconds);
+      const seekLoopEpoch = loopEpochRef.current;
       if (
         targetSession &&
         isPlayingRef.current &&
+        loopEpochRef.current === seekLoopEpoch &&
         playbackSignature(sessionRef.current) === playbackSignature(targetSession)
       ) {
         const bufferedClockIsActive =
@@ -2064,9 +2640,20 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
       }
 
       if (pendingTransition.shouldPlay) {
+        const nativeTransition = pendingTransition;
+        const playbackIntentEpoch = playbackIntentEpochRef.current;
+        const transitionShouldContinue = () => {
+          return (
+            playbackIntentEpochRef.current === playbackIntentEpoch &&
+            nativeTransition.shouldPlay
+          );
+        };
         const started = await tryStartNativePlayback(
           targetSession,
-          pendingTransition.targetTime,
+          nativeTransition.targetTime,
+          undefined,
+          null,
+          transitionShouldContinue,
         );
         const latestPendingTransition = pendingTransitionRef.current;
         const latestSession = sessionRef.current;
@@ -2271,6 +2858,8 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
   });
 
   const pausePlayback = useCallback(() => {
+    loopEpochRef.current += 1;
+    playbackIntentEpochRef.current += 1;
     allowFreshPlaybackRef.current = false;
     if (pendingNativeRecoveryRef.current) {
       pendingNativeRecoveryRef.current = null;
@@ -2278,12 +2867,54 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
     }
     cancelPrecount("playback-stopped");
     const pendingTransition = pendingTransitionRef.current;
+    const pendingTransitionWasPlaying = pendingTransition?.shouldPlay === true;
     if (pendingTransition) {
       pendingTransition.shouldPlay = false;
     }
 
     const targetSession = sessionRef.current;
-    if (nativePlaybackRef.current.active) {
+    const pendingNativePlay = pendingNativePlayRef.current;
+    const targetNativeSessionSignature = targetSession
+      ? nativeSessionSignature(targetSession)
+      : null;
+    const currentPendingNativePlay = Boolean(
+      targetSession &&
+        pendingNativePlay &&
+        pendingNativePlay.generation === nativeControlGenerationRef.current &&
+        pendingNativePlay.sessionSignature === targetNativeSessionSignature &&
+        pendingNativePlay.playbackSignature === playbackSignature(targetSession),
+    );
+    const currentPreparedNativeSession = Boolean(
+      targetSession &&
+        nativePlaybackRef.current.sessionSignature === targetNativeSessionSignature &&
+        nativePlaybackRef.current.generation !== null &&
+        nativePlaybackRef.current.timelineRevision !== null,
+    );
+    const currentNativeHandoff = Boolean(
+      targetSession &&
+        pendingTransitionWasPlaying &&
+        (nativeStopPromiseRef.current ||
+          nativePlaybackRef.current.preparePromise ||
+          nativePlaybackRef.current.prepareSignature === targetNativeSessionSignature),
+    );
+    if (
+      !nativePlaybackRef.current.active &&
+      (currentPendingNativePlay || currentPreparedNativeSession || currentNativeHandoff)
+    ) {
+      if (currentPendingNativePlay && pendingNativePlay) {
+        pendingNativePlay.stopRequested = true;
+      }
+      nativeControlGenerationRef.current += 1;
+      if (nativePlaybackRef.current.sessionSignature === targetNativeSessionSignature) {
+        void requestNativeStop();
+      }
+      markNativePlaybackInactive();
+      clearPlaybackControlBackend();
+      setIsPlaying(false);
+      markPlaybackPaused();
+      return;
+    }
+    if (nativePlaybackRef.current.active && targetSession) {
       const pauseGeneration = nativeControlGenerationRef.current + 1;
       nativeControlGenerationRef.current = pauseGeneration;
       const pausedSessionSignature = nativePlaybackRef.current.sessionSignature;
@@ -2291,14 +2922,21 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
         generation: pauseGeneration,
         sessionSignature: pausedSessionSignature,
       };
-      void pauseNativeAudio()
+      void enqueueNativeOutputMutation(
+        (control) => pauseNativeAudio(control),
+        { allowStaleIntent: true },
+      )
         .then((snapshot) => {
-          if (pendingNativePauseRef.current?.generation === pauseGeneration) {
+          const pauseStillCurrent =
+            pendingNativePauseRef.current?.generation === pauseGeneration;
+          if (pauseStillCurrent) {
             pendingNativePauseRef.current = null;
           }
           if (
-            nativeControlGenerationRef.current !== pauseGeneration ||
+            !snapshot ||
+            !pauseStillCurrent ||
             nativePlaybackRef.current.sessionSignature !== pausedSessionSignature ||
+            nativeSessionSignature(sessionRef.current) !== pausedSessionSignature ||
             playbackControlBackendRef.current !== "native"
           ) {
             return;
@@ -2329,8 +2967,23 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
           markPlaybackPaused();
         })
         .catch(() => {
-          if (pendingNativePauseRef.current?.generation === pauseGeneration) {
+          const pauseStillCurrent =
+            pendingNativePauseRef.current?.generation === pauseGeneration;
+          if (pauseStillCurrent) {
             pendingNativePauseRef.current = null;
+          }
+          if (
+            pauseStillCurrent &&
+            nativeControlGenerationRef.current === pauseGeneration &&
+            nativePlaybackRef.current.sessionSignature === pausedSessionSignature &&
+            nativeSessionSignature(sessionRef.current) === pausedSessionSignature &&
+            playbackControlBackendRef.current === "native"
+          ) {
+            setIsPlaying(true);
+            markPlaybackConfirmed({
+              backend: "native",
+              detail: nativeBackendRef.current,
+            });
           }
         });
       return;
@@ -2360,6 +3013,7 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
     canUseBufferedClock,
     cancelPrecount,
     clearPlaybackControlBackend,
+    enqueueNativeOutputMutation,
     getActiveMediaElements,
     markNativePlaybackInactive,
     recordNativePlaybackFailure,
@@ -2374,13 +3028,25 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
     {
       forceStartAtZero = false,
       scheduledStemStartTimeSeconds,
+      shouldContinue,
     }: {
       forceStartAtZero?: boolean;
       scheduledStemStartTimeSeconds?: number;
+      shouldContinue?: () => boolean;
     } = {},
   ) {
     const targetSession = sessionRef.current;
     if (!targetSession) {
+      return;
+    }
+    const targetSignature = playbackSignature(targetSession);
+    const playbackIntentEpoch = playbackIntentEpochRef.current;
+    const playbackIsCurrent =
+      shouldContinue ??
+      (() =>
+        playbackIntentEpochRef.current === playbackIntentEpoch &&
+        playbackSignature(sessionRef.current) === targetSignature);
+    if (!playbackIsCurrent()) {
       return;
     }
 
@@ -2396,7 +3062,14 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
       ? playbackResetTimeForSession(targetSession)
       : readMasterTime(targetSession);
     const masterTime = playbackStartTimeForSession(targetSession, requestedMasterTime);
-    if (await tryStartNativePlayback(targetSession, masterTime)) {
+    if (await tryStartNativePlayback(targetSession, masterTime, undefined, null, playbackIsCurrent)) {
+      return;
+    }
+    if (!playbackIsCurrent()) {
+      return;
+    }
+    if (isTauriRuntime() && !isWebAudioBackendForced()) {
+      markPlaybackError("Native playback could not start. Press Play to retry.");
       return;
     }
 
@@ -2405,7 +3078,11 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
         targetSession,
         masterTime,
         scheduledStemStartTimeSeconds,
+        { shouldContinue: playbackIsCurrent },
       );
+      if (!playbackIsCurrent()) {
+        return;
+      }
       if (started) {
         markNativePlaybackInactive();
         return;
@@ -2458,6 +3135,9 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
     applyMediaPlaybackRate(targetSession);
 
     markNativePlaybackInactive();
+    if (!playbackIsCurrent()) {
+      return;
+    }
     const started = await playWebMediaElements(activeElements);
     markWebPlaybackStartResult(started);
   });
@@ -2493,19 +3173,53 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
     }
     allowFreshPlaybackRef.current = false;
 
-    const clickCount = normalizePrecountClickCount(targetSession.precountClickCount);
-    const signature = playbackSignature(targetSession);
     cancelPrecount("superseded");
     const sequence = ++precountSequenceRef.current;
+    const clickCount = normalizePrecountClickCount(targetSession.precountClickCount);
+    const signature = playbackSignature(targetSession);
+    const loopEpoch = options.loopWrap === true ? loopEpochRef.current : null;
+    const precountIsCurrent = () =>
+      precountSequenceRef.current === sequence &&
+      playbackSignature(sessionRef.current) === signature &&
+      (loopEpoch === null || loopEpochRef.current === loopEpoch);
+    const beatSeconds = 60 / tempoBpm;
+    const countInIntervals = countInIntervalsForTiming({
+      clickCount,
+      fallbackBeatSeconds: beatSeconds,
+      sourceTempoBpm: targetSession.tempoOriginalBpm,
+      startTimeSeconds,
+      targetTempoBpm: targetSession.precountTempoBpm,
+      timingGrid: targetSession.timingGrid,
+    });
+
+    if (isTauriRuntime() && !isWebAudioBackendForced()) {
+      setPlaybackTimeSeconds(startTimeSeconds);
+      const started = await tryStartNativePlayback(
+        targetSession,
+        startTimeSeconds,
+        countInIntervals,
+        loopEpoch,
+        precountIsCurrent,
+      );
+      if (!started) {
+        setIsPrecounting(false);
+        setIsPlaying(false);
+        markPlaybackError("Native playback could not start. Press Play to retry.");
+      }
+      return true;
+    }
 
     let preparedStemPlaybackState: StemPlaybackState | null = null;
     const willUsePlaybackAudioContext = canUseBufferedClock(targetSession);
     if (willUsePlaybackAudioContext) {
-      preparedStemPlaybackState = await prepareStemPlaybackState(targetSession);
+      preparedStemPlaybackState = await prepareStemPlaybackState(
+        targetSession,
+        precountIsCurrent,
+      );
       if (!preparedStemPlaybackState) {
         return false;
       }
-      if (precountSequenceRef.current !== sequence || playbackSignature(sessionRef.current) !== signature) {
+      if (!precountIsCurrent()) {
         return true;
       }
     }
@@ -2527,7 +3241,7 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
       return false;
     }
 
-    if (precountSequenceRef.current !== sequence || playbackSignature(sessionRef.current) !== signature) {
+    if (!precountIsCurrent()) {
       if (precountAudio.ownsContext && precountAudioContextRef.current === precountAudio.context) {
         precountAudioContextRef.current = null;
       }
@@ -2549,13 +3263,6 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
     }
     setPlaybackTimeSeconds(startTimeSeconds);
 
-    const beatSeconds = 60 / tempoBpm;
-    const countInIntervals = countInIntervalsForTiming({
-      clickCount,
-      fallbackBeatSeconds: beatSeconds,
-      startTimeSeconds,
-      timingGrid: targetSession.timingGrid,
-    });
     const firstClickTimeSeconds = precountAudio.context.currentTime + PRECOUNT_START_DELAY_SECONDS;
     const playbackStartTimeSeconds =
       firstClickTimeSeconds + countInIntervals.reduce((total, interval) => total + interval, 0);
@@ -2584,7 +3291,13 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
 
     const timeoutId = window.setTimeout(() => {
       const activePrecount = activePrecountRef.current;
-      if (!activePrecount || activePrecount.sequence !== sequence || activePrecount.signature !== signature) {
+      if (
+        !activePrecount ||
+        activePrecount.sequence !== sequence ||
+        activePrecount.signature !== signature ||
+        (activePrecount.loopEpoch !== null &&
+          activePrecount.loopEpoch !== loopEpochRef.current)
+      ) {
         return;
       }
 
@@ -2592,7 +3305,8 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
       countInTelemetryRef.current = {
         ...countInTelemetryRef.current,
         active: false,
-        lastFired: playbackCountInFiredEvent(activePrecount.telemetry, activePrecount.context),
+        lastFired: playbackCountInFiredEvent(activePrecount.telemetry,
+          activePrecount.context.state === "closed" ? null : activePrecount.context.currentTime),
       };
       setIsPrecounting(false);
       closeOwnedPrecountContext(activePrecount);
@@ -2613,6 +3327,7 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
       clickHandles,
       context: precountAudio.context,
       ownsContext: precountAudio.ownsContext,
+      loopEpoch,
       sequence,
       signature,
       telemetry: countInTelemetry,
@@ -2629,7 +3344,7 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
   });
 
   const playPlayback = useCallback(async () => {
-    if (activePrecountRef.current) {
+    if (activePrecountRef.current || nativePrecountRef.current) {
       cancelPrecount("cancelled");
       return;
     }
@@ -2638,6 +3353,11 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
     if (!targetSession) {
       return;
     }
+    const playbackIntentEpoch = playbackIntentEpochRef.current;
+    const signature = playbackSignature(targetSession);
+    const playbackIsCurrent = () =>
+      playbackIntentEpochRef.current === playbackIntentEpoch &&
+      playbackSignature(sessionRef.current) === signature;
 
     const pendingNativePlay = pendingNativePlayRef.current;
     if (
@@ -2663,9 +3383,12 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
     if (await startPrecountThenPlayback(targetSession, masterTime)) {
       return;
     }
+    if (!playbackIsCurrent()) {
+      return;
+    }
 
     allowFreshPlaybackRef.current = false;
-    await playPlaybackImmediately();
+    await playPlaybackImmediately({ shouldContinue: playbackIsCurrent });
   }, [
     cancelPrecount,
     playPlaybackImmediately,
@@ -2691,6 +3414,8 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
   }, [cancelPrecount, pausePlayback, playPlayback, primeWebAudioForGesture]);
 
   const seekTo = useCallback((timeSeconds: number) => {
+    loopEpochRef.current += 1;
+    playbackIntentEpochRef.current += 1;
     cancelPrecount("superseded");
     const targetSession = sessionRef.current;
     const nextTime = targetSession
@@ -2701,34 +3426,10 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
       pendingTransition.targetTime = nextTime;
     }
 
-    if (nativePlaybackRef.current.active) {
-      const seekGeneration = nativeControlGenerationRef.current + 1;
-      nativeControlGenerationRef.current = seekGeneration;
-      const seekSessionSignature = nativePlaybackRef.current.sessionSignature;
-      void seekNativeAudio({ timeSeconds: nextTime })
-        .then((snapshot) => {
-          if (
-            nativeControlGenerationRef.current !== seekGeneration ||
-            nativePlaybackRef.current.sessionSignature !== seekSessionSignature
-          ) {
-            return;
-          }
-          recordNativeSnapshot(snapshot, {
-            activePath: "native",
-            transportState: snapshot.state,
-          });
-          setPlaybackTimeSeconds(snapshot.positionSeconds);
-        })
-        .catch(() => {
-          if (
-            nativeControlGenerationRef.current !== seekGeneration ||
-            nativePlaybackRef.current.sessionSignature !== seekSessionSignature
-          ) {
-            return;
-          }
-          markNativePlaybackInactive();
-          clearPlaybackControlBackend();
-        });
+    if (nativePlaybackRef.current.active && targetSession) {
+      invalidateNativeOutputMutations();
+      setPlaybackTimeSeconds(nextTime);
+      void requestNativeSeek(targetSession, nextTime);
       return;
     }
 
@@ -2756,11 +3457,9 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
   }, [
     canUseBufferedClock,
     cancelPrecount,
-    clearPlaybackControlBackend,
     getActiveMediaElements,
-    markNativePlaybackInactive,
     playbackStartTimeForSession,
-    recordNativeSnapshot,
+    requestNativeSeek,
     setPlaybackTimeSeconds,
     startStemPlayback,
     syncStemElementTimes,
@@ -2774,6 +3473,8 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
   );
 
   const stopPlayback = useCallback(() => {
+    loopEpochRef.current += 1;
+    playbackIntentEpochRef.current += 1;
     allowFreshPlaybackRef.current = true;
     pendingNativeRecoveryRef.current = null;
     nativeControlGenerationRef.current += 1;
@@ -2790,6 +3491,13 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
         (targetNativeSessionSignature === null ||
           nativePlaybackRef.current.sessionSignature === targetNativeSessionSignature));
     if (shouldStopNativeSession) {
+      const pendingNativePlay = pendingNativePlayRef.current;
+      if (
+        pendingNativePlay &&
+        pendingNativePlay.sessionSignature === nativePlaybackRef.current.sessionSignature
+      ) {
+        pendingNativePlay.stopRequested = true;
+      }
       void requestNativeStop();
       markNativePlaybackInactive();
     }
@@ -2827,6 +3535,7 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
   ]);
 
   const dismissSession = useCallback(() => {
+    loopEpochRef.current += 1;
     stopPlayback();
     closePlaybackAudioContext();
     setSession(null);
@@ -2840,8 +3549,20 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
     const nextSignature = playbackSignature(nextSession);
 
     if (previousSession && previousSession.projectId !== nextSession.projectId) {
+      loopEpochRef.current += 1;
+      playbackIntentEpochRef.current += 1;
       pendingNativeRecoveryRef.current = null;
       nativeControlGenerationRef.current += 1;
+      if (
+        nativePlaybackRef.current.sessionSignature !== null &&
+        nativePlaybackRef.current.generation !== null &&
+        nativePlaybackRef.current.timelineRevision !== null
+      ) {
+        void requestNativeStop();
+        markNativePlaybackInactive();
+      } else {
+        invalidateNativeOutputMutations();
+      }
       const resetTime = playbackResetTimeForSession(nextSession);
       cancelPrecount("session-changed");
       clearPendingTransition();
@@ -2857,6 +3578,7 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
       setIsPlaying(false);
       markPlaybackStopped();
     } else if (previousSession && previousSignature !== nextSignature) {
+      invalidateNativeOutputMutations();
       cancelPrecount("session-changed");
       const activePendingTransition = pendingTransitionRef.current;
       const requestedTransitionTime =
@@ -2926,10 +3648,11 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
           void releaseSystemMediaControls().catch((error) => recordNativePlaybackFailure(error));
         };
 
-        void setNativeAudioLanes(nativeLaneUpdateForSession(nextSession))
+        void enqueueNativeLaneMutation(nextSession)
           .then((snapshot) => {
             const latestSession = sessionRef.current;
             if (
+              !snapshot ||
               !latestSession ||
               playbackSignature(latestSession) !== nextSignature ||
               nativeSessionSignature(latestSession) !== nextNativeSessionSignature
@@ -3049,6 +3772,7 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
     clearPendingTransition,
     closePlaybackAudioContext,
     disposeStemPlaybackState,
+    enqueueNativeLaneMutation,
     getActiveMediaElements,
     getRenderedMediaElements,
     markNativePlaybackInactive,
@@ -3174,6 +3898,7 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
         if (
           !activeSession ||
           !nativePlaybackRef.current.active ||
+          nativePrecountRef.current !== null ||
           position.sessionId !== nativePlaybackRef.current.sessionSignature
         ) {
           return;
@@ -3182,8 +3907,23 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
           setPlaybackDurationSeconds(position.durationSeconds || activeSession.durationHintSeconds || 0);
           return;
         }
+        const loopRange = getPlayableLoopRange(activeSession);
+        const stoppedAtActiveLoopEnd =
+          position.state === "stopped" &&
+          isPlayingRef.current &&
+          loopRange !== null &&
+          position.positionSeconds >= loopRange.endSeconds - SEEK_TOLERANCE_SECONDS;
         setPlaybackTimeSeconds(position.positionSeconds);
         setPlaybackDurationSeconds(position.durationSeconds || activeSession.durationHintSeconds || 0);
+        if (stoppedAtActiveLoopEnd) {
+          writePlaybackE2ETelemetry({
+            activePath: "native",
+            transportState: "playing",
+            positionSeconds: position.positionSeconds,
+            durationSeconds: position.durationSeconds || activeSession.durationHintSeconds || 0,
+          });
+          return;
+        }
         if (position.state === "stopped") {
           clearPlaybackControlBackend();
           markPlaybackStopped();
@@ -3205,10 +3945,16 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
         });
       }),
       listenNativeAudioEnded((snapshot: NativeAudioSnapshot) => {
-        if (snapshot.sessionId !== nativePlaybackRef.current.sessionSignature) {
+        const activeSession = sessionRef.current;
+        if (
+          !activeSession ||
+          snapshot.sessionId !== nativePlaybackRef.current.sessionSignature ||
+          nativeSessionSignature(activeSession) !== snapshot.sessionId ||
+          (typeof snapshot.generation === "number" &&
+            snapshot.generation !== nativePlaybackRef.current.generation)
+        ) {
           return;
         }
-        const activeSession = sessionRef.current;
         markNativePlaybackInactive();
         void requestNativeStop();
         recordNativeSnapshot(snapshot, {
@@ -3228,6 +3974,63 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
           element.pause();
           element.currentTime = resetTime;
         });
+      }),
+      listenNativeAudioCues((cue) => {
+        const active = nativePrecountRef.current;
+        if (!active) {
+          const pendingNativePlay = pendingNativePlayRef.current;
+          if (
+            cue.kind === "precount_completion" &&
+            pendingNativePlay?.hasPrecount === true &&
+            pendingNativePlay.generation === nativeControlGenerationRef.current &&
+            pendingNativePlay.sessionSignature === nativePlaybackRef.current.sessionSignature &&
+            cue.generation === nativePlaybackRef.current.generation
+          ) {
+            pendingNativePlay.precountCompletion = cue;
+          }
+          return;
+        }
+        if (
+          cue.generation !== active.generation ||
+          cue.revision !== active.revision ||
+          (active.loopEpoch !== null && active.loopEpoch !== loopEpochRef.current)
+        ) return;
+        if (cue.kind === "precount_beat" && cue.cueIndex === 0) {
+          const firstClickTimeSeconds = cue.scheduledNativeTimeUs / 1_000_000;
+          active.telemetry = { ...active.telemetry, firstClickTimeSeconds,
+            playbackStartTimeSeconds: active.telemetry.playbackStartTimeSeconds + firstClickTimeSeconds - active.telemetry.firstClickTimeSeconds };
+          countInTelemetryRef.current = { ...countInTelemetryRef.current, lastScheduled: active.telemetry };
+          writePlaybackE2ETelemetry();
+          return;
+        }
+        completeNativePrecount(cue);
+      }),
+      listenNativeAudioTerminal((terminal) => {
+        const activeSession = sessionRef.current;
+        if (
+          !activeSession ||
+          terminal.generation !== nativePlaybackRef.current.generation ||
+          nativeSessionSignature(activeSession) !== nativePlaybackRef.current.sessionSignature
+        ) return;
+        const activePrecount = nativePrecountRef.current;
+        if (activePrecount) countInTelemetryRef.current = { ...countInTelemetryRef.current, active: false,
+          lastCancelled: playbackCountInCancelledEvent(activePrecount.telemetry, terminal.nativeTimeUs / 1_000_000, "unavailable") };
+        nativePrecountRef.current = null;
+        nativePlaybackRef.current = {
+          ...nativePlaybackRef.current,
+          active: false,
+          blockedSessionSignature: nativePlaybackRef.current.sessionSignature,
+          preparePromise: null,
+          prepareSignature: null,
+          sessionSignature: null,
+          playbackSignature: null,
+          generation: null,
+          timelineRevision: null,
+        };
+        clearPlaybackControlBackend();
+        setIsPrecounting(false);
+        setIsPlaying(false);
+        markPlaybackError("Native playback stopped. Press Play to retry.");
       }),
       listenNativeAudioErrors((error) => {
         const activeSession = sessionRef.current;
@@ -3259,6 +4062,15 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
         const message = nativePlaybackErrorMessage(error.code);
         if (error.code === "device_changed") {
           rememberNativePlaybackError(message);
+          return;
+        }
+        if (!isWebAudioBackendForced()) {
+          recordNativePlaybackFailure(message);
+          nativePlaybackRef.current.blockedSessionSignature = error.sessionId;
+          markNativePlaybackInactive();
+          clearPlaybackControlBackend();
+          setIsPlaying(false);
+          markPlaybackError("Native playback stopped. Press Play to retry.");
           return;
         }
         const shouldContinuePlayback =
@@ -3338,7 +4150,9 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
     };
   }, [
     clearPlaybackControlBackend,
+    completeNativePrecount,
     getRenderedMediaElements,
+    getPlayableLoopRange,
     markNativePlaybackInactive,
     playbackResetTimeForSession,
     playPlaybackImmediately,
@@ -3347,6 +4161,7 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
     requestNativeStop,
     restartActiveLoopPlayback,
     restartLoopIfNeeded,
+    setIsPrecounting,
     setIsPlaying,
     setPlaybackControlBackend,
     setPlaybackDurationSeconds,
@@ -3385,6 +4200,8 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
       primeWebAudioForGesture,
       getPlaybackSnapshot,
       registerProjectSession,
+      updateActiveLoopRange,
+      updateFollowedMetronomeCues,
       togglePlayback,
       playPlayback,
       pausePlayback,
@@ -3405,6 +4222,8 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
       playbackTimeSeconds,
       playPlayback,
       registerProjectSession,
+      updateActiveLoopRange,
+      updateFollowedMetronomeCues,
       seekBy,
       seekTo,
       session,

--- a/apps/desktop/src/features/projects/precountSound.test.ts
+++ b/apps/desktop/src/features/projects/precountSound.test.ts
@@ -38,7 +38,7 @@ describe("precount sound", () => {
     getMockAudioContexts().length = 0;
   });
 
-  it("schedules a fixed lower full-volume clave-style click", () => {
+  it("schedules the shared 760 Hz triangle count-in envelope", () => {
     const audioContext = new AudioContext() as MockAudioContext;
 
     schedulePrecountClaveClick({
@@ -52,7 +52,7 @@ describe("precount sound", () => {
       throw new Error("Expected precount click nodes to be created.");
     }
 
-    expect(oscillator.type).toBe("square");
+    expect(oscillator.type).toBe("triangle");
     const startFrequencyCall = oscillator.frequency.setValueAtTime.mock.calls[0];
     const startFrequencyHz = Number(startFrequencyCall?.[0]);
     const safeStartTimeSeconds = Number(startFrequencyCall?.[1]);

--- a/apps/desktop/src/features/projects/precountSound.ts
+++ b/apps/desktop/src/features/projects/precountSound.ts
@@ -40,7 +40,7 @@ export function schedulePrecountClaveClick({
     disconnectAudioNode(gainNode);
   };
 
-  oscillator.type = "square";
+  oscillator.type = "triangle";
   oscillator.frequency.setValueAtTime(PRECOUNT_FREQUENCY_HZ, safeStartTimeSeconds);
   gainNode.gain.setValueAtTime(0.0001, safeStartTimeSeconds);
   gainNode.gain.exponentialRampToValueAtTime(PRECOUNT_GAIN, peakTimeSeconds);

--- a/apps/desktop/src/features/tools/metronome.tsx
+++ b/apps/desktop/src/features/tools/metronome.tsx
@@ -1,7 +1,12 @@
 import { useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import {
+  getNativeAudioSessionSnapshot,
   isWebAudioBackendForced,
-  setNativeAudioClick,
+  listenNativeAudioCues,
+  listenNativeAudioSessions,
+  listenNativeAudioTerminal,
+  nativePlayCueProvider,
+  type NativeAudioSessionSnapshot,
 } from "../../lib/nativeAudio";
 import { useStableCallback } from "../../lib/useStableCallback";
 import { nextTimedBeatIndex, type AnalysisTimingBeat } from "../../lib/timingGrid";
@@ -31,7 +36,12 @@ const SCHEDULER_INTERVAL_MS = 25;
 const START_DELAY_SECONDS = 0.035;
 
 export function MetronomeProvider({ children }: { children: ReactNode }) {
-  const { getPlaybackSnapshot, isPlaying, session } = usePlayback();
+  const {
+    getPlaybackSnapshot,
+    isPlaying,
+    session,
+    updateFollowedMetronomeCues,
+  } = usePlayback();
   const [bpm, setBpm] = useState(() => normalizeMetronomeBpm(null));
   const [bpmDraft, setBpmDraft] = useState(() => normalizeMetronomeBpm(null).toString());
   const [beatsPerBar, setBeatsPerBar] = useState(DEFAULT_BEATS_PER_BAR);
@@ -52,7 +62,8 @@ export function MetronomeProvider({ children }: { children: ReactNode }) {
   const isRunningRef = useRef(isRunning);
   const lastSyncedPlaybackTimeRef = useRef<number | null>(null);
   const lastSyncedScheduledBeatRef = useRef<number | null>(null);
-  const nativeFollowClickActiveRef = useRef(false);
+  const [nativeSession, setNativeSession] = useState<NativeAudioSessionSnapshot | null>(null);
+  const nativeActivationEpochRef = useRef(0);
   const nextFreeRunBeatIndexRef = useRef(0);
   const schedulerIntervalRef = useRef<number | null>(null);
   const tapTempoStateRef = useRef<TapTempoState>(createTapTempoState());
@@ -152,15 +163,13 @@ export function MetronomeProvider({ children }: { children: ReactNode }) {
     const accent = timingBeat
       ? accentFirstBeatRef.current && timingBeat.beat_in_bar === 1
       : isAccentBeat(beatIndex, beatsPerBarRef.current, accentFirstBeatRef.current);
-    if (!(followPlaybackRef.current && nativeFollowClickActiveRef.current)) {
-      scheduleMetronomeClick({
-        accent,
-        audioContext,
-        sound: DEFAULT_METRONOME_SOUND,
-        startTimeSeconds,
-        volume: volumeRef.current,
-      });
-    }
+    scheduleMetronomeClick({
+      accent,
+      audioContext,
+      sound: DEFAULT_METRONOME_SOUND,
+      startTimeSeconds,
+      volume: volumeRef.current,
+    });
 
     const timeoutId = window.setTimeout(
       () => setActiveBeat(beatNumber),
@@ -266,6 +275,10 @@ export function MetronomeProvider({ children }: { children: ReactNode }) {
 
   const startMetronome = useStableCallback(async function startMetronome() {
     setErrorMessage(null);
+    if (followPlaybackRef.current && isTauriRuntime() && !isWebAudioBackendForced()) {
+      setIsRunning(true);
+      return;
+    }
     const audioContext = await activateAudioContext();
     if (!audioContext) {
       return;
@@ -282,6 +295,7 @@ export function MetronomeProvider({ children }: { children: ReactNode }) {
     enabled: boolean,
   ) {
     setFollowPlayback(enabled);
+    followPlaybackRef.current = enabled;
     if (!enabled) {
       return;
     }
@@ -296,6 +310,7 @@ export function MetronomeProvider({ children }: { children: ReactNode }) {
     }
     if (typeof options.followPlayback === "boolean") {
       setFollowPlayback(options.followPlayback);
+      followPlaybackRef.current = options.followPlayback;
     }
     await startMetronome();
   });
@@ -383,6 +398,7 @@ export function MetronomeProvider({ children }: { children: ReactNode }) {
 
     let frameId: number | null = null;
     function tick() {
+      if (isTauriRuntime() && !isWebAudioBackendForced()) return;
       const snapshot = getPlaybackSnapshot();
       if (!snapshot.session || !snapshot.isPlaying) {
         pauseSyncedClock();
@@ -412,46 +428,110 @@ export function MetronomeProvider({ children }: { children: ReactNode }) {
   ]);
 
   useEffect(() => {
-    if (
-      !isTauriRuntime() ||
-      isWebAudioBackendForced() ||
-      !isRunning ||
-      !followPlayback ||
-      session?.timingGrid
-    ) {
-      nativeFollowClickActiveRef.current = false;
-      if (isTauriRuntime()) {
-        void setNativeAudioClick({ enabled: false }).catch(() => undefined);
-      }
-      return;
-    }
+    if (!isTauriRuntime() || isWebAudioBackendForced()) return;
+    const unlisteners = Promise.all([
+      listenNativeAudioSessions((next) =>
+        setNativeSession((current) =>
+          current?.generation === next.generation &&
+          current.timelineRevision === next.timelineRevision &&
+          current.status === next.status ? current : next,
+        ),
+      ),
+      listenNativeAudioCues((cue) => {
+        if (
+          cue.kind !== "metronome" ||
+          cue.generation !== nativeSession?.generation ||
+          cue.revision !== nativeSession.timelineRevision
+        ) return;
+        setActiveBeat(beatNumberForIndex(cue.cueIndex, beatsPerBarRef.current));
+        activeBeatTimeoutsRef.current.push(window.setTimeout(() => setActiveBeat(null), 90));
+      }),
+      listenNativeAudioTerminal((event) => {
+        if (event.generation === nativeSession?.generation) setNativeSession(null);
+      }),
+    ]);
+    return () => void unlisteners.then((items) => items.forEach((unlisten) => unlisten()));
+  }, [nativeSession?.generation, nativeSession?.timelineRevision]);
 
-    let cancelled = false;
-    void setNativeAudioClick({
-      enabled: true,
-      bpm,
-      beatsPerBar,
-      accentFirstBeat,
-      gain: volume,
-      followTransport: true,
-    })
-      .then((snapshot) => {
-        if (!cancelled) {
-          nativeFollowClickActiveRef.current = Boolean(
-            snapshot.nativePlaybackSupported && snapshot.sessionId,
-          );
-        }
-      })
-      .catch(() => {
-        if (!cancelled) {
-          nativeFollowClickActiveRef.current = false;
-        }
-      });
+  const nativeCuePlan = useStableCallback((positionSeconds: number) => {
+    const snapshot = getPlaybackSnapshot();
+    const beatSeconds = secondsPerBeat(bpm);
+    const beats = snapshot.session?.timingGrid?.beats.map((beat) => ({
+      index: beat.index, seconds: beat.seconds, accent: beat.beat_in_bar === 1,
+    })) ?? Array.from({ length: Math.ceil(snapshot.playbackDurationSeconds / beatSeconds) }, (_, index) => ({
+      index, seconds: index * beatSeconds, accent: isAccentBeat(index, beatsPerBar, accentFirstBeat),
+    }));
+    return beats.filter((beat) => beat.seconds >= positionSeconds).map((beat) => ({
+      cueIndex: beat.index, positionSeconds: beat.seconds, kind: "metronome" as const,
+      accent: accentFirstBeat && beat.accent, gain: volume,
+    }));
+  });
 
+  const advanceNativeActivationEpoch = useStableCallback(
+    () => ++nativeActivationEpochRef.current,
+  );
+  const isNativeActivationEpochCurrent = useStableCallback(
+    (epoch: number) => nativeActivationEpochRef.current === epoch,
+  );
+  useEffect(() => {
+    if (!isRunning || !followPlayback || !isTauriRuntime() || isWebAudioBackendForced()) return;
+    const activationEpoch = advanceNativeActivationEpoch();
+    nativePlayCueProvider.current = nativeCuePlan;
     return () => {
-      cancelled = true;
+      if (nativePlayCueProvider.current === nativeCuePlan) nativePlayCueProvider.current = null;
+      if (!isNativeActivationEpochCurrent(activationEpoch)) return;
+      const cleanupEpoch = advanceNativeActivationEpoch();
+      void getNativeAudioSessionSnapshot()
+        .then((snapshot) => {
+          if (
+            !isNativeActivationEpochCurrent(cleanupEpoch) ||
+            snapshot.status !== "output" ||
+            snapshot.leaseId !== "project-playback"
+          ) return null;
+          return updateFollowedMetronomeCues?.([]) ?? null;
+        })
+        .then((snapshot) => {
+          if (!isNativeActivationEpochCurrent(cleanupEpoch) || !snapshot) return;
+          setNativeSession(snapshot);
+        })
+        .catch(() => undefined);
     };
-  }, [accentFirstBeat, beatsPerBar, bpm, followPlayback, isRunning, session?.timingGrid, volume]);
+  }, [advanceNativeActivationEpoch, followPlayback, isNativeActivationEpochCurrent, isRunning, nativeCuePlan, updateFollowedMetronomeCues]);
+
+  useEffect(() => {
+    if (
+      !isRunning || !followPlayback || !isTauriRuntime() || isWebAudioBackendForced()
+    ) return;
+    const activationEpoch = nativeActivationEpochRef.current;
+    const cues = nativeCuePlan(getPlaybackSnapshot().playbackTimeSeconds);
+    void getNativeAudioSessionSnapshot()
+      .then((snapshot) => {
+        if (
+          nativeActivationEpochRef.current !== activationEpoch ||
+          snapshot.status !== "output" ||
+          snapshot.leaseId !== "project-playback"
+        ) return null;
+        setNativeSession(snapshot);
+        return updateFollowedMetronomeCues?.(cues) ?? null;
+      })
+      .then((snapshot) => {
+        if (nativeActivationEpochRef.current !== activationEpoch || !snapshot) return;
+        setNativeSession(snapshot);
+      })
+      .catch(() => undefined);
+  }, [
+    accentFirstBeat,
+    beatsPerBar,
+    bpm,
+    followPlayback,
+    getPlaybackSnapshot,
+    isRunning,
+    nativeCuePlan,
+    session?.tempoOriginalBpm,
+    session?.tempoTargetBpm,
+    updateFollowedMetronomeCues,
+    volume,
+  ]);
 
   const syncStatus = followPlayback
     ? session

--- a/apps/desktop/src/lib/nativeAudio.test.ts
+++ b/apps/desktop/src/lib/nativeAudio.test.ts
@@ -292,17 +292,40 @@ describe("native audio adapter", () => {
       leaseId: "practice",
       generation: 7,
       timelineRevision: 3,
-      cues: [{ cueIndex: 2, positionSeconds: 1.5 }],
+      operationId: "metro-1",
+      cues: [{ cueIndex: 2, positionSeconds: 1.5, kind: "metronome", accent: true, gain: 0.4 }],
     });
-    await cancelNativeAudioCues({ leaseId: "practice", timelineRevision: 3 });
+    await cancelNativeAudioCues({ leaseId: "practice", timelineRevision: 3 }, "metronome");
 
     expect(mockInvoke.mock.calls).toEqual([
       ["audio_get_session_snapshot"],
       ["audio_schedule_cues", { payload: {
-        leaseId: "practice", generation: 7, timelineRevision: 3,
-        cues: [{ cueIndex: 2, positionSeconds: 1.5 }],
+        leaseId: "practice", generation: 7, timelineRevision: 3, operationId: "metro-1",
+        cues: [{ cueIndex: 2, positionSeconds: 1.5, kind: "metronome", accent: true, gain: 0.4 }],
       } }],
-      ["audio_cancel_cues", { payload: { leaseId: "practice", timelineRevision: 3 } }],
+      ["audio_cancel_cues", {
+        payload: { leaseId: "practice", timelineRevision: 3 }, kind: "metronome",
+      }],
+    ]);
+  });
+
+  it("threads control metadata through precount play and lane updates", async () => {
+    mockInvoke.mockResolvedValue(snapshot);
+    const control = {
+      leaseId: "project-playback", generation: 4, timelineRevision: 2, operationId: "play-1",
+    };
+    const metronomeCues = [
+      { cueIndex: 0, positionSeconds: 0, kind: "metronome" as const, accent: true, gain: 0.8 },
+    ];
+    await playNativeAudio({
+      ...control, startTimeSeconds: 0, precount: { intervalsSeconds: [0.5, 0.5] }, metronomeCues,
+    });
+    await setNativeAudioLanes({ lanes: [] }, control);
+    expect(mockInvoke.mock.calls).toEqual([
+      ["audio_play", { payload: {
+        ...control, startTimeSeconds: 0, precount: { intervalsSeconds: [0.5, 0.5] }, metronomeCues,
+      } }],
+      ["audio_set_lanes", { payload: { lanes: [] }, control }],
     ]);
   });
 
@@ -422,7 +445,8 @@ describe("native audio adapter", () => {
   it("decodes safe camelCase session, cue, and terminal events", async () => {
     const payloads = {
       "audio://session": { status: "output", owner: "cue", generation: 2 },
-      "audio://cue": { cueIndex: 4, scheduledNativeTimeUs: 100, actualNativeTimeUs: 101 },
+      "audio://cue": { cueIndex: 4, kind: "precount_completion", accent: false, gain: 1,
+        scheduledNativeTimeUs: 100, actualNativeTimeUs: 101 },
       "audio://terminal": { generation: 2, code: "output_stream_failure", nativeTimeUs: 102 },
     };
     mockListen.mockImplementation(async (eventName, callback) => {

--- a/apps/desktop/src/lib/nativeAudio.ts
+++ b/apps/desktop/src/lib/nativeAudio.ts
@@ -36,11 +36,21 @@ export type NativeAudioSessionSnapshot = {
   terminalDiagnostic: string | null;
 };
 
-export type NativeAudioCue = { cueIndex: number; positionSeconds: number };
+export type NativeAudioCueKind = "marker" | "precount_beat" | "precount_completion" | "metronome";
+export type NativeAudioCue = {
+  cueIndex: number;
+  positionSeconds: number;
+  kind?: "marker" | "metronome";
+  accent?: boolean;
+  gain?: number;
+};
 export type NativeAudioCueEvent = {
   generation: number;
   revision: number;
   cueIndex: number;
+  kind: NativeAudioCueKind;
+  accent: boolean;
+  gain: number;
   scheduledNativeTimeUs: number;
   actualNativeTimeUs: number;
   insertionSequence: number;
@@ -191,7 +201,11 @@ export type NativeAudioPlayRequest = NativeAudioSessionControl & {
   startTimeSeconds?: number | null;
   scheduledStartTimeSeconds?: number | null;
   startAtNativeUs?: number | null;
+  precount?: { intervalsSeconds: number[] } | null;
+  metronomeCues?: Array<NativeAudioCue & { kind: "metronome" }> | null;
 };
+
+export const nativePlayCueProvider = { current: null as ((positionSeconds: number) => Array<NativeAudioCue & { kind: "metronome" }>) | null };
 
 export type NativeAudioSeekRequest = NativeAudioSessionControl & {
   timeSeconds: number;
@@ -382,8 +396,11 @@ export function seekNativeAudio(payload: NativeAudioSeekRequest) {
   return invoke<NativeAudioSnapshot>("audio_seek", { payload });
 }
 
-export function setNativeAudioLanes(payload: NativeAudioLaneUpdate) {
-  return invoke<NativeAudioSnapshot>("audio_set_lanes", { payload });
+export function setNativeAudioLanes(
+  payload: NativeAudioLaneUpdate,
+  control?: NativeAudioSessionControl,
+) {
+  return invoke<NativeAudioSnapshot>("audio_set_lanes", control ? { payload, control } : { payload });
 }
 
 export function setNativeAudioClick(payload: NativeAudioClickRequest) {
@@ -404,10 +421,13 @@ export function scheduleNativeAudioCues(
   return invoke<NativeAudioSessionSnapshot>("audio_schedule_cues", { payload });
 }
 
-export function cancelNativeAudioCues(payload?: NativeAudioSessionControl) {
+export function cancelNativeAudioCues(
+  payload?: NativeAudioSessionControl,
+  kind?: "marker" | "metronome",
+) {
   return invoke<NativeAudioSessionSnapshot>(
     "audio_cancel_cues",
-    payload ? { payload } : undefined,
+    payload || kind ? { payload, kind } : undefined,
   );
 }
 

--- a/apps/desktop/src/lib/timingGrid.test.ts
+++ b/apps/desktop/src/lib/timingGrid.test.ts
@@ -47,13 +47,83 @@ describe("timing grid helpers", () => {
     const intervals = countInIntervalsForTiming({
       clickCount: 4,
       fallbackBeatSeconds: 0.5,
+      sourceTempoBpm: 120,
       startTimeSeconds: 2.04,
+      targetTempoBpm: 120,
       timingGrid,
     });
     expect(intervals[0]).toBeCloseTo(0.48, 3);
     expect(intervals[1]).toBeCloseTo(0.53, 3);
     expect(intervals[2]).toBeCloseTo(0.49, 3);
     expect(intervals[3]).toBeCloseTo(0.54, 3);
+  });
+
+  it("rejects doubled source gaps and keeps valid local variation", () => {
+    const variedGrid: AnalysisTimingGrid = {
+      ...timingGrid,
+      beats: [
+        { index: 0, seconds: 0, bar_index: 0, beat_in_bar: 1 },
+        { index: 1, seconds: 0.48, bar_index: 0, beat_in_bar: 2 },
+        { index: 2, seconds: 1.48, bar_index: 0, beat_in_bar: 3 },
+        { index: 3, seconds: 1.99, bar_index: 0, beat_in_bar: 4 },
+        { index: 4, seconds: 2.49, bar_index: 1, beat_in_bar: 1 },
+      ],
+    };
+    const intervals = countInIntervalsForTiming({
+        clickCount: 4,
+        fallbackBeatSeconds: 0.5,
+        sourceTempoBpm: 120,
+        startTimeSeconds: 2.49,
+        targetTempoBpm: 120,
+        timingGrid: variedGrid,
+      });
+    expect(intervals[0]).toBeCloseTo(0.48, 6);
+    expect(intervals[1]).toBeCloseTo(0.5, 6);
+    expect(intervals[2]).toBeCloseTo(0.51, 6);
+    expect(intervals[3]).toBeCloseTo(0.5, 6);
+  });
+
+  it("uses source BPM for validation and scales accepted gaps to displayed tempo", () => {
+    const fastGrid: AnalysisTimingGrid = {
+      ...timingGrid,
+      beats: [
+        { index: 0, seconds: 0, bar_index: 0, beat_in_bar: 1 },
+        { index: 1, seconds: 0.24, bar_index: 0, beat_in_bar: 2 },
+        { index: 2, seconds: 0.5, bar_index: 0, beat_in_bar: 3 },
+        { index: 3, seconds: 0.75, bar_index: 0, beat_in_bar: 4 },
+      ],
+    };
+    expect(
+      countInIntervalsForTiming({
+        clickCount: 3,
+        fallbackBeatSeconds: 0.5,
+        sourceTempoBpm: 240,
+        startTimeSeconds: 0.75,
+        targetTempoBpm: 120,
+        timingGrid: fastGrid,
+      }),
+    ).toEqual([0.48, 0.52, 0.5]);
+  });
+
+  it("fills pre-song intervals from beat gaps without treating intro silence as a beat", () => {
+    const introGrid: AnalysisTimingGrid = {
+      ...timingGrid,
+      beats: [
+        { index: 0, seconds: 4, bar_index: 0, beat_in_bar: 1 },
+        { index: 1, seconds: 4.5, bar_index: 0, beat_in_bar: 2 },
+        { index: 2, seconds: 5, bar_index: 0, beat_in_bar: 3 },
+      ],
+    };
+    expect(
+      countInIntervalsForTiming({
+        clickCount: 4,
+        fallbackBeatSeconds: 0.5,
+        sourceTempoBpm: 120,
+        startTimeSeconds: 0,
+        targetTempoBpm: 120,
+        timingGrid: introGrid,
+      }),
+    ).toEqual([0.5, 0.5, 0.5, 0.5]);
   });
 
   it("finds the next timed beat without rescheduling old beats", () => {

--- a/apps/desktop/src/lib/timingGrid.ts
+++ b/apps/desktop/src/lib/timingGrid.ts
@@ -124,12 +124,16 @@ export function snapLoopPointToTiming(
 export function countInIntervalsForTiming({
   clickCount,
   fallbackBeatSeconds,
+  sourceTempoBpm,
   startTimeSeconds,
+  targetTempoBpm,
   timingGrid,
 }: {
   clickCount: number;
   fallbackBeatSeconds: number;
+  sourceTempoBpm: number | null;
   startTimeSeconds: number;
+  targetTempoBpm: number | null;
   timingGrid: AnalysisTimingGrid | null;
 }) {
   const fallbackIntervals = Array.from({ length: clickCount }, () => fallbackBeatSeconds);
@@ -142,7 +146,26 @@ export function countInIntervalsForTiming({
     return fallbackIntervals;
   }
 
-  const localFallback = localBeatSeconds(timingGrid.beats, anchorIndex) ?? fallbackBeatSeconds;
+  const normalizedSourceTempo = positiveFiniteNumber(sourceTempoBpm);
+  const normalizedTargetTempo = positiveFiniteNumber(targetTempoBpm);
+  const sourcePeriod = normalizedSourceTempo ? 60 / normalizedSourceTempo : null;
+  const tempoScale =
+    normalizedSourceTempo && normalizedTargetTempo
+      ? normalizedSourceTempo / normalizedTargetTempo
+      : 1;
+  const localStartIndex = Math.max(0, anchorIndex - clickCount);
+  const localEndIndex = Math.min(timingGrid.beats.length - 1, anchorIndex + clickCount);
+  const validSourceGaps: number[] = [];
+  for (let index = localStartIndex; index < localEndIndex; index += 1) {
+    const gap = timingGrid.beats[index + 1].seconds - timingGrid.beats[index].seconds;
+    if (isAcceptedSourceGap(gap, sourcePeriod)) {
+      validSourceGaps.push(gap);
+    }
+  }
+  const medianSourceGap = median(validSourceGaps) ?? sourcePeriod;
+  const medianTargetGap = medianSourceGap
+    ? medianSourceGap * tempoScale
+    : fallbackBeatSeconds;
   return fallbackIntervals.map((_interval, index) => {
     const fromIndex = anchorIndex - clickCount + index;
     const toIndex = fromIndex + 1;
@@ -151,9 +174,15 @@ export function countInIntervalsForTiming({
       timingGrid.beats[toIndex] &&
       timingGrid.beats[toIndex].seconds > timingGrid.beats[fromIndex].seconds
     ) {
-      return timingGrid.beats[toIndex].seconds - timingGrid.beats[fromIndex].seconds;
+      const sourceGap = timingGrid.beats[toIndex].seconds - timingGrid.beats[fromIndex].seconds;
+      if (isAcceptedSourceGap(sourceGap, sourcePeriod)) {
+        const targetGap = sourceGap * tempoScale;
+        if (Math.abs(targetGap - medianTargetGap) <= medianTargetGap * 0.15) {
+          return targetGap;
+        }
+      }
     }
-    return localFallback;
+    return medianTargetGap;
   });
 }
 
@@ -274,15 +303,29 @@ function firstBeatIndexAtOrAfter(beats: AnalysisTimingBeat[], value: number) {
   return index === -1 ? beats.length : index;
 }
 
-function localBeatSeconds(beats: AnalysisTimingBeat[], anchorIndex: number) {
-  const previous = beats[anchorIndex - 1];
-  const anchor = beats[anchorIndex];
-  if (previous && anchor && anchor.seconds > previous.seconds) {
-    return anchor.seconds - previous.seconds;
+function positiveFiniteNumber(value: number | null) {
+  return typeof value === "number" && Number.isFinite(value) && value > 0
+    ? value
+    : null;
+}
+
+function isAcceptedSourceGap(gap: number, sourcePeriod: number | null) {
+  if (!Number.isFinite(gap) || gap <= 0) {
+    return false;
   }
-  const next = beats[anchorIndex + 1];
-  if (anchor && next && next.seconds > anchor.seconds) {
-    return next.seconds - anchor.seconds;
+  return (
+    sourcePeriod === null ||
+    (gap >= sourcePeriod * 0.75 && gap <= sourcePeriod * 1.25)
+  );
+}
+
+function median(values: number[]) {
+  if (!values.length) {
+    return null;
   }
-  return null;
+  const sorted = [...values].sort((first, second) => first - second);
+  const midpoint = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 0
+    ? (sorted[midpoint - 1] + sorted[midpoint]) / 2
+    : sorted[midpoint];
 }

--- a/apps/desktop/src/test/appTestHarness.tsx
+++ b/apps/desktop/src/test/appTestHarness.tsx
@@ -109,6 +109,9 @@ const {
   emitMockNativeAudioInputFrame,
   emitMockNativeAudioInputState,
   emitMockNativeAudioPosition,
+  emitMockNativeAudioCue,
+  emitMockNativeAudioSession,
+  emitMockNativeAudioTerminal,
   emitMockSystemMediaControl,
   getSystemMediaControlListenerCount,
   deferNextSystemMediaControlListen,
@@ -152,7 +155,8 @@ const {
       | "decoder_worker_failure";
   };
   type NativeAudioRuntimeEvent = {
-    event: "audio://position" | "audio://ended" | "audio://error" | "audio://input-state";
+    event: "audio://position" | "audio://ended" | "audio://error" | "audio://input-state" |
+      "audio://session" | "audio://cue" | "audio://terminal";
     id: number;
     payload: Record<string, unknown>;
   };
@@ -912,6 +916,10 @@ const {
         fallbackReason: "Native audio playback is not wired yet; use existing WebView playback.",
         lanes: [],
         bufferHealth: [],
+        leaseId: "project-playback",
+        generation: 1,
+        timelineRevision: 1,
+        nativeTimeUs: 1,
       },
       nativeAudioStartError: null,
       nativeAudioPlayFallbackReason: null,
@@ -1056,6 +1064,15 @@ const {
   function emitMockNativeAudioPosition(position: NativeAudioPositionPayload) {
     emitMockNativeRuntimeEvent("audio://position", position);
   }
+  function emitMockNativeAudioCue(payload: Record<string, unknown>) {
+    emitMockNativeRuntimeEvent("audio://cue", payload);
+  }
+  function emitMockNativeAudioSession(payload: Record<string, unknown>) {
+    emitMockNativeRuntimeEvent("audio://session", payload);
+  }
+  function emitMockNativeAudioTerminal(payload: Record<string, unknown>) {
+    emitMockNativeRuntimeEvent("audio://terminal", payload);
+  }
   function emitMockNativeAudioError(error: NativeAudioErrorPayload) {
     emitMockNativeRuntimeEvent("audio://error", error);
   }
@@ -1123,7 +1140,10 @@ const {
         eventName === "audio://position" ||
         eventName === "audio://ended" ||
         eventName === "audio://error" ||
-        eventName === "audio://input-state"
+        eventName === "audio://input-state" ||
+        eventName === "audio://session" ||
+        eventName === "audio://cue" ||
+        eventName === "audio://terminal"
       ) {
         const listenerId = nextNativeRuntimeListenerId;
         nextNativeRuntimeListenerId += 1;
@@ -1308,6 +1328,9 @@ const {
         nativePlaybackSupported,
         fallbackReason,
         laneCount: lanes.length,
+        generation: state.nativeAudioSnapshot.generation,
+        timelineRevision: state.nativeAudioSnapshot.timelineRevision,
+        nativeTimeUs: state.nativeAudioSnapshot.nativeTimeUs,
       };
     }
 
@@ -1396,6 +1419,17 @@ const {
 
     if (command === "audio_set_click" || command === "audio_get_snapshot") {
       return clone(state.nativeAudioSnapshot);
+    }
+
+    if (command === "audio_get_session_snapshot" || command === "audio_schedule_cues" || command === "audio_cancel_cues") {
+      return {
+        status: "output",
+        owner: "playback",
+        leaseId: "project-playback",
+        generation: state.nativeAudioSnapshot.generation,
+        timelineRevision: state.nativeAudioSnapshot.timelineRevision,
+        nativeTimeUs: state.nativeAudioSnapshot.nativeTimeUs,
+      };
     }
 
     if (command === "audio_start_input") {
@@ -2542,6 +2576,9 @@ const {
     emitMockNativeAudioInputFrame,
     emitMockNativeAudioInputState,
     emitMockNativeAudioPosition,
+    emitMockNativeAudioCue,
+    emitMockNativeAudioSession,
+    emitMockNativeAudioTerminal,
     emitMockSystemMediaControl,
     getSystemMediaControlListenerCount,
     deferNextSystemMediaControlListen,
@@ -2570,6 +2607,9 @@ export {
   mockOpen,
   mockSave,
   mockConfirm,
+  emitMockNativeAudioCue,
+  emitMockNativeAudioSession,
+  emitMockNativeAudioTerminal,
   mockInvoke,
   mockListProjects,
   mockImportProject,

--- a/docs/NATIVE_AUDIO.md
+++ b/docs/NATIVE_AUDIO.md
@@ -14,7 +14,10 @@ boundary.
   artifact has a local path. WAV uses a fast streaming reader; other common formats decode through
   Symphonia for playback only.
 - Native playback supports shared transport play/pause/seek, position events, mute/solo lane gains,
-  and generated metronome click lanes for follow-playback mode.
+  project count-ins, and generated metronome click lanes for follow-playback mode. Project count-ins
+  use a 760 Hz triangle click with a 2 ms attack, 45 ms duration, and exponential decay on both
+  native and Web Audio paths; timing-grid gaps are filtered against source BPM and scaled to the
+  displayed playback tempo.
 - Native tempo changes use `signalsmith-stretch` for pitch-preserving playback.
 - If native setup, decode, seek, or output startup fails, playback falls back to Web Audio at the
   same transport position.
@@ -50,6 +53,9 @@ cross-platform owner, backend, diagnostic, and validation rules.
 - Native playback owns the transport only after a matching native session confirms playback, and
   requests OS power protection while playing. User intent or an in-flight start does not count as
   confirmed protection.
+- Revision-dependent project playback mutations are serialized and stale responses cannot replace a
+  newer session, position, or lane state. Pause and Stop remain prompt cancellation boundaries and
+  are not held behind an unresolved Play response.
 - Web Audio/HTML media playback owns the transport only after a `playing` event or confirmed media
   progress,
   including `VITE_TUNEFORGE_FORCE_WEB_AUDIO=1` and native fallback. It uses the browser Screen Wake
@@ -207,7 +213,7 @@ BlackHole capture are release checks, not default `pnpm test` coverage.
 | Seek accuracy | scrub reflects transport position and lane audio resumes at target | same | same |
 | Stop semantics | returns transport to expected idle state | same | same |
 | Pause/Resume | no drift on resume at least for short cycle | no drift on resume at least for short cycle | no drift on resume at least for short cycle |
-| Loop | loop boundaries and loop duration stable | stable | stable |
+| Loop | loop boundaries and loop duration stable; clearing at a boundary cancels the pending wrap | same | same |
 | Song count-in | only runs from absolute song start | same | same |
 | Loop count-in | runs at loop start and on loop wrap, never on pause/resume | same | same |
 | Tempo control | tempo change applies and stays stable | tempo change applies and stays stable | tempo change applies and stays stable |

--- a/scripts/capture-release-media.mjs
+++ b/scripts/capture-release-media.mjs
@@ -13,6 +13,12 @@ const desktopRequire = createRequire(new URL("../apps/desktop/package.json", imp
 const repoRoot = fileURLToPath(new URL("../", import.meta.url));
 const defaultOutputDir = resolve(repoRoot, "apps/site/public/media/generated");
 const fixtureTimestamp = "2026-04-18T13:16:00.000Z";
+const releaseMediaNativeAudioMetadata = Object.freeze({
+  leaseId: "project-playback",
+  generation: 1,
+  timelineRevision: 1,
+  nativeTimeUs: 1,
+});
 const childTailLines = 40;
 const releaseMediaCaptureCatalog = [
   {
@@ -546,11 +552,12 @@ async function installPageStabilizers(
   const mobileFixture = entry?.runtime === "mobile"
     ? mobilePlaybackFixture(mobileFixtureOptions)
     : null;
-  await page.addInitScript(({ animatePlayback, mobileFixture, theme }) => {
+  await page.addInitScript(({ animatePlayback, mobileFixture, nativeAudioMetadata, theme }) => {
     const fixedNow = Date.parse("2026-04-18T13:16:00.000Z");
     let callbackId = 1;
     const callbacks = new Map();
     const eventListeners = new Map();
+    const powerInhibitionReasons = new Set();
     let tunerFrameTimer = null;
     let playbackPositionTimer = null;
     let playbackSnapshot = {
@@ -561,6 +568,7 @@ async function installPageStabilizers(
       playbackRate: 1,
       nativePlaybackSupported: true,
       fallbackReason: null,
+      ...nativeAudioMetadata,
       lanes: [],
       bufferHealth: [],
     };
@@ -678,6 +686,7 @@ async function installPageStabilizers(
       playbackSnapshot = {
         ...playbackSnapshot,
         ...overrides,
+        ...nativeAudioMetadata,
       };
       playbackSnapshot.bufferHealth = bufferHealthForLanes(playbackSnapshot.lanes);
       return { ...playbackSnapshot };
@@ -858,6 +867,9 @@ async function installPageStabilizers(
           nativePlaybackSupported: true,
           fallbackReason: null,
           laneCount: lanes.length,
+          generation: playbackSnapshot.generation,
+          timelineRevision: playbackSnapshot.timelineRevision,
+          nativeTimeUs: playbackSnapshot.nativeTimeUs,
         };
       }
       if (command === "audio_play") {
@@ -955,6 +967,23 @@ async function installPageStabilizers(
           error: "System input volume unavailable during release media capture.",
         };
       }
+      if (command === "power_inhibition_set_activity") {
+        const reason = args?.reason;
+        if (typeof reason === "string") {
+          if (args?.active) powerInhibitionReasons.add(reason);
+          else powerInhibitionReasons.delete(reason);
+        }
+        const active = powerInhibitionReasons.size > 0;
+        return {
+          phase: active ? "active" : "inactive",
+          backend: active ? "macos-iopm" : null,
+          activeReasons: [...powerInhibitionReasons],
+          screenProtected: active,
+          backgroundProtected: active,
+          errorCode: null,
+          errorMessage: null,
+        };
+      }
       if (command === "sync_transport_status" || command === "sync_transport_start_listener") {
         return releaseMediaSyncStatus();
       }
@@ -1037,7 +1066,12 @@ async function installPageStabilizers(
         }
       },
     };
-  }, { animatePlayback: motionPolicy.animatePlayback, mobileFixture, theme: options.theme });
+  }, {
+    animatePlayback: motionPolicy.animatePlayback,
+    mobileFixture,
+    nativeAudioMetadata: releaseMediaNativeAudioMetadata,
+    theme: options.theme,
+  });
 }
 
 function captureMotionPolicy(captureKind) {
@@ -2384,5 +2418,6 @@ export {
   overflowToScrollDelta,
   parseOptions,
   releaseMediaCaptureCatalog,
+  releaseMediaNativeAudioMetadata,
   validateReleaseMediaCatalog,
 };

--- a/scripts/capture-release-media.test.mjs
+++ b/scripts/capture-release-media.test.mjs
@@ -12,8 +12,19 @@ import {
   overflowToScrollDelta,
   parseOptions,
   releaseMediaCaptureCatalog,
+  releaseMediaNativeAudioMetadata,
   validateReleaseMediaCatalog,
 } from "./capture-release-media.mjs";
+
+test("native playback fixture exposes stable safe session metadata", () => {
+  assert.deepEqual(releaseMediaNativeAudioMetadata, {
+    leaseId: "project-playback",
+    generation: 1,
+    timelineRevision: 1,
+    nativeTimeUs: 1,
+  });
+  assert.equal(Object.isFrozen(releaseMediaNativeAudioMetadata), true);
+});
 
 test("settings fixture exposes the available default advanced chord backend", () => {
   const backends = chordBackends();


### PR DESCRIPTION
## Summary

- Move project count-in and playback metronome cues onto the native audio timeline.
- Keep cue ownership synchronized across play, pause, seek, tempo, and project changes.
- Preserve existing metronome sound and uniform count-in behavior.
- Stack on #522 as the second native-audio control-plane layer.
- Closes #509.
- Closes #510.

## Testing

- `cd apps/desktop/src-tauri && rtk cargo test native_audio::`
- `cd apps/desktop/src-tauri && rtk cargo check`
- `cd apps/desktop/src-tauri && rtk cargo fmt --all -- --check`
- `rtk pnpm --filter @tuneforge/desktop test -- --run`
- `rtk pnpm --filter @tuneforge/desktop lint`
- `rtk pnpm --dir apps/desktop run typecheck`
- `rtk node --test scripts/capture-release-media.test.mjs`
- `node scripts/capture-release-media.mjs --run`
- Inspected all eight screenshots and a six-frame overview-video contact sheet.
- `rtk git diff --check`
