### PR TITLE
feat(audio): move tool audio to native control plane

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ download, installation, verification, signature, and publication instructions.
 
 - Moved project count-ins and playback-following metronome cues onto the native audio timeline,
   with timing-grid-aware spacing and the same short triangle click on native and Web Audio paths.
+- Moved project count-ins and metronome timing onto one native output runtime, including standalone
+  free-run and playback-following modes, while keeping tuner capture independently concurrent.
 
 ### Fixed
 

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -557,6 +557,7 @@ pub fn run() {
             native_audio::audio_seek,
             native_audio::audio_set_lanes,
             native_audio::audio_set_click,
+            native_audio::audio_set_standalone_metronome,
             native_audio::audio_get_snapshot,
             native_audio::audio_get_session_snapshot,
             native_audio::audio_schedule_cues,

--- a/apps/desktop/src-tauri/src/native_audio/capture.rs
+++ b/apps/desktop/src-tauri/src/native_audio/capture.rs
@@ -10,7 +10,9 @@ use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
 use tauri::{Emitter, Manager};
 
 use super::{
-    session::{RuntimeReport, RuntimeReportKind, SessionCommand, TerminalEvent},
+    session::{
+        AudioResource, AudioSource, RuntimeReport, RuntimeReportKind, SessionCommand, TerminalEvent,
+    },
     timeline, AudioCapabilities, AUDIO_EVENT_INPUT_FRAME, AUDIO_EVENT_INPUT_STATE,
     AUDIO_EVENT_TERMINAL,
 };
@@ -1166,6 +1168,7 @@ fn finish_capture_with_error(
     );
     if let Some(sender) = report_sender {
         let _ = sender.try_send(RuntimeReport {
+            resource: AudioResource::Capture,
             generation: session_generation,
             kind: RuntimeReportKind::Terminal(terminal_code),
         });
@@ -1173,6 +1176,8 @@ fn finish_capture_with_error(
     let _ = app.emit(
         AUDIO_EVENT_TERMINAL,
         TerminalEvent {
+            resource: AudioResource::Capture,
+            source: AudioSource::CaptureRuntime,
             generation: session_generation,
             code: terminal_code,
             native_time_us: timeline::native_time_us(),

--- a/apps/desktop/src-tauri/src/native_audio/mod.rs
+++ b/apps/desktop/src-tauri/src/native_audio/mod.rs
@@ -37,7 +37,8 @@ struct NativeAudioEngine {
     mixer: mixer::MixerState,
     transport: transport::TransportState,
     capture: capture::CaptureState,
-    session: session::SessionCoordinator,
+    output_session: session::SessionCoordinator,
+    capture_session: session::SessionCoordinator,
     report_sender: mpsc::SyncSender<session::RuntimeReport>,
     report_receiver: mpsc::Receiver<session::RuntimeReport>,
 }
@@ -53,8 +54,16 @@ impl NativeAudioState {
                 mixer: mixer::MixerState::default(),
                 transport: transport::TransportState::default(),
                 capture: capture::CaptureState::default(),
-                session: session::SessionCoordinator::new(
+                output_session: session::SessionCoordinator::new_for_resource(
+                    session::AudioResource::Output,
+                    session::AudioSource::ProjectPlayback,
                     capabilities.native_playback_supported,
+                    false,
+                ),
+                capture_session: session::SessionCoordinator::new_for_resource(
+                    session::AudioResource::Capture,
+                    session::AudioSource::TunerCapture,
+                    false,
                     capabilities.mic_capture_supported,
                 ),
                 report_sender,
@@ -78,53 +87,91 @@ impl NativeAudioEngine {
     fn drain_reports(&mut self) {
         while let Ok(report) = self.report_receiver.try_recv() {
             match report.kind {
-                session::RuntimeReportKind::Ended => self.session.runtime_ended(report.generation),
+                session::RuntimeReportKind::Ended => self
+                    .session_mut(report.resource)
+                    .runtime_ended(report.generation),
                 session::RuntimeReportKind::Terminal(code) => {
-                    self.session.mark_terminal(report.generation, code);
+                    self.session_mut(report.resource)
+                        .mark_terminal(report.generation, code);
                 }
             }
         }
     }
 
+    fn session(&self, resource: session::AudioResource) -> &session::SessionCoordinator {
+        match resource {
+            session::AudioResource::Output => &self.output_session,
+            session::AudioResource::Capture => &self.capture_session,
+        }
+    }
+
+    fn session_mut(
+        &mut self,
+        resource: session::AudioResource,
+    ) -> &mut session::SessionCoordinator {
+        match resource {
+            session::AudioResource::Output => &mut self.output_session,
+            session::AudioResource::Capture => &mut self.capture_session,
+        }
+    }
+
     fn acquire(
         &mut self,
-        app: &AppHandle,
+        app: Option<&AppHandle>,
         owner: session::SessionOwner,
         command: &session::SessionCommand,
         duration: f64,
         rate: f64,
     ) -> Result<Option<u64>, String> {
         self.drain_reports();
-        if self.session.snapshot().terminal_diagnostic == Some("release_timeout") {
+        let resource = if owner.is_output() {
+            session::AudioResource::Output
+        } else {
+            session::AudioResource::Capture
+        };
+        if self.session(resource).snapshot().terminal_diagnostic == Some("release_timeout") {
             return Err("release_timeout".to_string());
         }
         let session::Acquire::Release {
             token,
             previous,
             lease,
-        } = self.session.begin_acquire(owner, command)
+        } = self.session_mut(resource).begin_acquire(owner, command)
         else {
             return Ok(None);
         };
-        let released = match previous {
-            Some(previous) if previous.is_output() => self.transport.release_for_transfer(),
-            Some(session::SessionOwner::Capture) => self.capture.release_for_transfer(),
-            None | Some(_) => Ok(()),
+        let preserve_auxiliary_output = resource == session::AudioResource::Output
+            && owner == session::SessionOwner::Playback
+            && previous != Some(session::SessionOwner::Playback)
+            && self.transport.has_auxiliary_runtime();
+        let released = match resource {
+            session::AudioResource::Output
+                if !preserve_auxiliary_output
+                    && (previous.is_some() || self.transport.has_runtime()) =>
+            {
+                self.transport.release_for_transfer()
+            }
+            session::AudioResource::Capture if previous.is_some() => {
+                self.capture.release_for_transfer()
+            }
+            _ => Ok(()),
         };
         if released.is_err() {
-            if let Some(event) = self.session.fail_release(token) {
-                let _ = app.emit(AUDIO_EVENT_TERMINAL, event);
+            if let Some(event) = self.session_mut(resource).fail_release(token) {
+                if let Some(app) = app {
+                    let _ = app.emit(AUDIO_EVENT_TERMINAL, event);
+                }
             }
             return Err("release_timeout".to_string());
         }
         let generation = self
-            .session
+            .session_mut(resource)
             .finish_acquire(token, owner, lease, command, duration, rate)
             .map_err(str::to_string)?;
         if owner.is_output() {
             self.transport.bind_session(
                 generation,
-                self.session.timeline(),
+                self.output_session.timeline(),
                 self.report_sender.clone(),
             );
         } else {
@@ -134,8 +181,8 @@ impl NativeAudioEngine {
         Ok(Some(generation))
     }
 
-    fn emit_session(&self, app: &AppHandle) {
-        let snapshot = self.session.snapshot();
+    fn emit_session(&self, app: &AppHandle, resource: session::AudioResource) {
+        let snapshot = self.session(resource).snapshot();
         let _ = app.emit(AUDIO_EVENT_SESSION, snapshot);
     }
 
@@ -146,14 +193,19 @@ impl NativeAudioEngine {
         explicit: bool,
     ) -> Result<bool, String> {
         self.drain_reports();
-        self.session
+        let resource = if owner.is_output() {
+            session::AudioResource::Output
+        } else {
+            session::AudioResource::Capture
+        };
+        self.session_mut(resource)
             .authorize(owner, command, explicit)
             .map_err(str::to_string)
     }
 
     fn output_snapshot(&self) -> transport::AudioSnapshot {
         let mut output = self.transport.snapshot();
-        let session = self.session.snapshot();
+        let session = self.output_session.snapshot();
         output.lease_id = session.lease_id;
         output.generation = Some(session.generation);
         output.timeline_revision = Some(session.timeline_revision);
@@ -164,7 +216,7 @@ impl NativeAudioEngine {
     }
 
     fn input_snapshot(&self, mut input: capture::AudioInputState) -> capture::AudioInputState {
-        let session = self.session.snapshot();
+        let session = self.capture_session.snapshot();
         input.lease_id = session.lease_id;
         input.generation = Some(session.generation);
         input.native_time_us = Some(session.native_time_us);
@@ -244,7 +296,7 @@ pub async fn audio_prepare_session(
             return Err("session_owner_mismatch".to_string());
         }
         let acquired = engine.acquire(
-            &app,
+            Some(&app),
             owner,
             &payload.control,
             payload.duration_seconds.unwrap_or(0.0),
@@ -273,7 +325,7 @@ pub async fn audio_prepare_session(
             effective_lanes,
             state.capabilities(),
         );
-        engine.emit_session(&app);
+        engine.emit_session(&app, session::AudioResource::Output);
         Ok(prepared)
     })
     .await
@@ -292,20 +344,20 @@ pub fn audio_play(
 
     let mut engine = state.engine()?;
     engine.drain_reports();
-    let previous_generation = engine.session.snapshot().generation;
+    let previous_generation = engine.output_session.snapshot().generation;
     if !engine
-        .session
+        .output_session
         .authorize(session::SessionOwner::Playback, &payload.control, true)
         .map_err(str::to_string)?
     {
         return Ok(engine.output_snapshot());
     }
-    let session_generation = engine.session.snapshot().generation;
+    let session_generation = engine.output_session.snapshot().generation;
     if session_generation != previous_generation {
         engine
             .transport
             .begin_explicit_attempt(state.capabilities());
-        let timeline = engine.session.timeline();
+        let timeline = engine.output_session.timeline();
         let reporter = engine.report_sender.clone();
         engine
             .transport
@@ -336,7 +388,7 @@ pub fn audio_play(
     let expected = payload
         .control
         .timeline_revision
-        .unwrap_or_else(|| engine.session.snapshot().timeline_revision);
+        .unwrap_or_else(|| engine.output_session.snapshot().timeline_revision);
     if requested_start.is_some_and(|deadline| deadline <= timeline::native_time_us()) {
         return Err("start_deadline_missed".to_string());
     }
@@ -349,14 +401,14 @@ pub fn audio_play(
     }
     if let Err(error) = engine.transport.play(payload) {
         if let Some(event) = engine
-            .session
+            .output_session
             .mark_terminal(session_generation, "runtime_start_failure")
         {
             let _ = app.emit(AUDIO_EVENT_TERMINAL, event);
         }
         return Err(error);
     }
-    let timeline = engine.session.timeline();
+    let timeline = engine.output_session.timeline();
     let now = timeline::native_time_us();
     let first_precount = precount.as_ref().map(|_| now.saturating_add(35_000));
     let source_start = precount
@@ -384,7 +436,7 @@ pub fn audio_play(
             .map_err(str::to_string)?;
     }
     drop(timeline);
-    engine.emit_session(&app);
+    engine.emit_session(&app, session::AudioResource::Output);
     Ok(engine.output_snapshot())
 }
 
@@ -402,12 +454,12 @@ pub fn audio_pause(
     )?;
     engine.transport.pause();
     engine
-        .session
+        .output_session
         .timeline()
         .lock()
         .map_err(|_| "timeline_unavailable")?
         .pause();
-    engine.emit_session(&app);
+    engine.emit_session(&app, session::AudioResource::Output);
     Ok(engine.output_snapshot())
 }
 
@@ -425,12 +477,12 @@ pub fn audio_stop(
     )?;
     engine.transport.stop();
     engine
-        .session
+        .output_session
         .timeline()
         .lock()
         .map_err(|_| "timeline_unavailable")?
         .stop();
-    engine.emit_session(&app);
+    engine.emit_session(&app, session::AudioResource::Output);
     Ok(engine.output_snapshot())
 }
 
@@ -445,9 +497,9 @@ pub fn audio_seek(
     let expected = payload
         .control
         .timeline_revision
-        .unwrap_or_else(|| engine.session.snapshot().timeline_revision);
+        .unwrap_or_else(|| engine.output_session.snapshot().timeline_revision);
     engine
-        .session
+        .output_session
         .timeline()
         .lock()
         .map_err(|_| "timeline_unavailable")?
@@ -459,7 +511,7 @@ pub fn audio_seek(
     );
     engine.transport.set_diagnostics_generation(generation);
     engine.transport.seek(payload);
-    engine.emit_session(&app);
+    engine.emit_session(&app, session::AudioResource::Output);
     Ok(engine.output_snapshot())
 }
 
@@ -493,9 +545,9 @@ pub fn audio_set_lanes(
     let generation = diagnostics::begin_operation(operation_kind, raw_lanes.len());
     engine.transport.set_diagnostics_generation(generation);
     if let Some(rate) = playback_rate {
-        let revision = engine.session.snapshot().timeline_revision;
+        let revision = engine.output_session.snapshot().timeline_revision;
         engine
-            .session
+            .output_session
             .timeline()
             .lock()
             .map_err(|_| "timeline_unavailable")?
@@ -505,7 +557,7 @@ pub fn audio_set_lanes(
     engine
         .transport
         .set_lanes(raw_lanes, effective_lanes, playback_rate);
-    engine.emit_session(&app);
+    engine.emit_session(&app, session::AudioResource::Output);
     Ok(engine.output_snapshot())
 }
 
@@ -526,6 +578,25 @@ pub fn audio_set_click(
 }
 
 #[tauri::command]
+pub fn audio_set_standalone_metronome(
+    app: AppHandle,
+    state: State<'_, NativeAudioState>,
+    payload: transport::StandaloneMetronomeRequest,
+) -> Result<transport::StandaloneMetronomeState, String> {
+    if !state.capabilities.native_playback_supported {
+        return Err("Native audio output is unavailable.".to_string());
+    }
+    let mut engine = state.engine()?;
+    engine.drain_reports();
+    let timeline = engine.output_session.timeline();
+    let reporter = engine.report_sender.clone();
+    engine.transport.bind_auxiliary_runtime(timeline, reporter);
+    engine
+        .transport
+        .set_standalone_metronome(app, payload, state.capabilities())
+}
+
+#[tauri::command]
 pub fn audio_get_snapshot(
     state: State<'_, NativeAudioState>,
 ) -> Result<transport::AudioSnapshot, String> {
@@ -540,7 +611,7 @@ pub fn audio_get_session_snapshot(
 ) -> Result<session::SessionSnapshot, String> {
     let mut engine = state.engine()?;
     engine.drain_reports();
-    Ok(engine.session.snapshot())
+    Ok(engine.output_session.snapshot())
 }
 
 #[tauri::command]
@@ -604,7 +675,7 @@ pub fn audio_start_input(
 
     let mut engine = state.engine()?;
     let acquired = engine.acquire(
-        &app,
+        Some(&app),
         session::SessionOwner::Capture,
         &payload.control,
         0.0,
@@ -616,12 +687,12 @@ pub fn audio_start_input(
     }
     let input = engine.capture.start(app.clone(), payload)?;
     if let Some(code) = input.error.as_ref().map(|error| error.code) {
-        let generation = engine.session.snapshot().generation;
-        if let Some(event) = engine.session.mark_terminal(generation, code) {
+        let generation = engine.capture_session.snapshot().generation;
+        if let Some(event) = engine.capture_session.mark_terminal(generation, code) {
             let _ = app.emit(AUDIO_EVENT_TERMINAL, event);
         }
     }
-    engine.emit_session(&app);
+    engine.emit_session(&app, session::AudioResource::Capture);
     Ok(engine.input_snapshot(input))
 }
 
@@ -632,13 +703,17 @@ pub fn audio_stop_input(
     payload: Option<session::SessionCommand>,
 ) -> Result<capture::AudioInputState, String> {
     let mut engine = state.engine()?;
-    engine.authorize(
-        session::SessionOwner::Capture,
-        &payload.unwrap_or_default(),
-        false,
-    )?;
-    let input = engine.capture.stop();
-    engine.emit_session(&app);
+    let command = payload.unwrap_or_default();
+    let released = engine
+        .capture_session
+        .release_capture(&command)
+        .map_err(str::to_string)?;
+    let input = if released {
+        engine.capture.stop()
+    } else {
+        engine.capture.state()
+    };
+    engine.emit_session(&app, session::AudioResource::Capture);
     Ok(engine.input_snapshot(input))
 }
 
@@ -669,26 +744,26 @@ pub fn audio_schedule_cues(
 ) -> Result<session::SessionSnapshot, String> {
     let mut engine = state.engine()?;
     let owner = engine
-        .session
+        .output_session
         .snapshot()
         .owner
         .unwrap_or(session::SessionOwner::Cue);
     if !engine.authorize(owner, &payload.session, false)? {
-        return Ok(engine.session.snapshot());
+        return Ok(engine.output_session.snapshot());
     }
     let revision = payload
         .session
         .timeline_revision
-        .unwrap_or_else(|| engine.session.snapshot().timeline_revision);
+        .unwrap_or_else(|| engine.output_session.snapshot().timeline_revision);
     engine
-        .session
+        .output_session
         .timeline()
         .lock()
         .map_err(|_| "timeline_unavailable")?
         .schedule(revision, payload.cues)
         .map_err(str::to_string)?;
-    engine.emit_session(&app);
-    Ok(engine.session.snapshot())
+    engine.emit_session(&app, session::AudioResource::Output);
+    Ok(engine.output_session.snapshot())
 }
 
 #[tauri::command]
@@ -701,25 +776,25 @@ pub fn audio_cancel_cues(
     let mut engine = state.engine()?;
     let payload = payload.unwrap_or_default();
     let owner = engine
-        .session
+        .output_session
         .snapshot()
         .owner
         .unwrap_or(session::SessionOwner::Cue);
     if !engine.authorize(owner, &payload, false)? {
-        return Ok(engine.session.snapshot());
+        return Ok(engine.output_session.snapshot());
     }
     let revision = payload
         .timeline_revision
-        .unwrap_or_else(|| engine.session.snapshot().timeline_revision);
+        .unwrap_or_else(|| engine.output_session.snapshot().timeline_revision);
     engine
-        .session
+        .output_session
         .timeline()
         .lock()
         .map_err(|_| "timeline_unavailable")?
         .cancel(revision, kind)
         .map_err(str::to_string)?;
-    engine.emit_session(&app);
-    Ok(engine.session.snapshot())
+    engine.emit_session(&app, session::AudioResource::Output);
+    Ok(engine.output_session.snapshot())
 }
 
 #[cfg(test)]
@@ -814,19 +889,30 @@ mod tests {
             mixer: mixer::MixerState::default(),
             transport: transport::TransportState::default(),
             capture: capture::CaptureState::default(),
-            session: session::SessionCoordinator::new(true, true),
+            output_session: session::SessionCoordinator::new_for_resource(
+                session::AudioResource::Output,
+                session::AudioSource::ProjectPlayback,
+                true,
+                false,
+            ),
+            capture_session: session::SessionCoordinator::new_for_resource(
+                session::AudioResource::Capture,
+                session::AudioSource::TunerCapture,
+                false,
+                true,
+            ),
             report_sender: report_sender.clone(),
             report_receiver,
         };
         let command = session::SessionCommand::default();
         let session::Acquire::Release { token, lease, .. } = engine
-            .session
+            .output_session
             .begin_acquire(session::SessionOwner::Playback, &command)
         else {
             panic!()
         };
         let generation = engine
-            .session
+            .output_session
             .finish_acquire(
                 token,
                 session::SessionOwner::Playback,
@@ -838,6 +924,7 @@ mod tests {
             .unwrap();
         report_sender
             .send(session::RuntimeReport {
+                resource: session::AudioResource::Output,
                 generation,
                 kind: session::RuntimeReportKind::Terminal("output_stream_failure"),
             })
@@ -845,14 +932,248 @@ mod tests {
 
         engine.drain_reports();
         assert_eq!(
-            engine.session.snapshot().terminal_diagnostic,
+            engine.output_session.snapshot().terminal_diagnostic,
             Some("output_stream_failure")
         );
         assert!(engine
-            .session
+            .output_session
             .authorize(session::SessionOwner::Playback, &command, true)
             .unwrap());
-        assert!(engine.session.snapshot().generation > generation);
+        assert!(engine.output_session.snapshot().generation > generation);
         assert!(capabilities.emits_events.contains(&AUDIO_EVENT_TERMINAL));
+    }
+
+    #[test]
+    fn output_and_capture_leases_are_concurrent_and_terminally_isolated() {
+        let mut output = session::SessionCoordinator::new_for_resource(
+            session::AudioResource::Output,
+            session::AudioSource::ProjectPlayback,
+            true,
+            false,
+        );
+        let mut capture = session::SessionCoordinator::new_for_resource(
+            session::AudioResource::Capture,
+            session::AudioSource::TunerCapture,
+            false,
+            true,
+        );
+        let output_command = session::SessionCommand {
+            lease_id: Some("project-playback".into()),
+            operation_id: Some("prepare".into()),
+            ..Default::default()
+        };
+        let capture_command = session::SessionCommand {
+            lease_id: Some("tuner-capture".into()),
+            operation_id: Some("start".into()),
+            ..Default::default()
+        };
+        let session::Acquire::Release { token, lease, .. } =
+            output.begin_acquire(session::SessionOwner::Playback, &output_command)
+        else {
+            panic!()
+        };
+        let output_generation = output
+            .finish_acquire(
+                token,
+                session::SessionOwner::Playback,
+                lease,
+                &output_command,
+                10.0,
+                1.0,
+            )
+            .unwrap();
+        let session::Acquire::Release { token, lease, .. } =
+            capture.begin_acquire(session::SessionOwner::Capture, &capture_command)
+        else {
+            panic!()
+        };
+        let capture_generation = capture
+            .finish_acquire(
+                token,
+                session::SessionOwner::Capture,
+                lease,
+                &capture_command,
+                0.0,
+                1.0,
+            )
+            .unwrap();
+
+        assert_eq!(output.snapshot().status, session::SessionStatus::Output);
+        assert_eq!(capture.snapshot().status, session::SessionStatus::Capture);
+        assert!(capture
+            .mark_terminal(capture_generation, "stream-interruption")
+            .is_some());
+        assert_eq!(output.snapshot().generation, output_generation);
+        assert_eq!(output.snapshot().status, session::SessionStatus::Output);
+        assert_eq!(output.snapshot().terminal_diagnostic, None);
+    }
+
+    #[test]
+    fn capture_stop_acknowledgement_does_not_release_output_session() {
+        let (report_sender, report_receiver) = mpsc::sync_channel(1);
+        let mut engine = NativeAudioEngine {
+            mixer: mixer::MixerState::default(),
+            transport: transport::TransportState::default(),
+            capture: capture::CaptureState::default(),
+            output_session: session::SessionCoordinator::new_for_resource(
+                session::AudioResource::Output,
+                session::AudioSource::ProjectPlayback,
+                true,
+                false,
+            ),
+            capture_session: session::SessionCoordinator::new_for_resource(
+                session::AudioResource::Capture,
+                session::AudioSource::TunerCapture,
+                false,
+                true,
+            ),
+            report_sender,
+            report_receiver,
+        };
+        let activate = |lease: &str, operation: &str| session::SessionCommand {
+            lease_id: Some(lease.into()),
+            operation_id: Some(operation.into()),
+            ..Default::default()
+        };
+        let output_command = activate("project-playback", "prepare");
+        let session::Acquire::Release { token, lease, .. } = engine
+            .output_session
+            .begin_acquire(session::SessionOwner::Playback, &output_command)
+        else {
+            panic!()
+        };
+        let output_generation = engine
+            .output_session
+            .finish_acquire(
+                token,
+                session::SessionOwner::Playback,
+                lease,
+                &output_command,
+                10.0,
+                1.0,
+            )
+            .unwrap();
+        let capture_command = activate("tuner-capture", "start");
+        let session::Acquire::Release { token, lease, .. } = engine
+            .capture_session
+            .begin_acquire(session::SessionOwner::Capture, &capture_command)
+        else {
+            panic!()
+        };
+        let capture_generation = engine
+            .capture_session
+            .finish_acquire(
+                token,
+                session::SessionOwner::Capture,
+                lease,
+                &capture_command,
+                0.0,
+                1.0,
+            )
+            .unwrap();
+        let stop = session::SessionCommand {
+            lease_id: Some("tuner-capture".into()),
+            operation_id: Some("stop".into()),
+            generation: Some(capture_generation),
+            timeline_revision: None,
+        };
+
+        assert!(engine.capture_session.release_capture(&stop).unwrap());
+        let stopped_input = engine.capture.stop();
+        let acknowledgement = engine.input_snapshot(stopped_input);
+        assert!(!acknowledgement.active);
+        assert_eq!(acknowledgement.lease_id, None);
+        assert_eq!(acknowledgement.generation, Some(capture_generation));
+        assert_eq!(
+            engine.capture_session.snapshot().status,
+            session::SessionStatus::Released
+        );
+        assert_eq!(
+            engine.output_session.snapshot().status,
+            session::SessionStatus::Output
+        );
+        assert_eq!(
+            engine.output_session.snapshot().generation,
+            output_generation
+        );
+    }
+
+    #[test]
+    #[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
+    fn playback_acquire_and_prepare_preserve_standalone_auxiliary_runtime() {
+        let capabilities = AudioCapabilities::detect();
+        let (report_sender, report_receiver) = mpsc::sync_channel(8);
+        let mut engine = NativeAudioEngine {
+            mixer: mixer::MixerState::default(),
+            transport: transport::TransportState::default(),
+            capture: capture::CaptureState::default(),
+            output_session: session::SessionCoordinator::new_for_resource(
+                session::AudioResource::Output,
+                session::AudioSource::ProjectPlayback,
+                true,
+                false,
+            ),
+            capture_session: session::SessionCoordinator::new_for_resource(
+                session::AudioResource::Capture,
+                session::AudioSource::TunerCapture,
+                false,
+                true,
+            ),
+            report_sender,
+            report_receiver,
+        };
+        engine
+            .transport
+            .set_standalone_metronome_for_test(
+                transport::StandaloneMetronomeRequest {
+                    enabled: true,
+                    bpm: 120.0,
+                    beats_per_bar: 4,
+                    accent_first_beat: true,
+                    gain: 0.8,
+                    follow_playback: true,
+                    control: session::SessionCommand {
+                        lease_id: Some("standalone-metronome".into()),
+                        operation_id: Some("start".into()),
+                        ..Default::default()
+                    },
+                },
+                capabilities.clone(),
+            )
+            .unwrap();
+        engine.transport.install_test_auxiliary_runtime();
+
+        let prepare_control = session::SessionCommand {
+            lease_id: Some("project-playback".into()),
+            operation_id: Some("prepare".into()),
+            ..Default::default()
+        };
+        let acquired = engine
+            .acquire(
+                None,
+                session::SessionOwner::Playback,
+                &prepare_control,
+                10.0,
+                1.0,
+            )
+            .unwrap();
+        assert!(acquired.is_some());
+        assert!(engine.transport.has_auxiliary_runtime());
+
+        let prepared = engine.transport.prepare(
+            None,
+            transport::AudioSessionRequest {
+                session_id: "project-session".into(),
+                duration_seconds: Some(10.0),
+                playback_rate: Some(1.0),
+                lanes: Vec::new(),
+                control: prepare_control,
+                owner: Some(session::SessionOwner::Playback),
+            },
+            Vec::new(),
+            capabilities,
+        );
+        assert_eq!(prepared.id, "project-session");
+        assert!(engine.transport.has_auxiliary_runtime());
     }
 }

--- a/apps/desktop/src-tauri/src/native_audio/session.rs
+++ b/apps/desktop/src-tauri/src/native_audio/session.rs
@@ -11,6 +11,22 @@ pub enum SessionOwner {
     Capture,
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AudioResource {
+    Output,
+    Capture,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AudioSource {
+    ProjectPlayback,
+    TunerCapture,
+    OutputRuntime,
+    CaptureRuntime,
+}
+
 impl SessionOwner {
     pub fn is_output(self) -> bool {
         matches!(self, Self::Playback | Self::Cue)
@@ -39,6 +55,8 @@ pub struct SessionCommand {
 #[derive(Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SessionSnapshot {
+    pub resource: AudioResource,
+    pub source: AudioSource,
     pub status: SessionStatus,
     pub owner: Option<SessionOwner>,
     pub lease_id: Option<String>,
@@ -54,6 +72,8 @@ pub struct SessionSnapshot {
 #[derive(Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct TerminalEvent {
+    pub resource: AudioResource,
+    pub source: AudioSource,
     pub generation: u64,
     pub code: &'static str,
     pub native_time_us: u64,
@@ -76,6 +96,7 @@ pub enum RuntimeReportKind {
 
 #[derive(Clone, Copy)]
 pub struct RuntimeReport {
+    pub resource: AudioResource,
     pub generation: u64,
     pub kind: RuntimeReportKind,
 }
@@ -90,6 +111,8 @@ pub enum Acquire {
 }
 
 pub struct SessionCoordinator {
+    resource: AudioResource,
+    source: AudioSource,
     status: SessionStatus,
     owner: Option<SessionOwner>,
     lease: Option<String>,
@@ -98,13 +121,31 @@ pub struct SessionCoordinator {
     terminal: Option<&'static str>,
     terminal_emitted: bool,
     operations: HashSet<(u64, String)>,
+    released_operation: Option<(String, u64, String)>,
     timeline: Arc<Mutex<Timeline>>,
     availability_reason: Option<&'static str>,
 }
 
 impl SessionCoordinator {
+    #[cfg(test)]
     pub fn new(native_output: bool, native_input: bool) -> Self {
+        Self::new_for_resource(
+            AudioResource::Output,
+            AudioSource::ProjectPlayback,
+            native_output,
+            native_input,
+        )
+    }
+
+    pub fn new_for_resource(
+        resource: AudioResource,
+        source: AudioSource,
+        native_output: bool,
+        native_input: bool,
+    ) -> Self {
         Self {
+            resource,
+            source,
             status: SessionStatus::Released,
             owner: None,
             lease: None,
@@ -113,6 +154,7 @@ impl SessionCoordinator {
             terminal: None,
             terminal_emitted: false,
             operations: HashSet::new(),
+            released_operation: None,
             timeline: Arc::new(Mutex::new(Timeline::default())),
             availability_reason: (!native_output && !native_input)
                 .then_some("native_audio_unavailable"),
@@ -127,6 +169,8 @@ impl SessionCoordinator {
         let now = timeline::native_time_us();
         let timeline = self.timeline.lock().ok();
         SessionSnapshot {
+            resource: self.resource,
+            source: self.source,
             status: self.status,
             owner: self.owner,
             lease_id: self.lease.clone(),
@@ -193,6 +237,7 @@ impl SessionCoordinator {
         self.terminal = None;
         self.terminal_emitted = false;
         self.operations.clear();
+        self.released_operation = None;
         self.record(command);
         self.timeline
             .lock()
@@ -271,6 +316,72 @@ impl SessionCoordinator {
         Ok(true)
     }
 
+    pub fn release_capture(&mut self, command: &SessionCommand) -> Result<bool, &'static str> {
+        if self.resource != AudioResource::Capture {
+            return Err("session_owner_mismatch");
+        }
+        if self.status == SessionStatus::Released {
+            if command.lease_id.is_none()
+                && command.generation.is_none()
+                && command.operation_id.is_none()
+            {
+                return Ok(false);
+            }
+            if command.operation_id.as_ref().is_some_and(|operation| {
+                self.released_operation.as_ref().is_some_and(
+                    |(lease, generation, released_operation)| {
+                        released_operation == operation
+                            && command
+                                .lease_id
+                                .as_deref()
+                                .is_none_or(|requested| requested == lease)
+                            && command
+                                .generation
+                                .is_none_or(|requested| requested == *generation)
+                    },
+                )
+            }) {
+                return Ok(false);
+            }
+            return Err("stale_session_generation");
+        }
+        if command
+            .lease_id
+            .as_deref()
+            .is_some_and(|lease| self.lease.as_deref() != Some(lease))
+            || command
+                .generation
+                .is_some_and(|generation| generation != self.generation)
+        {
+            return Err("stale_session_generation");
+        }
+        if self.owner != Some(SessionOwner::Capture)
+            || !matches!(
+                self.status,
+                SessionStatus::Capture | SessionStatus::Terminal
+            )
+        {
+            return Err("session_not_active");
+        }
+        let released_lease = self
+            .lease
+            .take()
+            .unwrap_or_else(|| "legacy-capture".to_string());
+        self.status = SessionStatus::Released;
+        self.owner = None;
+        self.terminal = None;
+        self.terminal_emitted = false;
+        self.operations.clear();
+        self.released_operation = command
+            .operation_id
+            .as_ref()
+            .map(|operation| (released_lease, self.generation, operation.clone()));
+        if let Ok(mut timeline) = self.timeline.lock() {
+            timeline.stop();
+        }
+        Ok(true)
+    }
+
     pub fn mark_terminal(&mut self, generation: u64, code: &'static str) -> Option<TerminalEvent> {
         if generation != self.generation || self.terminal_emitted {
             return None;
@@ -282,6 +393,8 @@ impl SessionCoordinator {
             timeline.stop();
         }
         Some(TerminalEvent {
+            resource: self.resource,
+            source: self.source,
             generation,
             code,
             native_time_us: timeline::native_time_us(),
@@ -397,14 +510,20 @@ mod tests {
     fn terminal_is_once_per_generation_and_payload_is_safe_camel_case() {
         let mut state = SessionCoordinator::new(true, true);
         let generation = acquire(&mut state, SessionOwner::Playback, "play");
-        assert!(state
+        let terminal = state
             .mark_terminal(generation, "output_stream_failure")
-            .is_some());
+            .unwrap();
         assert!(state
             .mark_terminal(generation, "output_stream_failure")
             .is_none());
         let value = serde_json::to_value(state.snapshot()).unwrap();
+        let terminal_value = serde_json::to_value(terminal).unwrap();
         assert_eq!(value["terminalDiagnostic"], "output_stream_failure");
+        assert_eq!(value["resource"], "output");
+        assert_eq!(value["source"], "project_playback");
+        assert_eq!(terminal_value["nativeTimeUs"].is_number(), true);
+        assert_eq!(terminal_value["resource"], "output");
+        assert_eq!(terminal_value["source"], "project_playback");
         assert!(value.get("fallbackReason").is_none());
     }
 
@@ -414,5 +533,79 @@ mod tests {
         assert!(state
             .authorize(SessionOwner::Playback, &SessionCommand::default(), false)
             .unwrap());
+    }
+
+    #[test]
+    fn capture_release_acknowledges_duplicates_and_rejects_stale_cleanup() {
+        let mut state = SessionCoordinator::new_for_resource(
+            AudioResource::Capture,
+            AudioSource::TunerCapture,
+            false,
+            true,
+        );
+        let generation = acquire(&mut state, SessionOwner::Capture, "tuner-capture");
+        let stop = SessionCommand {
+            lease_id: Some("tuner-capture".into()),
+            operation_id: Some("stop-1".into()),
+            generation: Some(generation),
+            timeline_revision: None,
+        };
+
+        assert!(state.release_capture(&stop).unwrap());
+        let released = state.snapshot();
+        assert_eq!(released.status, SessionStatus::Released);
+        assert_eq!(released.owner, None);
+        assert_eq!(released.lease_id, None);
+        assert_eq!(released.generation, generation);
+        assert_eq!(released.terminal_diagnostic, None);
+        assert!(!state.release_capture(&stop).unwrap());
+
+        let restart = SessionCommand {
+            lease_id: Some("tuner-capture".into()),
+            operation_id: Some("start-2".into()),
+            ..Default::default()
+        };
+        let Acquire::Release { token, lease, .. } =
+            state.begin_acquire(SessionOwner::Capture, &restart)
+        else {
+            panic!()
+        };
+        let next_generation = state
+            .finish_acquire(token, SessionOwner::Capture, lease, &restart, 0.0, 1.0)
+            .unwrap();
+        assert!(next_generation > generation);
+        assert_eq!(
+            state.release_capture(&stop),
+            Err("stale_session_generation")
+        );
+        assert_eq!(state.snapshot().status, SessionStatus::Capture);
+        assert_eq!(state.snapshot().generation, next_generation);
+    }
+
+    #[test]
+    fn capture_release_clears_terminal_state_without_changing_generation() {
+        let mut state = SessionCoordinator::new_for_resource(
+            AudioResource::Capture,
+            AudioSource::TunerCapture,
+            false,
+            true,
+        );
+        let generation = acquire(&mut state, SessionOwner::Capture, "tuner-capture");
+        assert!(state
+            .mark_terminal(generation, "stream_interruption")
+            .is_some());
+
+        assert!(state
+            .release_capture(&SessionCommand {
+                lease_id: Some("tuner-capture".into()),
+                operation_id: Some("terminal-cleanup".into()),
+                generation: Some(generation),
+                timeline_revision: None,
+            })
+            .unwrap());
+        let snapshot = state.snapshot();
+        assert_eq!(snapshot.status, SessionStatus::Released);
+        assert_eq!(snapshot.generation, generation);
+        assert_eq!(snapshot.terminal_diagnostic, None);
     }
 }

--- a/apps/desktop/src-tauri/src/native_audio/timeline.rs
+++ b/apps/desktop/src-tauri/src/native_audio/timeline.rs
@@ -38,6 +38,8 @@ pub struct CueRequest {
 #[derive(Clone, Debug, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CueEvent {
+    pub resource: &'static str,
+    pub source: &'static str,
     pub generation: u64,
     pub revision: u64,
     pub cue_index: u32,
@@ -346,6 +348,8 @@ impl Timeline {
             };
             due.push(FiredCue {
                 event: CueEvent {
+                    resource: "output",
+                    source: "project_playback",
                     generation: self.generation,
                     revision: self.revision,
                     cue_index: cue.index,

--- a/apps/desktop/src-tauri/src/native_audio/transport.rs
+++ b/apps/desktop/src-tauri/src/native_audio/transport.rs
@@ -1,5 +1,5 @@
 use serde::{Deserialize, Serialize};
-use std::collections::VecDeque;
+use std::collections::{HashMap, VecDeque};
 use std::sync::{
     atomic::{AtomicBool, Ordering},
     Arc, Mutex,
@@ -35,7 +35,9 @@ use tauri::Emitter;
 use super::{
     diagnostics::{self, DiagnosticCheckpoint, DiagnosticSafeCode},
     mixer::{AudioLaneRequest, AudioLaneRole, EffectiveAudioLane},
-    session::{RuntimeReport, RuntimeReportKind, SessionCommand, SessionOwner},
+    session::{
+        AudioResource, AudioSource, RuntimeReport, RuntimeReportKind, SessionCommand, SessionOwner,
+    },
     timeline::{self, CueRequest, Timeline},
     AudioCapabilities,
 };
@@ -135,6 +137,34 @@ pub struct AudioClickRequest {
     pub accent_first_beat: Option<bool>,
     pub gain: Option<f32>,
     pub follow_transport: Option<bool>,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct StandaloneMetronomeRequest {
+    pub enabled: bool,
+    pub bpm: f64,
+    pub beats_per_bar: u32,
+    pub accent_first_beat: bool,
+    pub gain: f32,
+    pub follow_playback: bool,
+    #[serde(default, flatten)]
+    pub control: SessionCommand,
+}
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct StandaloneMetronomeState {
+    pub enabled: bool,
+    pub bpm: f64,
+    pub beats_per_bar: u32,
+    pub accent_first_beat: bool,
+    pub gain: f32,
+    pub follow_playback: bool,
+    pub lease_id: Option<String>,
+    pub generation: u64,
+    pub revision: u64,
+    pub native_time_us: u64,
 }
 
 #[derive(Clone, Debug, Serialize)]
@@ -385,6 +415,11 @@ struct ClickState {
     accent_first_beat: bool,
     gain: f32,
     follow_transport: bool,
+    generation: u64,
+    revision: u64,
+    free_run_frame: u64,
+    following_playback: bool,
+    last_emitted_beat: Option<u64>,
 }
 
 impl Default for ClickState {
@@ -396,8 +431,21 @@ impl Default for ClickState {
             accent_first_beat: true,
             gain: 0.75,
             follow_transport: true,
+            generation: 0,
+            revision: 0,
+            free_run_frame: 0,
+            following_playback: false,
+            last_emitted_beat: None,
         }
     }
+}
+
+#[derive(Clone, Default)]
+struct StandaloneMetronomeControl {
+    lease_id: Option<String>,
+    generation: u64,
+    revision: u64,
+    operations: HashMap<(String, String), StandaloneMetronomeState>,
 }
 
 struct PlaybackShared {
@@ -565,6 +613,7 @@ struct PlaybackRuntime {
     audio_thread: Option<JoinHandle<()>>,
     reporter_thread: Option<JoinHandle<()>>,
     worker_threads: Vec<JoinHandle<()>>,
+    auxiliary_only: bool,
 }
 
 #[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
@@ -584,6 +633,7 @@ pub struct TransportState {
     raw_lanes: Vec<AudioLaneRequest>,
     lanes: Vec<EffectiveAudioLane>,
     click: ClickState,
+    standalone_metronome: StandaloneMetronomeControl,
     diagnostics_generation: u64,
     timeline: Option<Arc<Mutex<Timeline>>>,
     generation: u64,
@@ -593,6 +643,10 @@ pub struct TransportState {
     app: Option<AppHandle>,
     #[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
     runtime: Option<PlaybackRuntime>,
+    #[cfg(test)]
+    fail_next_runtime_start: bool,
+    #[cfg(test)]
+    fail_next_release: bool,
 }
 
 impl Default for TransportState {
@@ -609,6 +663,7 @@ impl Default for TransportState {
             raw_lanes: Vec::new(),
             lanes: Vec::new(),
             click: ClickState::default(),
+            standalone_metronome: StandaloneMetronomeControl::default(),
             diagnostics_generation: 0,
             timeline: None,
             generation: 0,
@@ -618,6 +673,10 @@ impl Default for TransportState {
             app: None,
             #[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
             runtime: None,
+            #[cfg(test)]
+            fail_next_runtime_start: false,
+            #[cfg(test)]
+            fail_next_release: false,
         }
     }
 }
@@ -642,6 +701,86 @@ impl TransportState {
         self.raw_lanes.len().min(6)
     }
 
+    pub fn has_runtime(&self) -> bool {
+        #[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
+        {
+            self.runtime.is_some()
+        }
+        #[cfg(not(any(target_os = "android", target_os = "linux", target_os = "macos")))]
+        {
+            false
+        }
+    }
+
+    pub fn has_auxiliary_runtime(&self) -> bool {
+        #[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
+        {
+            self.runtime
+                .as_ref()
+                .is_some_and(|runtime| runtime.auxiliary_only)
+        }
+        #[cfg(not(any(target_os = "android", target_os = "linux", target_os = "macos")))]
+        {
+            false
+        }
+    }
+
+    #[cfg(all(
+        test,
+        any(target_os = "android", target_os = "linux", target_os = "macos")
+    ))]
+    pub(crate) fn install_test_auxiliary_runtime(&mut self) {
+        let timeline = self
+            .timeline
+            .clone()
+            .unwrap_or_else(|| Arc::new(Mutex::new(Timeline::default())));
+        let report_sender = self.report_sender.clone().unwrap_or_else(|| {
+            let (sender, _receiver) = mpsc::sync_channel(1);
+            sender
+        });
+        let shared = PlaybackShared {
+            session_id: Some("standalone-metronome".into()),
+            status: TransportStatus::Stopped,
+            position_seconds: 0.0,
+            duration_seconds: 0.0,
+            playback_rate: self.playback_rate,
+            native_playback_supported: true,
+            fallback_reason: None,
+            sample_rate: 1_000,
+            channels: 1,
+            lanes: Vec::new(),
+            snapshot_lanes: Vec::new(),
+            click: self.click.clone(),
+            ended_pending: false,
+            error_pending: None,
+            terminal_error: None,
+            buffering: false,
+            sustained_underrun_frames: 0,
+            underrun_error_pending: false,
+            fallback_cause: None,
+            diagnostics_generation: 0,
+            diagnostics_gain_first_change_recorded: false,
+            timeline,
+            generation: self.generation,
+            report_sender,
+            pending_cues: VecDeque::new(),
+            terminal_reported: false,
+            cue_voices: Vec::new(),
+        };
+        let (audio_stop_sender, _audio_stop_receiver) = mpsc::channel();
+        let (reporter_stop_sender, _reporter_stop_receiver) = mpsc::channel();
+        self.runtime = Some(PlaybackRuntime {
+            shared: Arc::new(Mutex::new(shared)),
+            audio_stop_sender,
+            reporter_stop_sender,
+            worker_control_senders: Vec::new(),
+            audio_thread: None,
+            reporter_thread: None,
+            worker_threads: Vec::new(),
+            auxiliary_only: true,
+        });
+    }
+
     pub fn begin_explicit_attempt(&mut self, capabilities: AudioCapabilities) {
         #[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
         if self.runtime.as_ref().is_some_and(|runtime| {
@@ -656,6 +795,10 @@ impl TransportState {
     }
 
     pub fn release_for_transfer(&mut self) -> Result<(), &'static str> {
+        #[cfg(test)]
+        if std::mem::take(&mut self.fail_next_release) {
+            return Err("release_timeout");
+        }
         self.status = TransportStatus::Stopped;
         self.started_at = None;
         if let Some(timeline) = &self.timeline {
@@ -737,6 +880,13 @@ impl TransportState {
             capabilities.native_playback_supported && runtime_unavailable_reason.is_none();
         let fallback_reason =
             runtime_unavailable_reason.or_else(|| capabilities.fallback_reason.map(str::to_string));
+        #[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
+        let preserve_standalone_runtime = self.click.enabled && self.runtime.is_some();
+        #[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
+        if !preserve_standalone_runtime {
+            self.stop_runtime();
+        }
+        #[cfg(not(any(target_os = "android", target_os = "linux", target_os = "macos")))]
         self.stop_runtime();
 
         self.session_id = Some(request.session_id.clone());
@@ -752,7 +902,24 @@ impl TransportState {
         #[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
         {
             self.app = app;
-            self.runtime = None;
+            if preserve_standalone_runtime {
+                if let Some(runtime) = &mut self.runtime {
+                    runtime.auxiliary_only = true;
+                    if let Ok(mut shared) = runtime.shared.lock() {
+                        shared.session_id = self.session_id.clone();
+                        shared.status = TransportStatus::Stopped;
+                        shared.position_seconds = 0.0;
+                        shared.duration_seconds = self.duration_seconds;
+                        shared.playback_rate = self.playback_rate;
+                        shared.snapshot_lanes = self.lanes.clone();
+                        shared.click = self.click.clone();
+                        shared.ended_pending = false;
+                        shared.buffering = false;
+                    }
+                }
+            } else if self.click.enabled {
+                let _ = self.ensure_runtime(false);
+            }
         }
 
         AudioSession {
@@ -836,6 +1003,7 @@ impl TransportState {
             accent_first_beat: request.accent_first_beat.unwrap_or(true),
             gain: request.gain.unwrap_or(0.75).clamp(0.0, 1.0),
             follow_transport: request.follow_transport.unwrap_or(true),
+            ..self.click.clone()
         };
 
         #[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
@@ -846,6 +1014,195 @@ impl TransportState {
         }
 
         self.snapshot()
+    }
+
+    pub fn bind_auxiliary_runtime(
+        &mut self,
+        timeline: Arc<Mutex<Timeline>>,
+        #[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
+        report_sender: mpsc::SyncSender<RuntimeReport>,
+    ) {
+        if self.timeline.is_none() {
+            self.timeline = Some(timeline);
+        }
+        #[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
+        if self.report_sender.is_none() {
+            self.report_sender = Some(report_sender);
+        }
+    }
+
+    pub fn set_standalone_metronome(
+        &mut self,
+        app: AppHandle,
+        request: StandaloneMetronomeRequest,
+        capabilities: AudioCapabilities,
+    ) -> Result<StandaloneMetronomeState, String> {
+        self.set_standalone_metronome_inner(Some(app), request, capabilities)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn set_standalone_metronome_for_test(
+        &mut self,
+        request: StandaloneMetronomeRequest,
+        capabilities: AudioCapabilities,
+    ) -> Result<StandaloneMetronomeState, String> {
+        self.set_standalone_metronome_inner(None, request, capabilities)
+    }
+
+    fn set_standalone_metronome_inner(
+        &mut self,
+        app: Option<AppHandle>,
+        request: StandaloneMetronomeRequest,
+        capabilities: AudioCapabilities,
+    ) -> Result<StandaloneMetronomeState, String> {
+        let previous_click = self.click.clone();
+        let previous_control = self.standalone_metronome.clone();
+        let previous_session_id = self.session_id.clone();
+        let previous_generation = self.generation;
+        let previous_native_playback_supported = self.native_playback_supported;
+        let previous_fallback_reason = self.fallback_reason.clone();
+        let previous_status = self.status;
+        let previous_position_seconds = self.position_seconds;
+        let previous_started_at = self.started_at;
+        #[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
+        let previous_app = self.app.clone();
+        let state = self.apply_standalone_metronome(&request)?;
+        #[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
+        let lifecycle_result = (|| {
+            if let Some(app) = app {
+                self.app = Some(app);
+            }
+            self.native_playback_supported = capabilities.native_playback_supported;
+            self.fallback_reason = capabilities.fallback_reason.map(str::to_string);
+            if let Some(runtime) = &self.runtime {
+                if let Ok(mut shared) = runtime.shared.lock() {
+                    shared.click = self.click.clone();
+                }
+            } else if self.click.enabled {
+                if self
+                    .session_id
+                    .as_deref()
+                    .is_none_or(|session_id| session_id == "standalone-metronome")
+                {
+                    self.session_id = Some("standalone-metronome".to_string());
+                    self.generation = self.standalone_metronome.generation;
+                }
+                self.ensure_runtime(false)?;
+            }
+            if !self.click.enabled && self.status != TransportStatus::Playing {
+                self.release_for_transfer().map_err(str::to_string)?;
+            }
+            Ok::<(), String>(())
+        })();
+        #[cfg(not(any(target_os = "android", target_os = "linux", target_os = "macos")))]
+        let lifecycle_result = Ok::<(), String>(());
+        if let Err(error) = lifecycle_result {
+            self.click = previous_click;
+            self.standalone_metronome = previous_control;
+            self.session_id = previous_session_id;
+            self.generation = previous_generation;
+            self.native_playback_supported = previous_native_playback_supported;
+            self.fallback_reason = previous_fallback_reason;
+            self.status = previous_status;
+            self.position_seconds = previous_position_seconds;
+            self.started_at = previous_started_at;
+            #[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
+            {
+                self.app = previous_app;
+            }
+            #[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
+            if let Some(runtime) = &self.runtime {
+                if let Ok(mut shared) = runtime.shared.lock() {
+                    shared.click = self.click.clone();
+                }
+            }
+            return Err(error);
+        }
+        Ok(state)
+    }
+
+    fn apply_standalone_metronome(
+        &mut self,
+        request: &StandaloneMetronomeRequest,
+    ) -> Result<StandaloneMetronomeState, String> {
+        let lease = request
+            .control
+            .lease_id
+            .clone()
+            .unwrap_or_else(|| "standalone-metronome".to_string());
+        let operation_key = request
+            .control
+            .operation_id
+            .as_ref()
+            .map(|operation| (lease.clone(), operation.clone()));
+        if let Some(state) = operation_key
+            .as_ref()
+            .and_then(|key| self.standalone_metronome.operations.get(key))
+        {
+            return Ok(state.clone());
+        }
+        let control = &mut self.standalone_metronome;
+        if control.lease_id.is_some()
+            && (control.lease_id.as_deref() != Some(&lease)
+                || request
+                    .control
+                    .generation
+                    .is_some_and(|generation| generation != control.generation))
+        {
+            return Err("stale_session_generation".to_string());
+        }
+        if request
+            .control
+            .timeline_revision
+            .is_some_and(|revision| revision != control.revision)
+        {
+            return Err("stale_timeline_revision".to_string());
+        }
+        if request.enabled && !self.click.enabled {
+            control.generation = control.generation.wrapping_add(1).max(1);
+            control.revision = 1;
+            control.lease_id = Some(lease);
+            control.operations.clear();
+        } else if control.lease_id.is_none() {
+            control.lease_id = Some(lease);
+        } else {
+            control.revision = control.revision.wrapping_add(1).max(1);
+        }
+        self.click = ClickState {
+            enabled: request.enabled,
+            bpm: request.bpm.clamp(30.0, 300.0),
+            beats_per_bar: request.beats_per_bar.clamp(1, 12),
+            accent_first_beat: request.accent_first_beat,
+            gain: request.gain.clamp(0.0, 1.0),
+            follow_transport: request.follow_playback,
+            generation: control.generation,
+            revision: control.revision,
+            free_run_frame: 0,
+            following_playback: false,
+            last_emitted_beat: None,
+        };
+        let state = self.standalone_metronome_state();
+        if let Some(key) = operation_key {
+            self.standalone_metronome
+                .operations
+                .insert(key, state.clone());
+        }
+        Ok(state)
+    }
+
+    fn standalone_metronome_state(&self) -> StandaloneMetronomeState {
+        StandaloneMetronomeState {
+            enabled: self.click.enabled,
+            bpm: self.click.bpm,
+            beats_per_bar: self.click.beats_per_bar,
+            accent_first_beat: self.click.accent_first_beat,
+            gain: self.click.gain,
+            follow_playback: self.click.follow_transport,
+            lease_id: self.standalone_metronome.lease_id.clone(),
+            generation: self.standalone_metronome.generation,
+            revision: self.standalone_metronome.revision,
+            native_time_us: timeline::native_time_us(),
+        }
     }
 
     pub fn play(&mut self, request: AudioPlayRequest) -> Result<AudioSnapshot, String> {
@@ -864,7 +1221,7 @@ impl TransportState {
         }
         let _ = request.scheduled_start_time_seconds;
         #[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
-        let runtime_started = self.ensure_runtime()?;
+        let runtime_started = self.ensure_runtime(true)?;
         #[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
         let terminal_runtime = self.runtime.as_ref().and_then(|runtime| {
             let shared = runtime.shared.lock().ok()?;
@@ -939,7 +1296,7 @@ impl TransportState {
 
         #[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
         if let Some(runtime) = &self.runtime {
-            if let Ok(shared) = runtime.shared.lock() {
+            if let Ok(mut shared) = runtime.shared.lock() {
                 self.position_seconds = shared.position_seconds;
                 if let Some(reason) = shared
                     .terminal_error
@@ -952,9 +1309,20 @@ impl TransportState {
                 {
                     self.native_playback_supported = false;
                     self.fallback_reason = Some(reason);
+                } else if self.click.enabled {
+                    shared.status = TransportStatus::Paused;
+                    shared.position_seconds = self.position_seconds;
+                    shared.buffering = false;
+                    shared.ended_pending = false;
+                    shared.click = self.click.clone();
                 }
             }
         }
+        #[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
+        if !self.click.enabled || !self.native_playback_supported {
+            self.stop_runtime();
+        }
+        #[cfg(not(any(target_os = "android", target_os = "linux", target_os = "macos")))]
         self.stop_runtime();
 
         self.snapshot()
@@ -988,6 +1356,22 @@ impl TransportState {
         self.position_seconds = 0.0;
         self.status = TransportStatus::Stopped;
         self.started_at = None;
+        #[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
+        if self.click.enabled {
+            if let Some(runtime) = &self.runtime {
+                seek_runtime_workers(runtime, 0.0, self.diagnostics_generation);
+                if let Ok(mut shared) = runtime.shared.lock() {
+                    shared.status = TransportStatus::Stopped;
+                    shared.position_seconds = 0.0;
+                    shared.buffering = false;
+                    shared.ended_pending = false;
+                    shared.click = self.click.clone();
+                }
+            }
+        } else {
+            self.stop_runtime();
+        }
+        #[cfg(not(any(target_os = "android", target_os = "linux", target_os = "macos")))]
         self.stop_runtime();
 
         self.snapshot()
@@ -1079,7 +1463,11 @@ impl TransportState {
     }
 
     #[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
-    fn ensure_runtime(&mut self) -> Result<bool, String> {
+    fn ensure_runtime(&mut self, require_project_runtime: bool) -> Result<bool, String> {
+        #[cfg(test)]
+        if std::mem::take(&mut self.fail_next_runtime_start) {
+            return Err("injected_runtime_start_failure".to_string());
+        }
         let runtime_finished = self.runtime.as_ref().is_some_and(|runtime| {
             runtime
                 .audio_thread
@@ -1089,8 +1477,15 @@ impl TransportState {
                     .reporter_thread
                     .as_ref()
                     .is_some_and(JoinHandle::is_finished)
+                || (require_project_runtime
+                    && runtime.worker_threads.iter().any(JoinHandle::is_finished))
         });
-        if runtime_finished {
+        let runtime_kind_mismatch = require_project_runtime
+            && self
+                .runtime
+                .as_ref()
+                .is_some_and(|runtime| runtime.auxiliary_only);
+        if runtime_finished || runtime_kind_mismatch {
             self.stop_runtime();
         }
         if self.runtime.is_some() {
@@ -1103,17 +1498,31 @@ impl TransportState {
             #[cfg(not(test))]
             return Err("Native audio runtime is unavailable.".to_string());
         };
-        let session_id = self
-            .session_id
-            .as_deref()
-            .ok_or_else(|| "Native audio session is not prepared.".to_string())?;
+        let session_id = if require_project_runtime {
+            self.session_id
+                .as_deref()
+                .ok_or_else(|| "Native audio session is not prepared.".to_string())?
+        } else {
+            "standalone-metronome"
+        };
+        let raw_lanes = require_project_runtime
+            .then_some(self.raw_lanes.as_slice())
+            .unwrap_or(&[]);
+        let lanes = require_project_runtime
+            .then_some(self.lanes.as_slice())
+            .unwrap_or(&[]);
+        let duration_seconds = if require_project_runtime {
+            self.duration_seconds
+        } else {
+            0.0
+        };
         match start_native_runtime(
             app,
             session_id,
-            self.duration_seconds,
+            duration_seconds,
             self.playback_rate,
-            &self.raw_lanes,
-            &self.lanes,
+            raw_lanes,
+            lanes,
             &self.click,
             self.diagnostics_generation,
             self.timeline
@@ -1124,7 +1533,8 @@ impl TransportState {
                 .clone()
                 .ok_or_else(|| "Native session reporter is unavailable.".to_string())?,
         ) {
-            Ok(runtime) => {
+            Ok(mut runtime) => {
+                runtime.auxiliary_only = !require_project_runtime;
                 self.runtime = Some(runtime);
                 Ok(true)
             }
@@ -1423,16 +1833,12 @@ fn mix_shared_frame(shared: &mut PlaybackShared, channel: usize, sample_index: u
         }
     }
 
-    if !shared.click.follow_transport || shared.status == TransportStatus::Playing {
-        sample += click_sample(&shared.click, shared.position_seconds, channel);
-    }
-
     sample.clamp(-1.0, 1.0)
 }
 
 fn mix_shared_frame_without_diagnostics(
     shared: &mut PlaybackShared,
-    channel: usize,
+    _channel: usize,
     sample_index: usize,
 ) -> f32 {
     let mut sample = 0.0;
@@ -1450,11 +1856,51 @@ fn mix_shared_frame_without_diagnostics(
         }
     }
 
-    if !shared.click.follow_transport || shared.status == TransportStatus::Playing {
-        sample += click_sample(&shared.click, shared.position_seconds, channel);
-    }
-
     sample.clamp(-1.0, 1.0)
+}
+
+fn standalone_click_frame(shared: &mut PlaybackShared) -> f32 {
+    if !shared.click.enabled {
+        return 0.0;
+    }
+    let following_playback = shared.click.follow_transport
+        && shared.status == TransportStatus::Playing
+        && !shared.buffering;
+    if following_playback != shared.click.following_playback {
+        shared.click.following_playback = following_playback;
+        shared.click.free_run_frame = 0;
+        shared.click.last_emitted_beat = None;
+    }
+    if following_playback {
+        return 0.0;
+    }
+    let position_seconds = shared.click.free_run_frame as f64 / f64::from(shared.sample_rate);
+    let beat_seconds = 60.0 / shared.click.bpm;
+    let beat_index = (position_seconds / beat_seconds).floor().max(0.0) as u64;
+    let beat_offset = position_seconds - beat_index as f64 * beat_seconds;
+    if beat_offset < 1.0 / f64::from(shared.sample_rate)
+        && shared.click.last_emitted_beat != Some(beat_index)
+    {
+        shared.click.last_emitted_beat = Some(beat_index);
+        let now = timeline::native_time_us();
+        shared.pending_cues.push_back(timeline::CueEvent {
+            resource: "output",
+            source: "standalone_metronome",
+            generation: shared.click.generation,
+            revision: shared.click.revision,
+            cue_index: beat_index.min(u64::from(u32::MAX)) as u32,
+            kind: timeline::CueKind::Metronome,
+            accent: shared.click.accent_first_beat
+                && beat_index % u64::from(shared.click.beats_per_bar) == 0,
+            gain: shared.click.gain,
+            scheduled_native_time_us: now,
+            actual_native_time_us: now,
+            insertion_sequence: beat_index,
+        });
+    }
+    let sample = click_sample(&shared.click, position_seconds, 0);
+    shared.click.free_run_frame = shared.click.free_run_frame.saturating_add(1);
+    sample
 }
 
 fn prepare_lane_scratch(
@@ -1662,7 +2108,7 @@ fn render_shared_output(shared: &mut PlaybackShared, output: &mut [f32]) {
             .iter()
             .filter(|cue| cue.frame_offset == frame_index)
             .for_each(|cue| start_cue_voice(shared, cue));
-        let cue_sample = cue_frame_sample(shared);
+        let cue_sample = cue_frame_sample(shared) + standalone_click_frame(shared);
         if shared.status != TransportStatus::Playing
             || shared.buffering
             || frame_index < start_offset
@@ -1672,11 +2118,13 @@ fn render_shared_output(shared: &mut PlaybackShared, output: &mut [f32]) {
         }
 
         for (channel, sample) in frame.iter_mut().enumerate() {
-            *sample = mix_shared_frame(
+            let click_pan = if channel == 0 { 1.0 } else { 0.92 };
+            *sample = (mix_shared_frame(
                 shared,
                 channel,
                 (frame_index - start_offset) * shared.channels + channel,
-            ) + cue_sample;
+            ) + cue_sample * click_pan)
+                .clamp(-1.0, 1.0);
         }
     }
     if shared.diagnostics_generation != 0
@@ -1733,7 +2181,7 @@ where
             .iter()
             .filter(|cue| cue.frame_offset == frame_index)
             .for_each(|cue| start_cue_voice(shared, cue));
-        let cue_sample = cue_frame_sample(shared);
+        let cue_sample = cue_frame_sample(shared) + standalone_click_frame(shared);
         if shared.status != TransportStatus::Playing
             || shared.buffering
             || frame_index < start_offset
@@ -1746,7 +2194,9 @@ where
 
         for (channel, sample) in frame.iter_mut().enumerate() {
             let sample_index = (frame_index - start_offset) * shared.channels + channel;
-            let mixed = mix_shared_frame(shared, channel, sample_index) + cue_sample;
+            let click_pan = if channel == 0 { 1.0 } else { 0.92 };
+            let mixed = (mix_shared_frame(shared, channel, sample_index) + cue_sample * click_pan)
+                .clamp(-1.0, 1.0);
             if track_nonzero {
                 any_nonzero |= mixed.abs() > AUDIBLE_GAIN_FLOOR;
             }
@@ -1919,6 +2369,7 @@ fn start_native_runtime(
         audio_thread: Some(audio_thread),
         reporter_thread: Some(reporter_thread),
         worker_threads,
+        auxiliary_only: false,
     })
 }
 
@@ -2037,7 +2488,7 @@ where
 
 #[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
 fn emit_runtime_events(app: &AppHandle, shared: &Arc<Mutex<PlaybackShared>>) -> bool {
-    let (snapshot, ended, error, terminal, cues, reporter) = {
+    let (snapshot, ended, error, terminal, cues, reporter, metronome_enabled) = {
         let mut shared = match shared.lock() {
             Ok(shared) => shared,
             Err(_) => return false,
@@ -2075,6 +2526,7 @@ fn emit_runtime_events(app: &AppHandle, shared: &Arc<Mutex<PlaybackShared>>) -> 
             terminal,
             cues,
             (shared.generation, shared.report_sender.clone()),
+            shared.click.enabled,
         )
     };
 
@@ -2098,6 +2550,7 @@ fn emit_runtime_events(app: &AppHandle, shared: &Arc<Mutex<PlaybackShared>>) -> 
     if ended {
         let _ = app.emit(AUDIO_EVENT_ENDED, snapshot.clone());
         let _ = reporter.1.try_send(RuntimeReport {
+            resource: AudioResource::Output,
             generation: reporter.0,
             kind: RuntimeReportKind::Ended,
         });
@@ -2116,24 +2569,32 @@ fn emit_runtime_events(app: &AppHandle, shared: &Arc<Mutex<PlaybackShared>>) -> 
     }
     if let Some(code) = terminal {
         let _ = reporter.1.try_send(RuntimeReport {
+            resource: AudioResource::Output,
             generation: reporter.0,
             kind: RuntimeReportKind::Terminal(code),
         });
         let _ = app.emit(
             AUDIO_EVENT_TERMINAL,
             super::session::TerminalEvent {
+                resource: AudioResource::Output,
+                source: AudioSource::OutputRuntime,
                 generation: reporter.0,
                 code,
                 native_time_us: timeline::native_time_us(),
             },
         );
     }
-    ended || terminal.is_some()
+    should_stop_runtime_after_report(ended, terminal.is_some(), metronome_enabled)
 }
 
 #[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
 fn should_emit_ended(ended_pending: bool, requires_error_handling: bool) -> bool {
     ended_pending && !requires_error_handling
+}
+
+#[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
+fn should_stop_runtime_after_report(ended: bool, terminal: bool, metronome_enabled: bool) -> bool {
+    terminal || (ended && !metronome_enabled)
 }
 
 #[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
@@ -3145,6 +3606,8 @@ mod tests {
         let mut shared = shared_with_lane(ring, 48_000, 1, 1.0);
         let cue = |kind, accent, gain| timeline::FiredCue {
             event: timeline::CueEvent {
+                resource: "output",
+                source: "project_playback",
                 generation: 1,
                 revision: 1,
                 cue_index: 0,
@@ -3237,6 +3700,7 @@ mod tests {
                 audio_thread: Some(audio_thread),
                 reporter_thread: Some(reporter_thread),
                 worker_threads: vec![worker_thread],
+                auxiliary_only: false,
             },
             vec![
                 audio_exited_receiver,
@@ -3518,6 +3982,7 @@ mod tests {
             audio_thread: None,
             reporter_thread: None,
             worker_threads: Vec::new(),
+            auxiliary_only: false,
         });
 
         let error = state
@@ -3586,6 +4051,7 @@ mod tests {
             audio_thread: None,
             reporter_thread: None,
             worker_threads: Vec::new(),
+            auxiliary_only: false,
         });
 
         let snapshot = state.stop();
@@ -3878,6 +4344,7 @@ mod tests {
             accent_first_beat: true,
             gain: 1.0,
             follow_transport: true,
+            ..ClickState::default()
         };
 
         let accented = click_sample(&click, 0.001, 0).abs();
@@ -4269,6 +4736,313 @@ mod tests {
         assert!(output.iter().all(|sample| *sample == 0.0));
         assert_eq!(shared.position_seconds, 0.0);
         assert_eq!(shared.lanes[0].underrun_count, 0);
+    }
+
+    fn standalone_request(
+        enabled: bool,
+        operation_id: &str,
+        generation: Option<u64>,
+        revision: Option<u64>,
+    ) -> StandaloneMetronomeRequest {
+        StandaloneMetronomeRequest {
+            enabled,
+            bpm: 120.0,
+            beats_per_bar: 4,
+            accent_first_beat: true,
+            gain: 0.8,
+            follow_playback: true,
+            control: SessionCommand {
+                lease_id: Some("standalone-metronome".into()),
+                operation_id: Some(operation_id.into()),
+                generation,
+                timeline_revision: revision,
+            },
+        }
+    }
+
+    #[test]
+    fn standalone_metronome_control_is_idempotent_and_rejects_stale_updates() {
+        let mut transport = TransportState::default();
+        let started = transport
+            .apply_standalone_metronome(&standalone_request(true, "start", None, None))
+            .unwrap();
+        let duplicate = transport
+            .apply_standalone_metronome(&standalone_request(
+                true,
+                "start",
+                Some(started.generation),
+                Some(started.revision),
+            ))
+            .unwrap();
+        assert_eq!(duplicate.revision, started.revision);
+        let updated = transport
+            .apply_standalone_metronome(&standalone_request(
+                true,
+                "update",
+                Some(started.generation),
+                Some(started.revision),
+            ))
+            .unwrap();
+        let duplicate_update = transport
+            .apply_standalone_metronome(&standalone_request(
+                true,
+                "update",
+                Some(started.generation),
+                Some(started.revision),
+            ))
+            .unwrap();
+        assert_eq!(duplicate_update.revision, updated.revision);
+        assert_eq!(
+            transport
+                .apply_standalone_metronome(&standalone_request(
+                    false,
+                    "stale",
+                    Some(started.generation + 1),
+                    Some(updated.revision),
+                ))
+                .unwrap_err(),
+            "stale_session_generation"
+        );
+        let stopped = transport
+            .apply_standalone_metronome(&standalone_request(
+                false,
+                "stop",
+                Some(started.generation),
+                Some(updated.revision),
+            ))
+            .unwrap();
+        assert!(!stopped.enabled);
+        assert!(stopped.revision > updated.revision);
+        let duplicate_stop = transport
+            .apply_standalone_metronome(&standalone_request(
+                false,
+                "stop",
+                Some(started.generation),
+                Some(updated.revision),
+            ))
+            .unwrap();
+        assert_eq!(duplicate_stop.revision, stopped.revision);
+        assert!(!duplicate_stop.enabled);
+    }
+
+    #[test]
+    #[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
+    fn standalone_enable_rolls_back_control_when_runtime_start_fails() {
+        let mut transport = TransportState::default();
+        transport.fail_next_runtime_start = true;
+        let request = standalone_request(true, "start", None, None);
+
+        assert_eq!(
+            transport
+                .set_standalone_metronome_inner(None, request.clone(), capabilities())
+                .unwrap_err(),
+            "injected_runtime_start_failure"
+        );
+        assert!(!transport.click.enabled);
+        assert_eq!(transport.standalone_metronome.generation, 0);
+        assert_eq!(transport.standalone_metronome.revision, 0);
+        assert!(transport.standalone_metronome.operations.is_empty());
+        assert!(transport.runtime.is_none());
+
+        let retried = transport
+            .set_standalone_metronome_inner(None, request, capabilities())
+            .expect("retry remains valid");
+        assert!(retried.enabled);
+        assert_eq!(retried.generation, 1);
+        assert_eq!(retried.revision, 1);
+    }
+
+    #[test]
+    #[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
+    fn standalone_enable_preserves_paused_project_generation() {
+        let mut transport = TransportState::default();
+        transport.session_id = Some("project-session".into());
+        transport.generation = 2;
+        transport.status = TransportStatus::Paused;
+
+        let standalone = transport
+            .set_standalone_metronome_inner(
+                None,
+                standalone_request(true, "start", None, None),
+                capabilities(),
+            )
+            .expect("enable metronome");
+
+        assert_eq!(transport.generation, 2);
+        assert_eq!(standalone.generation, 1);
+    }
+
+    #[test]
+    #[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
+    fn standalone_disable_rolls_back_control_when_release_fails() {
+        let mut transport = TransportState::default();
+        let started = transport
+            .set_standalone_metronome_inner(
+                None,
+                standalone_request(true, "start", None, None),
+                capabilities(),
+            )
+            .unwrap();
+        transport.install_test_auxiliary_runtime();
+        transport.fail_next_release = true;
+        let stop = standalone_request(
+            false,
+            "stop",
+            Some(started.generation),
+            Some(started.revision),
+        );
+
+        assert_eq!(
+            transport
+                .set_standalone_metronome_inner(None, stop.clone(), capabilities())
+                .unwrap_err(),
+            "release_timeout"
+        );
+        assert!(transport.click.enabled);
+        assert_eq!(transport.standalone_metronome.revision, started.revision);
+        assert!(!transport
+            .standalone_metronome
+            .operations
+            .contains_key(&("standalone-metronome".into(), "stop".into())));
+        let runtime = transport.runtime.as_ref().expect("runtime retained");
+        assert!(runtime.shared.lock().unwrap().click.enabled);
+
+        let stopped = transport
+            .set_standalone_metronome_inner(None, stop, capabilities())
+            .expect("same stop tuple remains valid");
+        assert!(!stopped.enabled);
+        assert!(transport.runtime.is_none());
+    }
+
+    #[test]
+    #[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
+    fn pause_and_stop_keep_enabled_standalone_runtime_free_running() {
+        let mut shared =
+            shared_with_lane(Arc::new(Mutex::new(RingBuffer::new(1_000))), 1_000, 1, 1.0);
+        shared.click.enabled = true;
+        shared.click.follow_transport = true;
+        let (runtime, exits) = stoppable_runtime(shared);
+        let shared = runtime.shared.clone();
+        let mut state = TransportState::default();
+        state.session_id = Some("session".into());
+        state.status = TransportStatus::Playing;
+        state.position_seconds = 2.0;
+        state.duration_seconds = 10.0;
+        state.native_playback_supported = true;
+        state.click = shared.lock().unwrap().click.clone();
+        state.runtime = Some(runtime);
+
+        assert_eq!(state.pause().state, "paused");
+        assert!(state.runtime.is_some());
+        {
+            let mut shared = shared.lock().unwrap();
+            assert_eq!(shared.status, TransportStatus::Paused);
+            render_shared_output(&mut shared, &mut [0.0; 8]);
+            assert_eq!(
+                shared.pending_cues.front().map(|cue| cue.source),
+                Some("standalone_metronome")
+            );
+        }
+
+        assert_eq!(state.stop().state, "stopped");
+        assert!(state.runtime.is_some());
+        assert_eq!(shared.lock().unwrap().status, TransportStatus::Stopped);
+        assert!(exits.iter().all(|receiver| receiver.try_recv().is_err()));
+    }
+
+    #[test]
+    #[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
+    fn reporter_keeps_output_alive_after_end_only_for_enabled_metronome() {
+        assert!(!should_stop_runtime_after_report(true, false, true));
+        assert!(should_stop_runtime_after_report(true, false, false));
+        assert!(should_stop_runtime_after_report(false, true, true));
+    }
+
+    #[test]
+    #[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
+    fn unavailable_playback_prepare_preserves_existing_standalone_runtime() {
+        let ring = Arc::new(Mutex::new(RingBuffer::new(1_000)));
+        let mut shared = shared_with_lane(ring, 1_000, 1, 1.0);
+        shared.click.enabled = true;
+        let (runtime, _exits) = stoppable_runtime(shared);
+        let retained_shared = runtime.shared.clone();
+        let click = runtime.shared.lock().unwrap().click.clone();
+        let mut state = TransportState::default();
+        state.click = click;
+        state.runtime = Some(runtime);
+
+        let session = state.prepare(
+            None,
+            AudioSessionRequest {
+                session_id: "unavailable-project".into(),
+                duration_seconds: Some(10.0),
+                playback_rate: Some(1.0),
+                lanes: Vec::new(),
+                control: SessionCommand::default(),
+                owner: None,
+            },
+            Vec::new(),
+            unsupported_capabilities("Project playback is unavailable."),
+        );
+
+        assert!(!session.native_playback_supported);
+        assert!(state.click.enabled);
+        let runtime = state.runtime.as_ref().expect("standalone runtime retained");
+        assert!(runtime.auxiliary_only);
+        assert!(Arc::ptr_eq(&runtime.shared, &retained_shared));
+    }
+
+    #[test]
+    fn callback_mixes_free_running_metronome_with_project_lane_and_emits_correlation() {
+        let ring = Arc::new(Mutex::new(RingBuffer::new(1_000)));
+        push_ring_samples(&ring, &[0.2; 64]);
+        let mut shared = shared_with_lane(ring, 1_000, 1, 1.0);
+        shared.click = ClickState {
+            enabled: true,
+            bpm: 120.0,
+            beats_per_bar: 4,
+            accent_first_beat: true,
+            gain: 0.8,
+            follow_transport: false,
+            generation: 3,
+            revision: 2,
+            free_run_frame: 0,
+            following_playback: false,
+            last_emitted_beat: None,
+        };
+        let mut output = vec![0.0; 32];
+
+        render_shared_output(&mut shared, &mut output);
+
+        assert!(output[0] > 0.2);
+        let cue = shared.pending_cues.front().unwrap();
+        assert_eq!(cue.resource, "output");
+        assert_eq!(cue.source, "standalone_metronome");
+        assert_eq!(cue.generation, 3);
+        assert_eq!(cue.revision, 2);
+    }
+
+    #[test]
+    fn following_metronome_returns_to_free_run_when_playback_pauses() {
+        let ring = Arc::new(Mutex::new(RingBuffer::new(1_000)));
+        push_ring_samples(&ring, &[0.2; 64]);
+        let mut shared = shared_with_lane(ring, 1_000, 1, 1.0);
+        shared.click.enabled = true;
+        shared.click.follow_transport = true;
+        shared.click.generation = 1;
+        shared.click.revision = 1;
+        let mut output = vec![0.0; 16];
+
+        render_shared_output(&mut shared, &mut output);
+        assert!(shared.pending_cues.is_empty());
+        shared.status = TransportStatus::Paused;
+        render_shared_output(&mut shared, &mut output);
+
+        assert_eq!(
+            shared.pending_cues.front().unwrap().source,
+            "standalone_metronome"
+        );
+        assert!(output.iter().any(|sample| sample.abs() > 0.0));
     }
 
     #[test]

--- a/apps/desktop/src/App.project-media-controls.test.tsx
+++ b/apps/desktop/src/App.project-media-controls.test.tsx
@@ -760,6 +760,8 @@ describe("Desktop app project media controls", () => {
     );
     act(() => {
       emitMockNativeAudioTerminal({
+        resource: "output",
+        source: "output_runtime",
         generation: 1,
         code: "output_stream_failure",
         nativeTimeUs: 10,

--- a/apps/desktop/src/App.project-precount.test.tsx
+++ b/apps/desktop/src/App.project-precount.test.tsx
@@ -1051,7 +1051,8 @@ describe("Desktop app project playback pre-count", () => {
     await user.click(screen.getByRole("button", { name: "Play playback" }));
     await waitFor(() => expect(readPlaybackE2ETelemetry().countIn.active).toBe(true));
     act(() => emitMockNativeAudioTerminal({
-      generation: 1, code: "output_stream_failure", nativeTimeUs: 3_000_000,
+      resource: "output", source: "output_runtime", generation: 1,
+      code: "output_stream_failure", nativeTimeUs: 3_000_000,
     }));
     expect(readPlaybackE2ETelemetry().countIn).toMatchObject({ active: false, lastCancelled: {
       reason: "unavailable", cancelledAtContextTimeSeconds: 3,

--- a/apps/desktop/src/App.tools-metronome.test.tsx
+++ b/apps/desktop/src/App.tools-metronome.test.tsx
@@ -89,7 +89,7 @@ describe("Desktop app tools metronome", () => {
     expect(screen.getByText("Seeded from project analysis.")).toBeInTheDocument();
     expect(screen.getByLabelText("Beats per bar")).toHaveValue(4);
     expect(screen.getByLabelText("Accent first beat")).toBeChecked();
-    expect(screen.getByLabelText("Follow project playback")).not.toBeChecked();
+    expect(screen.getByLabelText("Follow project playback")).toBeChecked();
   });
 
   it("arms follow mode from query params", async () => {
@@ -99,7 +99,26 @@ describe("Desktop app tools metronome", () => {
     expect(screen.getByLabelText("Tempo BPM")).toHaveValue(121.5);
     expect(screen.getByLabelText("Follow project playback")).toBeChecked();
     expect(screen.getByRole("button", { name: "Stop" })).toBeInTheDocument();
-    expect(screen.getByText("No project playback active")).toBeInTheDocument();
+    expect(screen.getAllByText("Free-running at 121.5 BPM").length).toBeGreaterThan(0);
+  });
+
+  it("describes idle follow and free-running modes truthfully", async () => {
+    const user = userEvent.setup();
+    renderApp(["/projects/proj_123"]);
+
+    expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
+    await user.click(screen.getByRole("link", { name: "Tools" }));
+    await user.click(await screen.findByRole("tab", { name: "Metronome" }));
+
+    expect(screen.getAllByText("Ready at 100.0 BPM").length).toBeGreaterThan(0);
+    await user.click(screen.getByRole("button", { name: "Start" }));
+    expect(screen.getAllByText(
+      "Free-running at 100.0 BPM · follows Demo Song when playback starts",
+    ).length).toBeGreaterThan(0);
+    await user.click(screen.getByLabelText("Follow project playback"));
+    expect(screen.getAllByText("Free-running at 100.0 BPM").length).toBeGreaterThan(0);
+    await user.click(screen.getByRole("button", { name: "Stop" }));
+    expect(screen.getAllByText("Ready at 100.0 BPM").length).toBeGreaterThan(0);
   });
 
   it("updates tempo from the tap pad", async () => {
@@ -194,9 +213,9 @@ describe("Desktop app tools metronome", () => {
 
     await user.click(screen.getByRole("link", { name: "Tools" }));
     await user.click(await screen.findByRole("tab", { name: "Metronome" }));
-    await user.click(screen.getByLabelText("Follow project playback"));
+    await user.click(screen.getByRole("button", { name: "Start" }));
     await waitFor(() => expect(screen.getByRole("button", { name: "Stop" })).toBeInTheDocument());
-    await waitFor(() => expect(screen.getAllByText("Following Demo Song").length).toBeGreaterThan(0));
+    await waitFor(() => expect(screen.getAllByText("Following Demo Song playback").length).toBeGreaterThan(0));
     act(() => {
       advanceMockAnimationFrames();
     });
@@ -209,23 +228,29 @@ describe("Desktop app tools metronome", () => {
 
     await user.click(screen.getByRole("button", { name: "Pause background playback" }));
     await waitFor(() =>
-      expect(screen.getAllByText("Waiting for Demo Song playback").length).toBeGreaterThan(0),
+      expect(screen.getAllByText(
+        "Free-running at 100.0 BPM · follows Demo Song when playback starts",
+      ).length).toBeGreaterThan(0),
     );
     act(() => {
       advanceMockAnimationFrames();
     });
     expect(syncedContext?.close).not.toHaveBeenCalled();
+    await waitFor(() =>
+      expect(syncedContext?.createdOscillators.length).toBeGreaterThan(scheduledBeforePause),
+    );
+    const scheduledDuringPause = syncedContext?.createdOscillators.length ?? 0;
 
     await user.click(screen.getByRole("button", { name: "Play background playback" }));
     await waitFor(() =>
       expect(screen.getByRole("button", { name: "Pause background playback" })).toBeInTheDocument(),
     );
-    await waitFor(() => expect(screen.getAllByText("Following Demo Song").length).toBeGreaterThan(0));
+    await waitFor(() => expect(screen.getAllByText("Following Demo Song playback").length).toBeGreaterThan(0));
     act(() => {
       advanceMockAnimationFrames();
     });
     await waitFor(() =>
-      expect(syncedContext?.createdOscillators.length).toBeGreaterThan(scheduledBeforePause),
+      expect(syncedContext?.createdOscillators.length).toBeGreaterThan(scheduledDuringPause),
     );
   });
 
@@ -247,9 +272,9 @@ describe("Desktop app tools metronome", () => {
     );
     await user.click(screen.getByRole("link", { name: "Tools" }));
     await user.click(await screen.findByRole("tab", { name: "Metronome" }));
-    await user.click(screen.getByLabelText("Follow project playback"));
+    await user.click(screen.getByRole("button", { name: "Start" }));
     await waitFor(() => expect(screen.getByRole("button", { name: "Stop" })).toBeInTheDocument());
-    await waitFor(() => expect(screen.getAllByText("Following Demo Song").length).toBeGreaterThan(0));
+    await waitFor(() => expect(screen.getAllByText("Following Demo Song playback").length).toBeGreaterThan(0));
     act(() => {
       advanceMockAnimationFrames();
     });
@@ -278,9 +303,8 @@ describe("Desktop app tools metronome", () => {
     await waitFor(() => expect(getMockInvoke().mock.calls.some(([name]) => name === "audio_play")).toBe(true));
     await user.click(screen.getByRole("link", { name: "Tools" }));
     await user.click(await screen.findByRole("tab", { name: "Metronome" }));
-    await user.click(screen.getByLabelText("Follow project playback"));
+    await user.click(screen.getByRole("button", { name: "Start" }));
     await waitFor(() => {
-      expect(getMockInvoke().mock.calls.some(([name]) => name === "audio_get_session_snapshot")).toBe(true);
       const call = getMockInvoke().mock.calls.find(([name]) => name === "audio_schedule_cues");
       const payload = (call?.[1] as { payload?: { cues?: unknown[] } })?.payload;
       expect(payload).toMatchObject({
@@ -347,6 +371,92 @@ describe("Desktop app tools metronome", () => {
     delete (window as Window & { __TAURI_INTERNALS__?: unknown }).__TAURI_INTERNALS__;
   });
 
+  it("serializes rapid native settings and stop using the latest revision", async () => {
+    (window as Window & { __TAURI_INTERNALS__?: unknown }).__TAURI_INTERNALS__ = {};
+    setMockNativeAudioState({ capabilities: {
+      nativePlaybackSupported: true, fallbackRequired: false,
+      fallbackReason: null, backend: "desktop-cpal",
+    } });
+    const firstStart = createDeferred<{
+      enabled: boolean; bpm: number; beatsPerBar: number; accentFirstBeat: boolean;
+      gain: number; followPlayback: boolean; leaseId: string; generation: number;
+      revision: number; nativeTimeUs: number;
+    }>();
+    const invoke = getMockInvoke();
+    const originalInvoke = invoke.getMockImplementation()!;
+    let standaloneInvocationCount = 0;
+    invoke.mockImplementation(async (command, args) => {
+      if (command === "audio_set_standalone_metronome" && standaloneInvocationCount++ === 0) {
+        return firstStart.promise;
+      }
+      return originalInvoke(command, args);
+    });
+    const user = userEvent.setup();
+    renderApp(["/tools?tool=metronome"]);
+    await screen.findByRole("heading", { name: "Metronome" });
+
+    await user.click(screen.getByRole("button", { name: "Start" }));
+    await waitFor(() => expect(standaloneInvocationCount).toBe(1));
+    fireEvent.change(screen.getByLabelText("Tempo BPM"), { target: { value: "140" } });
+    await user.click(screen.getByRole("button", { name: "Stop" }));
+    expect(standaloneInvocationCount).toBe(1);
+
+    await act(async () => firstStart.resolve({
+      enabled: true, bpm: 100, beatsPerBar: 4, accentFirstBeat: true,
+      gain: 0.8, followPlayback: true, leaseId: "standalone-metronome",
+      generation: 1, revision: 1, nativeTimeUs: 1,
+    }));
+    await waitFor(() => expect(standaloneInvocationCount).toBe(2));
+    const standaloneCalls = invoke.mock.calls.filter(
+      ([command]) => command === "audio_set_standalone_metronome",
+    );
+    expect(standaloneCalls).toHaveLength(2);
+    expect(standaloneCalls[1]?.[1]).toMatchObject({ payload: {
+      enabled: false,
+      bpm: 140,
+      generation: 1,
+      timelineRevision: 1,
+    } });
+    await waitFor(() => expect(screen.getByRole("button", { name: "Start" })).toBeInTheDocument());
+    delete (window as Window & { __TAURI_INTERNALS__?: unknown }).__TAURI_INTERNALS__;
+  });
+
+  it("reconciles a failed native settings update by stopping the active metronome", async () => {
+    (window as Window & { __TAURI_INTERNALS__?: unknown }).__TAURI_INTERNALS__ = {};
+    setMockNativeAudioState({ capabilities: {
+      nativePlaybackSupported: true, fallbackRequired: false,
+      fallbackReason: null, backend: "desktop-cpal",
+    } });
+    const invoke = getMockInvoke();
+    const originalInvoke = invoke.getMockImplementation()!;
+    const user = userEvent.setup();
+    renderApp(["/tools?tool=metronome"]);
+    await screen.findByRole("heading", { name: "Metronome" });
+    await user.click(screen.getByRole("button", { name: "Start" }));
+    await waitFor(() => expect(invoke.mock.calls.filter(
+      ([command]) => command === "audio_set_standalone_metronome",
+    ).length).toBeGreaterThanOrEqual(2));
+
+    let rejectNextUpdate = true;
+    invoke.mockImplementation(async (command, args) => {
+      const enabled = (args as { payload?: { enabled?: boolean } } | undefined)?.payload?.enabled;
+      if (command === "audio_set_standalone_metronome" && enabled && rejectNextUpdate) {
+        rejectNextUpdate = false;
+        throw new Error("stale_timeline_revision");
+      }
+      return originalInvoke(command, args);
+    });
+    fireEvent.change(screen.getByLabelText("Metronome volume"), { target: { value: "0.5" } });
+
+    await waitFor(() => expect(screen.getByRole("button", { name: "Start" })).toBeInTheDocument());
+    const lastStandaloneCall = [...invoke.mock.calls].reverse().find(
+      ([command]) => command === "audio_set_standalone_metronome",
+    );
+    expect(lastStandaloneCall?.[1]).toMatchObject({ payload: { enabled: false } });
+    expect(screen.getByText(/stopping it safely/)).toBeInTheDocument();
+    delete (window as Window & { __TAURI_INTERNALS__?: unknown }).__TAURI_INTERNALS__;
+  });
+
   it("replaces followed cues from the authoritative completed native seek position", async () => {
     (window as Window & { __TAURI_INTERNALS__?: unknown }).__TAURI_INTERNALS__ = {};
     setMockNativeAudioState({ capabilities: {
@@ -361,7 +471,7 @@ describe("Desktop app tools metronome", () => {
     await user.click(screen.getByRole("button", { name: "Play playback" }));
     await user.click(screen.getByRole("link", { name: "Tools" }));
     await user.click(await screen.findByRole("tab", { name: "Metronome" }));
-    await user.click(screen.getByLabelText("Follow project playback"));
+    await user.click(screen.getByRole("button", { name: "Start" }));
     await waitFor(() => expect(getMockInvoke().mock.calls.some(([name]) => name === "audio_schedule_cues")).toBe(true));
     await user.click(screen.getByRole("link", { name: "Open Demo Song project" }));
     await user.click(screen.getByRole("tab", { name: "Playback" }));
@@ -408,7 +518,7 @@ describe("Desktop app tools metronome", () => {
     await user.click(screen.getByRole("button", { name: "Play playback" }));
     await user.click(screen.getByRole("link", { name: "Tools" }));
     await user.click(await screen.findByRole("tab", { name: "Metronome" }));
-    await user.click(screen.getByLabelText("Follow project playback"));
+    await user.click(screen.getByRole("button", { name: "Start" }));
     await waitFor(() => expect(getMockInvoke().mock.calls.some(([name]) => name === "audio_schedule_cues")).toBe(true));
     await user.click(screen.getByRole("link", { name: "Open Demo Song project" }));
     await user.click(screen.getByRole("tab", { name: "Playback" }));
@@ -433,7 +543,7 @@ describe("Desktop app tools metronome", () => {
     delete (window as Window & { __TAURI_INTERNALS__?: unknown }).__TAURI_INTERNALS__;
   });
 
-  it("ignores stale follow scheduling and cleanup snapshots across reactivation", async () => {
+  it("serializes followed cue updates behind an in-flight native seek", async () => {
     (window as Window & { __TAURI_INTERNALS__?: unknown }).__TAURI_INTERNALS__ = {};
     setMockNativeAudioState({ capabilities: {
       nativePlaybackSupported: true, fallbackRequired: false,
@@ -445,45 +555,56 @@ describe("Desktop app tools metronome", () => {
     await screen.findByRole("heading", { name: "Demo Song" });
     await user.click(screen.getByRole("tab", { name: "Playback" }));
     await user.click(screen.getByRole("button", { name: "Play playback" }));
-    await user.click(screen.getByRole("link", { name: "Tools" }));
-    await user.click(await screen.findByRole("tab", { name: "Metronome" }));
+    await waitFor(() => expect(getMockInvoke().mock.calls.some(([name]) => name === "audio_play")).toBe(true));
 
-    const snapshot = {
-      status: "output" as const, owner: "playback" as const, leaseId: "project-playback",
-      generation: 1, timelineRevision: 1, nativeTimeUs: 1, positionSeconds: 0,
-      playbackRate: 1, availabilityReason: null, terminalDiagnostic: null,
+    const preparedSessionId = latestNativeSessionId();
+    const seek = createDeferred<{
+      sessionId: string;
+      state: "playing";
+      positionSeconds: number;
+      durationSeconds: number;
+      playbackRate: number;
+      nativePlaybackSupported: boolean;
+      fallbackReason: null;
+      lanes: never[];
+      bufferHealth: never[];
+      leaseId: string;
+      generation: number;
+      timelineRevision: number;
+      nativeTimeUs: number;
+    }>();
+    const sessionSnapshot = {
+      resource: "output" as const, source: "project_playback" as const,
+      status: "output" as const, owner: "playback" as const,
+      leaseId: "project-playback", generation: 1, timelineRevision: 2,
+      nativeTimeUs: 1, positionSeconds: 0.48, playbackRate: 1,
+      availabilityReason: null, terminalDiagnostic: null,
     };
-    const staleSchedule = createDeferred<typeof snapshot>();
-    const staleCleanup = createDeferred<typeof snapshot>();
-    const currentSchedule = createDeferred<typeof snapshot>();
-    const snapshotPromises = [staleSchedule.promise, staleCleanup.promise, currentSchedule.promise];
-    let snapshotCallCount = 0;
     const invoke = getMockInvoke();
     const originalInvoke = invoke.getMockImplementation();
     invoke.mockImplementation(async (command, args) => {
-      if (command === "audio_get_session_snapshot" && snapshotCallCount < snapshotPromises.length) {
-        return snapshotPromises[snapshotCallCount++];
-      }
+      if (command === "audio_seek") return seek.promise;
+      if (command === "audio_schedule_cues" || command === "audio_cancel_cues") return sessionSnapshot;
       return originalInvoke!(command, args);
     });
 
-    await user.click(screen.getByLabelText("Follow project playback"));
-    await waitFor(() => expect(snapshotCallCount).toBe(1));
-    await user.click(screen.getByLabelText("Follow project playback"));
-    await waitFor(() => expect(snapshotCallCount).toBe(2));
-    await act(async () => { staleSchedule.resolve(snapshot); });
+    fireEvent.change(screen.getByLabelText("Playback position"), { target: { value: "0.2" } });
+    await waitFor(() => expect(invoke.mock.calls.filter(([name]) => name === "audio_seek")).toHaveLength(1));
+    await user.click(screen.getByRole("link", { name: "Tools" }));
+    await user.click(await screen.findByRole("tab", { name: "Metronome" }));
+    await user.click(screen.getByRole("button", { name: "Start" }));
     expect(invoke.mock.calls.filter(([name]) => name === "audio_schedule_cues")).toHaveLength(0);
 
-    await user.click(screen.getByLabelText("Follow project playback"));
-    await waitFor(() => expect(snapshotCallCount).toBe(3));
-    await act(async () => { currentSchedule.resolve(snapshot); });
-    await waitFor(() => expect(invoke.mock.calls.filter(([name]) => name === "audio_schedule_cues")).toHaveLength(1));
-    await act(async () => { staleCleanup.resolve(snapshot); });
-    expect(invoke.mock.calls.filter(([name]) => name === "audio_cancel_cues")).toHaveLength(0);
-
-    invoke.mockImplementation(originalInvoke!);
-    await user.click(screen.getByLabelText("Follow project playback"));
-    await waitFor(() => expect(invoke.mock.calls.filter(([name]) => name === "audio_cancel_cues")).toHaveLength(1));
+    await act(async () => seek.resolve({
+      sessionId: preparedSessionId, state: "playing", positionSeconds: 0.48,
+      durationSeconds: 182, playbackRate: 1, nativePlaybackSupported: true,
+      fallbackReason: null, lanes: [], bufferHealth: [], leaseId: "project-playback",
+      generation: 1, timelineRevision: 2, nativeTimeUs: 10,
+    }));
+    await waitFor(() => expect(invoke.mock.calls.some(([name]) => name === "audio_schedule_cues")).toBe(true));
+    for (const call of invoke.mock.calls.filter(([name]) => name === "audio_schedule_cues")) {
+      expect(call[1]).toMatchObject({ payload: { timelineRevision: 2 } });
+    }
     delete (window as Window & { __TAURI_INTERNALS__?: unknown }).__TAURI_INTERNALS__;
   });
 
@@ -505,9 +626,9 @@ describe("Desktop app tools metronome", () => {
 
     await user.click(screen.getByRole("link", { name: "Tools" }));
     await user.click(await screen.findByRole("tab", { name: "Metronome" }));
-    await user.click(screen.getByLabelText("Follow project playback"));
+    await user.click(screen.getByRole("button", { name: "Start" }));
     await waitFor(() => expect(screen.getByRole("button", { name: "Stop" })).toBeInTheDocument());
-    await waitFor(() => expect(screen.getAllByText("Following Demo Song").length).toBeGreaterThan(0));
+    await waitFor(() => expect(screen.getAllByText("Following Demo Song playback").length).toBeGreaterThan(0));
     act(() => {
       advanceMockAnimationFrames();
     });

--- a/apps/desktop/src/App.tools-tuner.test.tsx
+++ b/apps/desktop/src/App.tools-tuner.test.tsx
@@ -1,7 +1,9 @@
 import { act, fireEvent, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { readPlaybackLiveDiagnostics } from "./lib/playbackDiagnostics";
 import {
+  emitMockNativeAudioTerminal,
   emitMockNativeInputFrame,
   emitMockNativeInputState,
   getMockAudioContexts,
@@ -270,6 +272,7 @@ describe("Desktop app tools tuner", () => {
 
   it("acquires Web tuner protection only after capture is listening and releases on stop", async () => {
     const user = userEvent.setup();
+    vi.stubEnv("VITE_TUNEFORGE_FORCE_WEB_AUDIO", "1");
     const endingStream = makeEndingMediaStream();
     let resolveCapture: (stream: MediaStream) => void = () => undefined;
     getMockMediaDevices().getUserMedia.mockImplementationOnce(
@@ -340,6 +343,7 @@ describe("Desktop app tools tuner", () => {
 
   it("uses native microphone capture when available", async () => {
     const user = userEvent.setup();
+    mockTauriRuntime();
     setMockNativeAudioState({
       capabilities: {
         micCaptureSupported: true,
@@ -363,7 +367,11 @@ describe("Desktop app tools tuner", () => {
 
     await waitFor(() =>
       expect(getMockInvoke()).toHaveBeenCalledWith("audio_start_input", {
-        payload: { deviceId: "cpal:1:usb" },
+        payload: expect.objectContaining({
+          deviceId: "cpal:1:usb",
+          leaseId: "tuner-capture",
+          operationId: expect.stringMatching(/^tuner-capture-/),
+        }),
       }),
     );
     expect(window.localStorage.getItem("tuneforge.tuner-input-capture-backend")).toContain(
@@ -400,7 +408,12 @@ describe("Desktop app tools tuner", () => {
 
     await user.click(screen.getByRole("button", { name: "Stop" }));
 
-    expect(getMockInvoke()).toHaveBeenCalledWith("audio_stop_input");
+    expect(getMockInvoke()).toHaveBeenCalledWith("audio_stop_input", {
+      payload: expect.objectContaining({
+        leaseId: "tuner-capture",
+        operationId: expect.stringMatching(/^tuner-capture-/),
+      }),
+    });
     act(() => {
       emitMockNativeInputFrame({
         deviceId: "cpal:1:usb",
@@ -428,8 +441,58 @@ describe("Desktop app tools tuner", () => {
     expect(screen.getByRole("meter", { name: "Input signal level" })).toHaveAttribute("aria-valuenow", "0");
   });
 
+  it("keeps native project playback owned when tuner capture terminates", async () => {
+    const user = userEvent.setup();
+    mockTauriRuntime();
+    setMockNativeAudioState({
+      capabilities: {
+        nativePlaybackSupported: true,
+        micCaptureSupported: true,
+        fallbackRequired: false,
+        fallbackReason: null,
+        backend: "desktop-cpal",
+      },
+    });
+    renderApp(["/projects/proj_123"]);
+
+    expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
+    await user.click(screen.getByRole("tab", { name: "Playback" }));
+    await user.click(screen.getByRole("button", { name: "Play playback" }));
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: "Pause playback" })).toBeInTheDocument(),
+    );
+    await user.click(screen.getByRole("link", { name: "Tools" }));
+    await user.click(await screen.findByRole("button", { name: "Start" }));
+    await waitFor(() =>
+      expect(getMockInvoke().mock.calls.some(([command]) => command === "audio_start_input")).toBe(true),
+    );
+    const outputStopCount = getMockInvoke().mock.calls.filter(
+      ([command]) => command === "audio_stop",
+    ).length;
+
+    act(() => emitMockNativeAudioTerminal({
+      resource: "capture",
+      source: "tuner_capture",
+      generation: 1,
+      code: "capture_stream_failure",
+      nativeTimeUs: 10,
+    }));
+
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: "Pause background playback" })).toBeInTheDocument(),
+    );
+    expect(getMockInvoke().mock.calls.filter(([command]) => command === "audio_stop")).toHaveLength(
+      outputStopCount,
+    );
+    expect(readPlaybackLiveDiagnostics()).toMatchObject({
+      currentState: "playing",
+      currentPath: "native",
+    });
+  });
+
   it("stops native capture when the tuner unmounts", async () => {
     const user = userEvent.setup();
+    mockTauriRuntime();
     setMockNativeAudioState({ capabilities: { micCaptureSupported: true, backend: "desktop-cpal" } });
     renderApp(["/tools"]);
 
@@ -437,7 +500,10 @@ describe("Desktop app tools tuner", () => {
     await waitFor(() => expect(screen.getByRole("button", { name: "Stop" })).toBeInTheDocument());
     await user.click(screen.getByRole("tab", { name: "Metronome" }));
 
-    await waitFor(() => expect(getMockInvoke()).toHaveBeenCalledWith("audio_stop_input"));
+    await waitFor(() => expect(getMockInvoke()).toHaveBeenCalledWith(
+      "audio_stop_input",
+      { payload: expect.objectContaining({ leaseId: "tuner-capture" }) },
+    ));
   });
 
   it("does not query native microphone devices while the tuner is idle until the picker is opened", async () => {
@@ -585,8 +651,9 @@ describe("Desktop app tools tuner", () => {
     expect(screen.getByRole("button", { name: "Stop" })).toBeEnabled();
   });
 
-  it("falls back to Web Audio when native capture fails", async () => {
+  it("does not fall back to Web Audio when normal Tauri native capture fails", async () => {
     const user = userEvent.setup();
+    mockTauriRuntime();
     getMockMediaDevices().revealLabels();
     setMockNativeAudioState({
       capabilities: {
@@ -605,24 +672,14 @@ describe("Desktop app tools tuner", () => {
     expect(await screen.findByRole("heading", { name: "Tools" })).toBeInTheDocument();
     await user.click(screen.getByRole("button", { name: "Start" }));
 
-    await waitFor(() =>
-      expect(getMockMediaDevices().getUserMedia).toHaveBeenCalledWith({
-        audio: {
-          autoGainControl: false,
-          echoCancellation: false,
-          noiseSuppression: false,
-        },
-        video: false,
-      }),
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      "Native microphone capture could not start",
     );
-    expect(screen.queryByText("Native microphone failed.")).not.toBeInTheDocument();
+    expect(getMockMediaDevices().getUserMedia).not.toHaveBeenCalled();
     expect(window.localStorage.getItem("tuneforge.tuner-native-capture-error")).toBe(
-      "Native microphone failed.",
+      "Native microphone capture could not start. Check the microphone and choose Retry.",
     );
-    expect(window.localStorage.getItem("tuneforge.tuner-input-capture-backend")).toContain(
-      '"web"',
-    );
-    expect(screen.getByRole("button", { name: "Stop" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Retry" })).toBeInTheDocument();
   });
 
   it("never falls back to Web Audio when packaged Android native capture fails", async () => {
@@ -678,7 +735,11 @@ describe("Desktop app tools tuner", () => {
 
     await waitFor(() =>
       expect(mockInvoke).toHaveBeenCalledWith("audio_start_input", {
-        payload: { deviceId: null },
+        payload: expect.objectContaining({
+          deviceId: null,
+          leaseId: "tuner-capture",
+          operationId: expect.stringMatching(/^tuner-capture-/),
+        }),
       }),
     );
     expect(mockInvoke).toHaveBeenCalledWith("audio_request_input_permission");
@@ -821,7 +882,7 @@ describe("Desktop app tools tuner", () => {
     expect(screen.getByLabelText("Microphone source")).toHaveValue("");
     expect(screen.queryByRole("option", { name: "Built-in Microphone" })).not.toBeInTheDocument();
     expect(window.localStorage.getItem("tuneforge.tuner-native-capture-error")).toBe(
-      "Native microphone failed.",
+      "Selected microphone requires native input capture, but native capture is unavailable.",
     );
     expect(window.localStorage.getItem("tuneforge.tuner-input-capture-backend")).toContain(
       '"web"',

--- a/apps/desktop/src/features/projects/playback-context.ts
+++ b/apps/desktop/src/features/projects/playback-context.ts
@@ -46,10 +46,10 @@ export type PlaybackContextValue = {
   primeWebAudioForGesture: () => Promise<void>;
   getPlaybackSnapshot: () => PlaybackSnapshot;
   registerProjectSession: (session: ProjectPlaybackSession) => void;
-  updateActiveLoopRange?: (range: PlaybackLoopRange | null) => void;
   updateFollowedMetronomeCues?: (
     cues: NativeAudioCue[],
   ) => Promise<NativeAudioSessionSnapshot | null>;
+  updateActiveLoopRange?: (range: PlaybackLoopRange | null) => void;
   togglePlayback: () => Promise<void>;
   playPlayback: () => Promise<void>;
   pausePlayback: () => void;

--- a/apps/desktop/src/features/projects/playback.tsx
+++ b/apps/desktop/src/features/projects/playback.tsx
@@ -815,6 +815,7 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
         }
         if (
           !nativeOutputMutationOwnerIsCurrent(tag) ||
+          snapshot.resource !== "output" ||
           snapshot.leaseId !== "project-playback" ||
           snapshot.generation !== tag.generation ||
           snapshot.timelineRevision <
@@ -4009,6 +4010,7 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
         const activeSession = sessionRef.current;
         if (
           !activeSession ||
+          terminal.resource !== "output" ||
           terminal.generation !== nativePlaybackRef.current.generation ||
           nativeSessionSignature(activeSession) !== nativePlaybackRef.current.sessionSignature
         ) return;

--- a/apps/desktop/src/features/tools/ToolsView.tsx
+++ b/apps/desktop/src/features/tools/ToolsView.tsx
@@ -3,7 +3,6 @@ import { useSearchParams } from "react-router-dom";
 import {
   getNativeAudioCapabilities,
   getNativeAudioInputPermissionStatus,
-  getNativeAudioInputState,
   isAndroidRuntime,
   isWebAudioBackendForced,
   listenNativeAudioInputFrames,
@@ -14,6 +13,7 @@ import {
   type NativeAudioCapabilities,
   type NativeAudioInputFrame,
   type NativeAudioInputState,
+  type NativeAudioSessionControl,
 } from "../../lib/nativeAudio";
 import { useStableCallback } from "../../lib/useStableCallback";
 import {
@@ -156,6 +156,8 @@ function ChromaticTunerPage() {
   const mediaSourceRef = useRef<MediaStreamAudioSourceNode | null>(null);
   const nativeCaptureActiveRef = useRef(false);
   const nativeCaptureGenerationRef = useRef<number | null>(null);
+  const nativeCaptureControlRef = useRef<NativeAudioSessionControl | null>(null);
+  const nativeCaptureOperationRef = useRef(0);
   const nativeInputUnlistenRef = useRef<(() => void) | null>(null);
   const nativeStateUnlistenRef = useRef<(() => void) | null>(null);
   const referenceHzRef = useRef(defaultTunerReferenceHz);
@@ -228,7 +230,13 @@ function ChromaticTunerPage() {
     nativeCaptureGenerationRef.current = null;
     if (nativeCaptureActiveRef.current) {
       nativeCaptureActiveRef.current = false;
-      void stopNativeAudioInput().catch(() => undefined);
+      const control = nativeCaptureControlRef.current;
+      nativeCaptureControlRef.current = null;
+      void stopNativeAudioInput({
+        leaseId: control?.leaseId ?? "tuner-capture",
+        generation: control?.generation,
+        operationId: `tuner-capture-${++nativeCaptureOperationRef.current}`,
+      }).catch(() => undefined);
     }
 
     try {
@@ -384,22 +392,16 @@ function ChromaticTunerPage() {
         throw new Error(captureSafeErrorMessage(permission.error));
       }
     }
-    let inputState = await startNativeAudioInput({ deviceId });
+    const inputState = await startNativeAudioInput({
+      deviceId,
+      leaseId: "tuner-capture",
+      operationId: `tuner-capture-${++nativeCaptureOperationRef.current}`,
+    });
     nativeCaptureGenerationRef.current = inputState.captureGeneration;
-    while (
-      requestIdRef.current === requestId &&
-      !inputState.active &&
-      !inputState.error &&
-      (inputState.permissionState === "prompt" || inputState.permissionState === "prompting")
-    ) {
-      await waitForPermissionPoll();
-      inputState = await getNativeAudioInputState();
-      nativeCaptureGenerationRef.current = inputState.captureGeneration;
-      if (inputState.permissionState === "granted" && !inputState.active) {
-        inputState = await startNativeAudioInput({ deviceId });
-        nativeCaptureGenerationRef.current = inputState.captureGeneration;
-      }
-    }
+    nativeCaptureControlRef.current = {
+      leaseId: inputState.leaseId ?? "tuner-capture",
+      generation: inputState.generation,
+    };
     nativeCaptureActiveRef.current = inputState.active;
     if (requestIdRef.current !== requestId) {
       releaseCapture();
@@ -497,8 +499,18 @@ function ChromaticTunerPage() {
     const nativeCapabilities = await resolveNativeAudioCapabilities();
     const androidNativeRequired =
       isAndroidRuntime() || nativeCapabilities?.platform === "android";
+    const tauriNativeRequired = isTauriRuntime() && !webAudioForced;
+    const nativeRequired = tauriNativeRequired || androidNativeRequired;
 
-    if (!webAudioForced && nativeCapabilities?.micCaptureSupported) {
+    if (nativeRequired && !nativeCapabilities?.micCaptureSupported) {
+      const message = "Native microphone capture is unavailable. Check microphone access and retry.";
+      rememberTunerNativeCaptureError(message);
+      setStatus("error");
+      setErrorMessage(message);
+      return;
+    }
+
+    if (nativeRequired && nativeCapabilities?.micCaptureSupported) {
       try {
         await startNativeTuner(
           selectedDeviceId,
@@ -508,14 +520,15 @@ function ChromaticTunerPage() {
         );
         return;
       } catch (error) {
-        rememberTunerNativeCaptureError(captureErrorMessage(error));
+        const message = nativeCaptureErrorMessage(error);
+        rememberTunerNativeCaptureError(message);
         if (requestIdRef.current !== requestId) {
           return;
         }
         releaseCapture();
-        if (androidNativeRequired) {
+        if (tauriNativeRequired || androidNativeRequired) {
           setStatus("error");
-          setErrorMessage(captureErrorMessage(error));
+          setErrorMessage(message);
           return;
         }
       }
@@ -639,6 +652,7 @@ function ChromaticTunerPage() {
 
         <TunerPreferenceControls
           className="tuner-preferences--with-mode"
+          clearDevicesWhenSystemDefaultOnly={isTauriRuntime() || androidRuntime}
           inputDeviceId={defaultTunerInputDeviceId}
           nativeCaptureDisabled={webAudioForced}
           onInputDeviceChange={handleInputDeviceChange}
@@ -956,6 +970,24 @@ function captureErrorMessage(error: unknown) {
     }
   }
   return error instanceof Error ? error.message : "Could not start microphone capture.";
+}
+
+function nativeCaptureErrorMessage(error: unknown) {
+  const message = captureErrorMessage(error);
+  if (message.includes("Android Settings")) {
+    return message;
+  }
+  if (/permission|privacy/i.test(message)) {
+    return "Microphone access is blocked. Allow access in system settings, then choose Retry.";
+  }
+  if (/device|unavailable/i.test(message)) {
+    return "The selected microphone is unavailable. Choose another microphone, then retry.";
+  }
+  return "Native microphone capture could not start. Check the microphone and choose Retry.";
+}
+
+function isTauriRuntime() {
+  return typeof window !== "undefined" && "__TAURI_INTERNALS__" in window;
 }
 
 function captureStateErrorMessage(inputState: NativeAudioInputState) {

--- a/apps/desktop/src/features/tools/TunerPreferenceControls.tsx
+++ b/apps/desktop/src/features/tools/TunerPreferenceControls.tsx
@@ -20,6 +20,7 @@ import {
 type TunerPreferenceControlsProps = {
   children?: ReactNode;
   className?: string;
+  clearDevicesWhenSystemDefaultOnly?: boolean;
   inputDeviceId: string | null;
   nativeCaptureDisabled?: boolean;
   onInputDeviceChange: (value: string | null) => void;
@@ -36,6 +37,7 @@ type TunerPreferenceControlsProps = {
 export function TunerPreferenceControls({
   children,
   className,
+  clearDevicesWhenSystemDefaultOnly = false,
   inputDeviceId,
   nativeCaptureDisabled = false,
   onInputDeviceChange,
@@ -86,11 +88,15 @@ export function TunerPreferenceControls({
 
   useEffect(() => {
     if (systemDefaultOnly) {
-      setDevices([]);
+      setDevices((currentDevices) =>
+        clearDevicesWhenSystemDefaultOnly
+          ? []
+          : currentDevices.filter((device) => !device.deviceId.startsWith("cpal:")),
+      );
       setDeviceError(null);
       refreshRequestIdRef.current += 1;
     }
-  }, [systemDefaultOnly]);
+  }, [clearDevicesWhenSystemDefaultOnly, systemDefaultOnly]);
 
   const refreshDevices = useCallback(({ queueIfBusy = false } = {}) => {
     if (systemDefaultOnly) {

--- a/apps/desktop/src/features/tools/metronome.tsx
+++ b/apps/desktop/src/features/tools/metronome.tsx
@@ -1,12 +1,13 @@
 import { useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import {
-  getNativeAudioSessionSnapshot,
   isWebAudioBackendForced,
   listenNativeAudioCues,
   listenNativeAudioSessions,
   listenNativeAudioTerminal,
   nativePlayCueProvider,
+  setNativeStandaloneMetronome,
   type NativeAudioSessionSnapshot,
+  type NativeStandaloneMetronomeState,
 } from "../../lib/nativeAudio";
 import { useStableCallback } from "../../lib/useStableCallback";
 import { nextTimedBeatIndex, type AnalysisTimingBeat } from "../../lib/timingGrid";
@@ -35,6 +36,12 @@ const SCHEDULE_AHEAD_SECONDS = 0.12;
 const SCHEDULER_INTERVAL_MS = 25;
 const START_DELAY_SECONDS = 0.035;
 
+type NativeMetronomeCommand = {
+  enabled: boolean;
+  epoch: number;
+  lifecycle: number;
+};
+
 export function MetronomeProvider({ children }: { children: ReactNode }) {
   const {
     getPlaybackSnapshot,
@@ -46,7 +53,7 @@ export function MetronomeProvider({ children }: { children: ReactNode }) {
   const [bpmDraft, setBpmDraft] = useState(() => normalizeMetronomeBpm(null).toString());
   const [beatsPerBar, setBeatsPerBar] = useState(DEFAULT_BEATS_PER_BAR);
   const [accentFirstBeat, setAccentFirstBeat] = useState(true);
-  const [followPlayback, setFollowPlayback] = useState(false);
+  const [followPlayback, setFollowPlayback] = useState(true);
   const [volume, setVolumeState] = useState(DEFAULT_METRONOME_VOLUME);
   const [isRunning, setIsRunning] = useState(false);
   const [activeBeat, setActiveBeat] = useState<number | null>(null);
@@ -64,6 +71,11 @@ export function MetronomeProvider({ children }: { children: ReactNode }) {
   const lastSyncedScheduledBeatRef = useRef<number | null>(null);
   const [nativeSession, setNativeSession] = useState<NativeAudioSessionSnapshot | null>(null);
   const nativeActivationEpochRef = useRef(0);
+  const nativeStandaloneRef = useRef<NativeStandaloneMetronomeState | null>(null);
+  const nativeStandaloneCommandEpochRef = useRef(0);
+  const nativeStandaloneCommandQueueRef = useRef<Promise<void>>(Promise.resolve());
+  const nativeStandaloneLifecycleRef = useRef(0);
+  const nativeStandaloneOperationRef = useRef(0);
   const nextFreeRunBeatIndexRef = useRef(0);
   const schedulerIntervalRef = useRef<number | null>(null);
   const tapTempoStateRef = useRef<TapTempoState>(createTapTempoState());
@@ -116,12 +128,6 @@ export function MetronomeProvider({ children }: { children: ReactNode }) {
     if (audioContext && audioContext.state !== "closed") {
       void audioContext.close().catch(() => undefined);
     }
-  });
-
-  const pauseSyncedClock = useStableCallback(function pauseSyncedClock() {
-    clearScheduler();
-    lastSyncedPlaybackTimeRef.current = null;
-    lastSyncedScheduledBeatRef.current = null;
   });
 
   const ensureAudioContext = useStableCallback(function ensureAudioContext() {
@@ -269,14 +275,61 @@ export function MetronomeProvider({ children }: { children: ReactNode }) {
 
   const seedBpm = useStableCallback(function seedBpm(value: unknown) {
     const nextBpm = normalizeMetronomeBpm(value);
+    bpmRef.current = nextBpm;
     setBpm(nextBpm);
     setBpmDraft(nextBpm.toString());
   });
 
+  const enqueueNativeMetronomeCommand = useStableCallback(function enqueueNativeMetronomeCommand(
+    command: NativeMetronomeCommand,
+  ) {
+    const execute = async () => {
+      if (
+        command.lifecycle !== nativeStandaloneLifecycleRef.current ||
+        command.epoch !== nativeStandaloneCommandEpochRef.current
+      ) {
+        return null;
+      }
+      const current = nativeStandaloneRef.current;
+      if (!command.enabled && !current) {
+        return null;
+      }
+      const next = await setNativeStandaloneMetronome({
+        enabled: command.enabled,
+        bpm: bpmRef.current,
+        beatsPerBar: beatsPerBarRef.current,
+        accentFirstBeat: accentFirstBeatRef.current,
+        gain: volumeRef.current,
+        followPlayback: followPlaybackRef.current,
+        leaseId: current?.leaseId ?? "standalone-metronome",
+        operationId: `standalone-metronome-${++nativeStandaloneOperationRef.current}`,
+        generation: current?.generation,
+        timelineRevision: current?.revision,
+      });
+      if (command.lifecycle === nativeStandaloneLifecycleRef.current) {
+        nativeStandaloneRef.current = next;
+      }
+      return next;
+    };
+    const result = nativeStandaloneCommandQueueRef.current.then(execute, execute);
+    nativeStandaloneCommandQueueRef.current = result.then(() => undefined, () => undefined);
+    return result;
+  });
+
   const startMetronome = useStableCallback(async function startMetronome() {
     setErrorMessage(null);
-    if (followPlaybackRef.current && isTauriRuntime() && !isWebAudioBackendForced()) {
+    if (isTauriRuntime() && !isWebAudioBackendForced()) {
+      const epoch = ++nativeStandaloneCommandEpochRef.current;
+      const lifecycle = nativeStandaloneLifecycleRef.current;
       setIsRunning(true);
+      try {
+        await enqueueNativeMetronomeCommand({ enabled: true, epoch, lifecycle });
+      } catch {
+        if (epoch === nativeStandaloneCommandEpochRef.current) {
+          setIsRunning(false);
+          setErrorMessage("Could not start native metronome audio. Check the output device and retry.");
+        }
+      }
       return;
     }
     const audioContext = await activateAudioContext();
@@ -288,8 +341,48 @@ export function MetronomeProvider({ children }: { children: ReactNode }) {
 
   const stopMetronome = useStableCallback(function stopMetronome() {
     stopAudioClock();
+    if (isTauriRuntime() && !isWebAudioBackendForced()) {
+      const epoch = ++nativeStandaloneCommandEpochRef.current;
+      const lifecycle = nativeStandaloneLifecycleRef.current;
+      void enqueueNativeMetronomeCommand({ enabled: false, epoch, lifecycle }).then(() => {
+        if (epoch === nativeStandaloneCommandEpochRef.current) {
+          setIsRunning(false);
+          setErrorMessage(null);
+        }
+      }).catch(() => {
+        if (epoch === nativeStandaloneCommandEpochRef.current) {
+          setIsRunning(true);
+          setErrorMessage("Could not stop native metronome audio. Retry Stop before leaving it running.");
+        }
+      });
+      return;
+    }
     setIsRunning(false);
   });
+
+  const reconcileNativeMetronomeFailure = useStableCallback(
+    async function reconcileNativeMetronomeFailure(failedEpoch: number) {
+      if (failedEpoch !== nativeStandaloneCommandEpochRef.current) return;
+      const stopEpoch = ++nativeStandaloneCommandEpochRef.current;
+      const lifecycle = nativeStandaloneLifecycleRef.current;
+      setErrorMessage("Native metronome audio changed unexpectedly; stopping it safely.");
+      try {
+        await enqueueNativeMetronomeCommand({
+          enabled: false,
+          epoch: stopEpoch,
+          lifecycle,
+        });
+        if (stopEpoch === nativeStandaloneCommandEpochRef.current) {
+          setIsRunning(false);
+        }
+      } catch {
+        if (stopEpoch === nativeStandaloneCommandEpochRef.current) {
+          setIsRunning(true);
+          setErrorMessage("Native metronome state is uncertain. Choose Stop again.");
+        }
+      }
+    },
+  );
 
   const setFollowPlaybackEnabled = useStableCallback(async function setFollowPlaybackEnabled(
     enabled: boolean,
@@ -363,23 +456,20 @@ export function MetronomeProvider({ children }: { children: ReactNode }) {
     if (!isRunning) {
       return;
     }
-    if (!followPlayback) {
-      const audioContext = audioContextRef.current;
-      if (audioContext && audioContext.state !== "closed") {
-        startFreeRunClock(audioContext);
-        return;
-      }
-      void activateAudioContext().then((nextAudioContext) => {
-        if (nextAudioContext && isRunningRef.current && !followPlaybackRef.current) {
-          startFreeRunClock(nextAudioContext);
-        }
-      });
+    if (isTauriRuntime() && !isWebAudioBackendForced()) {
       return;
     }
-
-    clearScheduler();
-    lastSyncedPlaybackTimeRef.current = null;
-    lastSyncedScheduledBeatRef.current = null;
+    void activateAudioContext().then((audioContext) => {
+      if (!audioContext || !isRunningRef.current) return;
+      const snapshot = getPlaybackSnapshot();
+      if (!followPlaybackRef.current || !snapshot.session || !snapshot.isPlaying) {
+        startFreeRunClock(audioContext);
+      } else {
+        clearScheduler();
+        lastSyncedPlaybackTimeRef.current = null;
+        lastSyncedScheduledBeatRef.current = null;
+      }
+    });
   }, [
     accentFirstBeat,
     activateAudioContext,
@@ -387,27 +477,40 @@ export function MetronomeProvider({ children }: { children: ReactNode }) {
     bpm,
     clearScheduler,
     followPlayback,
+    getPlaybackSnapshot,
     isRunning,
     startFreeRunClock,
   ]);
 
   useEffect(() => {
-    if (!isRunning || !followPlayback) {
+    if (
+      !isRunning ||
+      !followPlayback ||
+      (isTauriRuntime() && !isWebAudioBackendForced())
+    ) {
       return;
     }
 
     let frameId: number | null = null;
     function tick() {
-      if (isTauriRuntime() && !isWebAudioBackendForced()) return;
       const snapshot = getPlaybackSnapshot();
+      const audioContext = ensureAudioContext();
+      if (!audioContext) {
+        frameId = window.requestAnimationFrame(tick);
+        return;
+      }
       if (!snapshot.session || !snapshot.isPlaying) {
-        pauseSyncedClock();
-      } else {
-        const audioContext = ensureAudioContext();
-        if (audioContext) {
-          void activateWebAudioContext(audioContext).catch(() => undefined);
-          scheduleSynced(audioContext, snapshot);
+        lastSyncedPlaybackTimeRef.current = null;
+        lastSyncedScheduledBeatRef.current = null;
+        if (schedulerIntervalRef.current === null) {
+          startFreeRunClock(audioContext);
         }
+      } else {
+        if (schedulerIntervalRef.current !== null) {
+          clearScheduler();
+        }
+        void activateWebAudioContext(audioContext).catch(() => undefined);
+        scheduleSynced(audioContext, snapshot);
       }
       frameId = window.requestAnimationFrame(tick);
     }
@@ -419,39 +522,74 @@ export function MetronomeProvider({ children }: { children: ReactNode }) {
       }
     };
   }, [
+    clearScheduler,
     ensureAudioContext,
     followPlayback,
     getPlaybackSnapshot,
     isRunning,
-    pauseSyncedClock,
     scheduleSynced,
+    startFreeRunClock,
   ]);
 
   useEffect(() => {
     if (!isTauriRuntime() || isWebAudioBackendForced()) return;
     const unlisteners = Promise.all([
-      listenNativeAudioSessions((next) =>
+      listenNativeAudioSessions((next) => {
+        if (next.resource !== "output") return;
         setNativeSession((current) =>
           current?.generation === next.generation &&
           current.timelineRevision === next.timelineRevision &&
           current.status === next.status ? current : next,
-        ),
-      ),
+        );
+      }),
       listenNativeAudioCues((cue) => {
         if (
           cue.kind !== "metronome" ||
-          cue.generation !== nativeSession?.generation ||
-          cue.revision !== nativeSession.timelineRevision
+          (cue.source === "project_playback" &&
+            (cue.generation !== nativeSession?.generation ||
+              cue.revision !== nativeSession.timelineRevision)) ||
+          (cue.source === "standalone_metronome" &&
+            (cue.generation !== nativeStandaloneRef.current?.generation ||
+              cue.revision !== nativeStandaloneRef.current.revision))
         ) return;
         setActiveBeat(beatNumberForIndex(cue.cueIndex, beatsPerBarRef.current));
         activeBeatTimeoutsRef.current.push(window.setTimeout(() => setActiveBeat(null), 90));
       }),
       listenNativeAudioTerminal((event) => {
-        if (event.generation === nativeSession?.generation) setNativeSession(null);
+        if (
+          event.resource === "output" &&
+          (event.generation === nativeSession?.generation ||
+            event.generation === nativeStandaloneRef.current?.generation)
+        ) {
+          nativeStandaloneLifecycleRef.current += 1;
+          nativeStandaloneCommandEpochRef.current += 1;
+          setNativeSession(null);
+          nativeStandaloneRef.current = null;
+          setIsRunning(false);
+          setErrorMessage("Native metronome audio stopped. Check the output device and retry.");
+        }
       }),
     ]);
     return () => void unlisteners.then((items) => items.forEach((unlisten) => unlisten()));
   }, [nativeSession?.generation, nativeSession?.timelineRevision]);
+
+  useEffect(() => {
+    if (!isRunning || !isTauriRuntime() || isWebAudioBackendForced()) return;
+    const epoch = nativeStandaloneCommandEpochRef.current;
+    const lifecycle = nativeStandaloneLifecycleRef.current;
+    void enqueueNativeMetronomeCommand({ enabled: true, epoch, lifecycle }).catch(() => {
+      void reconcileNativeMetronomeFailure(epoch);
+    });
+  }, [
+    accentFirstBeat,
+    beatsPerBar,
+    bpm,
+    enqueueNativeMetronomeCommand,
+    followPlayback,
+    isRunning,
+    reconcileNativeMetronomeFailure,
+    volume,
+  ]);
 
   const nativeCuePlan = useStableCallback((positionSeconds: number) => {
     const snapshot = getPlaybackSnapshot();
@@ -481,20 +619,10 @@ export function MetronomeProvider({ children }: { children: ReactNode }) {
       if (nativePlayCueProvider.current === nativeCuePlan) nativePlayCueProvider.current = null;
       if (!isNativeActivationEpochCurrent(activationEpoch)) return;
       const cleanupEpoch = advanceNativeActivationEpoch();
-      void getNativeAudioSessionSnapshot()
-        .then((snapshot) => {
-          if (
-            !isNativeActivationEpochCurrent(cleanupEpoch) ||
-            snapshot.status !== "output" ||
-            snapshot.leaseId !== "project-playback"
-          ) return null;
-          return updateFollowedMetronomeCues?.([]) ?? null;
-        })
-        .then((snapshot) => {
-          if (!isNativeActivationEpochCurrent(cleanupEpoch) || !snapshot) return;
-          setNativeSession(snapshot);
-        })
-        .catch(() => undefined);
+      void updateFollowedMetronomeCues?.([]).then((snapshot) => {
+        if (!snapshot || !isNativeActivationEpochCurrent(cleanupEpoch)) return;
+        setNativeSession(snapshot);
+      }).catch(() => undefined);
     };
   }, [advanceNativeActivationEpoch, followPlayback, isNativeActivationEpochCurrent, isRunning, nativeCuePlan, updateFollowedMetronomeCues]);
 
@@ -502,23 +630,14 @@ export function MetronomeProvider({ children }: { children: ReactNode }) {
     if (
       !isRunning || !followPlayback || !isTauriRuntime() || isWebAudioBackendForced()
     ) return;
+    let cancelled = false;
     const activationEpoch = nativeActivationEpochRef.current;
     const cues = nativeCuePlan(getPlaybackSnapshot().playbackTimeSeconds);
-    void getNativeAudioSessionSnapshot()
-      .then((snapshot) => {
-        if (
-          nativeActivationEpochRef.current !== activationEpoch ||
-          snapshot.status !== "output" ||
-          snapshot.leaseId !== "project-playback"
-        ) return null;
-        setNativeSession(snapshot);
-        return updateFollowedMetronomeCues?.(cues) ?? null;
-      })
-      .then((snapshot) => {
-        if (nativeActivationEpochRef.current !== activationEpoch || !snapshot) return;
-        setNativeSession(snapshot);
-      })
-      .catch(() => undefined);
+    void updateFollowedMetronomeCues?.(cues).then((snapshot) => {
+      if (!snapshot || cancelled || nativeActivationEpochRef.current !== activationEpoch) return;
+      setNativeSession(snapshot);
+    }).catch(() => undefined);
+    return () => { cancelled = true; };
   }, [
     accentFirstBeat,
     beatsPerBar,
@@ -533,13 +652,15 @@ export function MetronomeProvider({ children }: { children: ReactNode }) {
     volume,
   ]);
 
-  const syncStatus = followPlayback
-    ? session
-      ? isPlaying
-        ? `Following ${session.projectName}`
-        : `Waiting for ${session.projectName} playback`
-      : "No project playback active"
-    : "Standalone clock";
+  const tempoStatus = `${bpm.toFixed(1)} BPM`;
+  const freeRunningStatus = `Free-running at ${tempoStatus}`;
+  const syncStatus = !isRunning
+    ? `Ready at ${tempoStatus}`
+    : followPlayback && session && isPlaying
+      ? `Following ${session.projectName} playback`
+      : followPlayback && session
+        ? `${freeRunningStatus} · follows ${session.projectName} when playback starts`
+        : freeRunningStatus;
 
   const value = useMemo(
     () => ({

--- a/apps/desktop/src/lib/nativeAudio.test.ts
+++ b/apps/desktop/src/lib/nativeAudio.test.ts
@@ -51,6 +51,7 @@ import {
   setNativeAudioClick,
   setNativeAudioLanes,
   setNativeAudioMonitor,
+  setNativeStandaloneMetronome,
   startNativeAudioInput,
   stopNativeAudio,
   stopNativeAudioInput,
@@ -327,6 +328,50 @@ describe("native audio adapter", () => {
       } }],
       ["audio_set_lanes", { payload: { lanes: [] }, control }],
     ]);
+  });
+
+  it("sends the canonical standalone metronome payload with control metadata", async () => {
+    const state = {
+      enabled: true,
+      bpm: 121.5,
+      beatsPerBar: 3,
+      accentFirstBeat: true,
+      gain: 0.42,
+      followPlayback: true,
+      leaseId: "standalone-metronome",
+      generation: 2,
+      revision: 4,
+      nativeTimeUs: 99,
+    };
+    mockInvoke.mockResolvedValue(state);
+
+    await expect(setNativeStandaloneMetronome({
+      enabled: true,
+      bpm: 121.5,
+      beatsPerBar: 3,
+      accentFirstBeat: true,
+      gain: 0.42,
+      followPlayback: true,
+      leaseId: "standalone-metronome",
+      operationId: "metronome-4",
+      generation: 2,
+      timelineRevision: 3,
+    })).resolves.toEqual(state);
+
+    expect(mockInvoke).toHaveBeenCalledWith("audio_set_standalone_metronome", {
+      payload: {
+        enabled: true,
+        bpm: 121.5,
+        beatsPerBar: 3,
+        accentFirstBeat: true,
+        gain: 0.42,
+        followPlayback: true,
+        leaseId: "standalone-metronome",
+        operationId: "metronome-4",
+        generation: 2,
+        timelineRevision: 3,
+      },
+    });
   });
 
   it("wraps native input and monitor payloads", async () => {

--- a/apps/desktop/src/lib/nativeAudio.ts
+++ b/apps/desktop/src/lib/nativeAudio.ts
@@ -24,6 +24,8 @@ export type NativeAudioSessionControl = {
 };
 
 export type NativeAudioSessionSnapshot = {
+  resource: "output" | "capture";
+  source: "project_playback" | "tuner_capture";
   status: "released" | "output" | "capture" | "releasing" | "terminal";
   owner: "playback" | "cue" | "capture" | null;
   leaseId: string | null;
@@ -45,6 +47,8 @@ export type NativeAudioCue = {
   gain?: number;
 };
 export type NativeAudioCueEvent = {
+  resource: "output";
+  source: "project_playback" | "standalone_metronome";
   generation: number;
   revision: number;
   cueIndex: number;
@@ -56,6 +60,8 @@ export type NativeAudioCueEvent = {
   insertionSequence: number;
 };
 export type NativeAudioTerminalEvent = {
+  resource: "output" | "capture";
+  source: "output_runtime" | "capture_runtime" | "project_playback" | "tuner_capture";
   generation: number;
   code: string;
   nativeTimeUs: number;
@@ -256,6 +262,28 @@ export type NativeAudioClickRequest = {
   followTransport?: boolean | null;
 };
 
+export type NativeStandaloneMetronomeRequest = NativeAudioSessionControl & {
+  enabled: boolean;
+  bpm: number;
+  beatsPerBar: number;
+  accentFirstBeat: boolean;
+  gain: number;
+  followPlayback: boolean;
+};
+
+export type NativeStandaloneMetronomeState = {
+  enabled: boolean;
+  bpm: number;
+  beatsPerBar: number;
+  accentFirstBeat: boolean;
+  gain: number;
+  followPlayback: boolean;
+  leaseId: string | null;
+  generation: number;
+  revision: number;
+  nativeTimeUs: number;
+};
+
 export type NativeAudioPositionEvent = {
   sessionId: string | null;
   positionSeconds: number;
@@ -405,6 +433,10 @@ export function setNativeAudioLanes(
 
 export function setNativeAudioClick(payload: NativeAudioClickRequest) {
   return invoke<NativeAudioSnapshot>("audio_set_click", { payload });
+}
+
+export function setNativeStandaloneMetronome(payload: NativeStandaloneMetronomeRequest) {
+  return invoke<NativeStandaloneMetronomeState>("audio_set_standalone_metronome", { payload });
 }
 
 export function getNativeAudioSnapshot() {

--- a/apps/desktop/src/test/appTestHarness.tsx
+++ b/apps/desktop/src/test/appTestHarness.tsx
@@ -231,6 +231,8 @@ const {
       capturePath: "none" | "desktop-cpal" | "android-aaudio";
       permissionState: string;
       error: { code: string; message: string; guidance: string | null } | null;
+      leaseId?: string | null;
+      generation?: number | null;
     };
     nativeAudioInputPermission: {
       state: string;
@@ -1421,8 +1423,26 @@ const {
       return clone(state.nativeAudioSnapshot);
     }
 
+    if (command === "audio_set_standalone_metronome") {
+      const payload = (args?.payload ?? {}) as Record<string, unknown>;
+      return {
+        enabled: payload.enabled === true,
+        bpm: Number(payload.bpm ?? 120),
+        beatsPerBar: Number(payload.beatsPerBar ?? 4),
+        accentFirstBeat: payload.accentFirstBeat !== false,
+        gain: Number(payload.gain ?? 0.8),
+        followPlayback: payload.followPlayback !== false,
+        leaseId: String(payload.leaseId ?? "standalone-metronome"),
+        generation: Number(payload.generation ?? 1),
+        revision: Number(payload.timelineRevision ?? 0) + 1,
+        nativeTimeUs: 1,
+      };
+    }
+
     if (command === "audio_get_session_snapshot" || command === "audio_schedule_cues" || command === "audio_cancel_cues") {
       return {
+        resource: "output",
+        source: "project_playback",
         status: "output",
         owner: "playback",
         leaseId: "project-playback",
@@ -1440,6 +1460,7 @@ const {
         deviceId?: string | null;
         monitorEnabled?: boolean | null;
         monitorGain?: number | null;
+        leaseId?: string | null;
       };
       state.nativeAudioInputState = {
         active: true,
@@ -1454,6 +1475,8 @@ const {
         permissionState:
           state.nativeAudioCapabilities.platform === "android" ? "granted" : "unavailable",
         error: null,
+        leaseId: String(payload.leaseId ?? "tuner-capture"),
+        generation: Number(state.nativeAudioInputState.generation ?? 0) + 1,
       };
       return clone(state.nativeAudioInputState);
     }


### PR DESCRIPTION
## Summary

- Share one native output stream between project playback and the standalone metronome.
- Isolate native tuner capture so input can continue alongside playback and metronome output.
- Keep hybrid follow and free-run metronome behavior consistent across native and Web Audio.
- Require explicit retry after normal-Tauri metronome or tuner failures.
- Closes #511
- Closes #512

## Testing

- `cd apps/desktop/src-tauri && rtk cargo test native_audio::`
- `cd apps/desktop/src-tauri && rtk cargo check`
- `cd apps/desktop/src-tauri && rtk cargo fmt --all -- --check`
- `rtk pnpm --filter @tuneforge/desktop lint`
- `rtk pnpm --dir apps/desktop run typecheck`
- `rtk pnpm --filter @tuneforge/desktop test`
- `rtk pnpm --filter @tuneforge/site test`
- `rtk git diff --check`
