### PR TITLE
fix(audio): require native audio in Tauri

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,12 +12,19 @@ download, installation, verification, signature, and publication instructions.
 - Moved project count-ins and metronome timing onto one native output runtime, including standalone
   free-run and playback-following modes, while keeping tuner capture independently concurrent.
 
+### Changed
+
+- Made native audio required in normal Tauri sessions while preserving browser and explicitly
+  forced Web Audio modes.
+
 ### Fixed
 
 - Reduced Android sync reconciliation memory use for libraries with many pending projects.
 - Preserved project playback position across native output changes, rejected stale transport
   completions, cancelled pending native and Web starts, kept native loop restarts reliable, and
-  rescheduled playback-following metronome cues after tempo changes.
+  kept playback-following native and Web metronome timing aligned through tempo changes.
+- Avoided opening Web Audio during native stem selection and kept Linux native playback alive while
+  CPAL recovers a transient output xrun.
 
 ## [1.4.0] - 2026-09-01
 

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -556,7 +556,6 @@ pub fn run() {
             native_audio::audio_stop,
             native_audio::audio_seek,
             native_audio::audio_set_lanes,
-            native_audio::audio_set_click,
             native_audio::audio_set_standalone_metronome,
             native_audio::audio_get_snapshot,
             native_audio::audio_get_session_snapshot,

--- a/apps/desktop/src-tauri/src/native_audio/capture.rs
+++ b/apps/desktop/src-tauri/src/native_audio/capture.rs
@@ -62,7 +62,7 @@ pub struct AudioInputRequest {
     pub device_id: Option<String>,
     pub monitor_enabled: Option<bool>,
     pub monitor_gain: Option<f32>,
-    #[serde(default, flatten)]
+    #[serde(flatten)]
     pub control: SessionCommand,
 }
 
@@ -71,6 +71,8 @@ pub struct AudioInputRequest {
 pub struct AudioMonitorRequest {
     pub enabled: bool,
     pub gain: Option<f32>,
+    #[serde(flatten)]
+    pub control: SessionCommand,
 }
 
 #[derive(Clone, Debug, Serialize)]
@@ -153,6 +155,8 @@ pub struct CaptureState {
     permission_pending: bool,
     session_generation: u64,
     report_sender: Option<mpsc::SyncSender<RuntimeReport>>,
+    #[cfg(test)]
+    fail_next_release: bool,
     #[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
     runtime: Option<CaptureRuntime>,
 }
@@ -203,6 +207,8 @@ impl Default for CaptureState {
             permission_pending: false,
             session_generation: 0,
             report_sender: None,
+            #[cfg(test)]
+            fail_next_release: false,
             #[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
             runtime: None,
         }
@@ -220,6 +226,10 @@ impl CaptureState {
     }
 
     pub fn release_for_transfer(&mut self) -> Result<(), &'static str> {
+        #[cfg(test)]
+        if std::mem::take(&mut self.fail_next_release) {
+            return Err("release_timeout");
+        }
         #[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
         if let Some(runtime) = &self.runtime {
             let _ = runtime.stop_sender.send(CaptureControl::Stop);
@@ -238,6 +248,11 @@ impl CaptureState {
         self.stop_runtime();
         self.clear_live_state();
         Ok(())
+    }
+
+    #[cfg(test)]
+    pub(crate) fn fail_next_release_for_test(&mut self) {
+        self.fail_next_release = true;
     }
 
     pub fn list_devices(&self, capabilities: AudioCapabilities) -> AudioInputDevices {
@@ -1179,6 +1194,9 @@ fn finish_capture_with_error(
             resource: AudioResource::Capture,
             source: AudioSource::CaptureRuntime,
             generation: session_generation,
+            timeline_revision: 0,
+            capture_generation: Some(capture_generation),
+            position_seconds: 0.0,
             code: terminal_code,
             native_time_us: timeline::native_time_us(),
         },
@@ -1333,8 +1351,7 @@ mod tests {
             mic_monitoring_supported: false,
             system_input_volume_supported: false,
             emits_events: Vec::new(),
-            fallback_required: !native_playback_supported,
-            fallback_reason: None,
+            availability_reason: (!native_playback_supported).then_some("native_audio_unavailable"),
         }
     }
 
@@ -1494,6 +1511,7 @@ mod tests {
             permission_pending: false,
             session_generation: 0,
             report_sender: None,
+            fail_next_release: false,
             #[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
             runtime: None,
         };

--- a/apps/desktop/src-tauri/src/native_audio/diagnostics.rs
+++ b/apps/desktop/src-tauri/src/native_audio/diagnostics.rs
@@ -116,15 +116,77 @@ pub fn record_callback_safe_code(generation: u64, code: DiagnosticSafeCode) {
     }
 }
 
+pub fn record_callback_output_stream_error_kind(
+    generation: u64,
+    kind: DiagnosticOutputStreamErrorKind,
+) {
+    if generation == 0 {
+        return;
+    }
+    if let Some(recorder) = DIAGNOSTICS.get() {
+        recorder.record_output_stream_error_kind(generation, kind);
+    }
+}
+
 #[derive(Clone, Copy, Debug, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum DiagnosticOperationKind {
     Prepare,
     Play,
+    Pause,
+    Stop,
     Seek,
     Tempo,
     LaneUpdate,
     LaneRoute,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+#[repr(u64)]
+#[serde(rename_all = "snake_case")]
+pub enum DiagnosticOutputStreamErrorKind {
+    DeviceBusy = 1,
+    DeviceChanged = 2,
+    DeviceNotAvailable = 3,
+    HostUnavailable = 4,
+    InvalidInput = 5,
+    PermissionDenied = 6,
+    RealtimeDenied = 7,
+    ResourceExhausted = 8,
+    StreamInvalidated = 9,
+    UnsupportedConfig = 10,
+    UnsupportedOperation = 11,
+    Xrun = 12,
+    BackendError = 13,
+    Other = 14,
+    Unknown = 15,
+}
+
+impl DiagnosticOutputStreamErrorKind {
+    const fn code(self) -> u64 {
+        self as u64
+    }
+
+    const fn from_code(code: u64) -> Option<Self> {
+        match code {
+            1 => Some(Self::DeviceBusy),
+            2 => Some(Self::DeviceChanged),
+            3 => Some(Self::DeviceNotAvailable),
+            4 => Some(Self::HostUnavailable),
+            5 => Some(Self::InvalidInput),
+            6 => Some(Self::PermissionDenied),
+            7 => Some(Self::RealtimeDenied),
+            8 => Some(Self::ResourceExhausted),
+            9 => Some(Self::StreamInvalidated),
+            10 => Some(Self::UnsupportedConfig),
+            11 => Some(Self::UnsupportedOperation),
+            12 => Some(Self::Xrun),
+            13 => Some(Self::BackendError),
+            14 => Some(Self::Other),
+            15 => Some(Self::Unknown),
+            _ => None,
+        }
+    }
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -232,6 +294,7 @@ pub struct NativeAudioOperationExportV1 {
     pub ring_capacity_samples: Option<usize>,
     pub scratch_capacity_samples: Option<usize>,
     pub rss_kib_at_begin: Option<u64>,
+    pub first_output_stream_error_kind: Option<DiagnosticOutputStreamErrorKind>,
     pub safe_codes: Vec<DiagnosticSafeCodeCount>,
 }
 
@@ -335,6 +398,7 @@ struct CallbackSlot {
     first_gain_ramp_complete_us: AtomicU64,
     underrun_count: AtomicU64,
     first_underrun_us: AtomicU64,
+    first_output_stream_error_kind: AtomicU64,
     safe_code_counts: [AtomicU64; SAFE_CODE_COUNT],
 }
 
@@ -348,6 +412,7 @@ impl CallbackSlot {
             first_gain_ramp_complete_us: AtomicU64::new(0),
             underrun_count: AtomicU64::new(0),
             first_underrun_us: AtomicU64::new(0),
+            first_output_stream_error_kind: AtomicU64::new(0),
             safe_code_counts: std::array::from_fn(|_| AtomicU64::new(0)),
         }
     }
@@ -359,6 +424,8 @@ impl CallbackSlot {
         self.first_gain_ramp_complete_us.store(0, Ordering::Relaxed);
         self.underrun_count.store(0, Ordering::Relaxed);
         self.first_underrun_us.store(0, Ordering::Relaxed);
+        self.first_output_stream_error_kind
+            .store(0, Ordering::Relaxed);
         for count in &self.safe_code_counts {
             count.store(0, Ordering::Relaxed);
         }
@@ -618,6 +685,25 @@ impl DiagnosticsRecorder {
         }
     }
 
+    fn record_output_stream_error_kind(
+        &self,
+        generation: u64,
+        kind: DiagnosticOutputStreamErrorKind,
+    ) {
+        if !self.accepts_generation(generation) {
+            return;
+        }
+        let slot = self.callback_slot(generation);
+        if slot.generation.load(Ordering::Acquire) == generation {
+            let _ = slot.first_output_stream_error_kind.compare_exchange(
+                0,
+                kind.code(),
+                Ordering::AcqRel,
+                Ordering::Relaxed,
+            );
+        }
+    }
+
     fn callback_slot(&self, generation: u64) -> &CallbackSlot {
         &self.callback_slots[(generation as usize) % MAX_OPERATIONS]
     }
@@ -706,6 +792,13 @@ impl DiagnosticsRecorder {
                     ring_capacity_samples: operation.ring_capacity_samples,
                     scratch_capacity_samples: operation.scratch_capacity_samples,
                     rss_kib_at_begin: operation.rss_kib_at_begin,
+                    first_output_stream_error_kind: slot_matches
+                        .then(|| {
+                            DiagnosticOutputStreamErrorKind::from_code(
+                                slot.first_output_stream_error_kind.load(Ordering::Acquire),
+                            )
+                        })
+                        .flatten(),
                     safe_codes: slot_matches
                         .then(|| safe_code_counts(&slot.safe_code_counts))
                         .unwrap_or_default(),

--- a/apps/desktop/src-tauri/src/native_audio/diagnostics_tests.rs
+++ b/apps/desktop/src-tauri/src/native_audio/diagnostics_tests.rs
@@ -101,6 +101,48 @@ fn later_generation_rejects_stale_worker_and_callback_events() {
 }
 
 #[test]
+fn pause_and_stop_operations_export_at_command_entry() {
+    let (recorder, _) = recorder();
+    recorder.begin_operation(DiagnosticOperationKind::Pause, 2);
+    recorder.begin_operation(DiagnosticOperationKind::Stop, 2);
+
+    let json = serde_json::to_value(recorder.export().expect("export")).expect("json");
+    assert_eq!(json["operations"][0]["kind"], "pause");
+    assert_eq!(json["operations"][1]["kind"], "stop");
+}
+
+#[test]
+fn first_output_stream_error_kind_is_bounded_and_generation_isolated() {
+    let (recorder, _) = recorder();
+    let stale_generation = recorder.begin_operation(DiagnosticOperationKind::Play, 1);
+    let active_generation = recorder.begin_operation(DiagnosticOperationKind::Play, 1);
+
+    recorder.record_output_stream_error_kind(
+        stale_generation,
+        DiagnosticOutputStreamErrorKind::BackendError,
+    );
+    recorder
+        .record_output_stream_error_kind(active_generation, DiagnosticOutputStreamErrorKind::Xrun);
+    recorder.record_safe_code(active_generation, DiagnosticSafeCode::OutputStreamFailure);
+    recorder.record_output_stream_error_kind(
+        active_generation,
+        DiagnosticOutputStreamErrorKind::DeviceBusy,
+    );
+
+    let export = recorder.export().expect("export");
+    assert_eq!(export.counters.stale_generation_event_count, 1);
+    assert_eq!(export.operations[0].first_output_stream_error_kind, None);
+    assert_eq!(
+        export.operations[1].first_output_stream_error_kind,
+        Some(DiagnosticOutputStreamErrorKind::Xrun)
+    );
+    assert_eq!(export.operations[1].safe_codes.len(), 1);
+    assert_eq!(export.operations[1].safe_codes[0].count, 1);
+    let json = serde_json::to_value(export).expect("json");
+    assert_eq!(json["operations"][1]["firstOutputStreamErrorKind"], "xrun");
+}
+
+#[test]
 fn reset_clears_diagnostics_only_and_counts_resets() {
     let (recorder, _) = recorder();
     let generation = recorder.begin_operation(DiagnosticOperationKind::Prepare, 4);
@@ -122,6 +164,7 @@ fn reset_drops_old_producer_events_until_a_new_generation_is_active() {
     recorder.record_checkpoint(old_generation, DiagnosticCheckpoint::RingClear, None);
     recorder.record_callback(old_generation, CallbackCheckpoint::FirstNonzero);
     recorder.record_safe_code(old_generation, DiagnosticSafeCode::DecoderWorkerFailure);
+    recorder.record_output_stream_error_kind(old_generation, DiagnosticOutputStreamErrorKind::Xrun);
     assert_eq!(
         recorder
             .export()
@@ -135,18 +178,22 @@ fn reset_drops_old_producer_events_until_a_new_generation_is_active() {
     recorder.record_checkpoint(old_generation, DiagnosticCheckpoint::RingClear, None);
     recorder.record_callback(old_generation, CallbackCheckpoint::FirstNonzero);
     recorder.record_safe_code(old_generation, DiagnosticSafeCode::DecoderWorkerFailure);
+    recorder.record_output_stream_error_kind(
+        old_generation,
+        DiagnosticOutputStreamErrorKind::BackendError,
+    );
     assert_eq!(
         recorder
             .export()
             .expect("active-generation export")
             .counters
             .stale_generation_event_count,
-        3
+        4
     );
 }
 
 #[test]
-fn skipped_errors_and_safe_fallback_codes_are_counted_without_raw_errors() {
+fn skipped_errors_and_safe_terminal_codes_are_counted_without_raw_errors() {
     let (recorder, _) = recorder();
     let generation = recorder.begin_operation(DiagnosticOperationKind::Play, 1);
     recorder.record_checkpoint(
@@ -238,6 +285,7 @@ fn disabled_recorder_is_a_zero_generation_no_op() {
     recorder.record_callback(generation, CallbackCheckpoint::Underrun);
     recorder.record_capacities(generation, 1, 64, 64);
     recorder.record_safe_code(generation, DiagnosticSafeCode::PrebufferTimeout);
+    recorder.record_output_stream_error_kind(generation, DiagnosticOutputStreamErrorKind::Xrun);
 
     assert_eq!(clock.read_count.load(Ordering::Relaxed), 0);
     assert_eq!(recorder.next_generation.load(Ordering::Relaxed), 0);

--- a/apps/desktop/src-tauri/src/native_audio/mod.rs
+++ b/apps/desktop/src-tauri/src/native_audio/mod.rs
@@ -41,6 +41,8 @@ struct NativeAudioEngine {
     capture_session: session::SessionCoordinator,
     report_sender: mpsc::SyncSender<session::RuntimeReport>,
     report_receiver: mpsc::Receiver<session::RuntimeReport>,
+    #[cfg(test)]
+    last_terminal_event: Option<session::TerminalEvent>,
 }
 
 impl NativeAudioState {
@@ -68,6 +70,8 @@ impl NativeAudioState {
                 ),
                 report_sender,
                 report_receiver,
+                #[cfg(test)]
+                last_terminal_event: None,
             })),
         }
     }
@@ -124,6 +128,7 @@ impl NativeAudioEngine {
         rate: f64,
     ) -> Result<Option<u64>, String> {
         self.drain_reports();
+        command.validate_acquisition().map_err(str::to_string)?;
         let resource = if owner.is_output() {
             session::AudioResource::Output
         } else {
@@ -157,7 +162,16 @@ impl NativeAudioEngine {
             _ => Ok(()),
         };
         if released.is_err() {
-            if let Some(event) = self.session_mut(resource).fail_release(token) {
+            let capture_generation = (resource == session::AudioResource::Capture)
+                .then(|| self.capture.state().capture_generation);
+            if let Some(event) = self
+                .session_mut(resource)
+                .fail_release_with_capture_generation(token, capture_generation)
+            {
+                #[cfg(test)]
+                {
+                    self.last_terminal_event = Some(event.clone());
+                }
                 if let Some(app) = app {
                     let _ = app.emit(AUDIO_EVENT_TERMINAL, event);
                 }
@@ -207,12 +221,28 @@ impl NativeAudioEngine {
         let mut output = self.transport.snapshot();
         let session = self.output_session.snapshot();
         output.lease_id = session.lease_id;
-        output.generation = Some(session.generation);
-        output.timeline_revision = Some(session.timeline_revision);
-        output.native_time_us = Some(session.native_time_us);
+        output.generation = session.generation;
+        output.timeline_revision = session.timeline_revision;
+        output.native_time_us = session.native_time_us;
         output.position_seconds = session.position_seconds;
         output.playback_rate = session.playback_rate;
         output
+    }
+
+    fn require_healthy_output(
+        &mut self,
+        snapshot: transport::AudioSnapshot,
+    ) -> Result<transport::AudioSnapshot, String> {
+        if snapshot.native_playback_supported {
+            return Ok(self.output_snapshot());
+        }
+        let reason = snapshot
+            .availability_reason
+            .unwrap_or_else(|| "Native audio output failed.".to_string());
+        let generation = self.output_session.snapshot().generation;
+        self.output_session
+            .mark_terminal(generation, "output_stream_failure");
+        Err(reason)
     }
 
     fn input_snapshot(&self, mut input: capture::AudioInputState) -> capture::AudioInputState {
@@ -240,8 +270,7 @@ pub struct AudioCapabilities {
     mic_monitoring_supported: bool,
     system_input_volume_supported: bool,
     emits_events: Vec<&'static str>,
-    fallback_required: bool,
-    fallback_reason: Option<&'static str>,
+    availability_reason: Option<&'static str>,
 }
 
 impl AudioCapabilities {
@@ -267,8 +296,7 @@ impl AudioCapabilities {
                 AUDIO_EVENT_CUE,
                 AUDIO_EVENT_TERMINAL,
             ],
-            fallback_required: !platform.native_playback_supported,
-            fallback_reason: platform.fallback_reason,
+            availability_reason: platform.availability_reason,
         }
     }
 }
@@ -284,6 +312,9 @@ pub async fn audio_prepare_session(
     state: State<'_, NativeAudioState>,
     payload: transport::AudioSessionRequest,
 ) -> Result<transport::AudioSession, String> {
+    if !state.capabilities.native_playback_supported {
+        return Err("native_audio_unavailable".to_string());
+    }
     let state = state.inner().clone();
     tauri::async_runtime::spawn_blocking(move || {
         let diagnostic_generation = diagnostics::begin_operation(
@@ -291,6 +322,10 @@ pub async fn audio_prepare_session(
             payload.lanes.len(),
         );
         let mut engine = state.engine()?;
+        payload
+            .control
+            .validate_acquisition()
+            .map_err(str::to_string)?;
         let owner = payload.owner.unwrap_or(session::SessionOwner::Playback);
         if !owner.is_output() {
             return Err("session_owner_mismatch".to_string());
@@ -306,8 +341,11 @@ pub async fn audio_prepare_session(
             let snapshot = engine.output_snapshot();
             return Ok(transport::AudioSession {
                 id: payload.session_id,
+                lease_id: snapshot.lease_id.ok_or_else(|| {
+                    "Native session ownership metadata is unavailable.".to_string()
+                })?,
                 native_playback_supported: snapshot.native_playback_supported,
-                fallback_reason: snapshot.fallback_reason,
+                availability_reason: snapshot.availability_reason,
                 lane_count: snapshot.lanes.len(),
                 generation: snapshot.generation,
                 timeline_revision: snapshot.timeline_revision,
@@ -385,10 +423,7 @@ pub fn audio_play(
         return Err("invalid_precount_schedule".to_string());
     }
     let requested_start = payload.start_at_native_us;
-    let expected = payload
-        .control
-        .timeline_revision
-        .unwrap_or_else(|| engine.output_session.snapshot().timeline_revision);
+    let expected = engine.output_session.snapshot().timeline_revision;
     if requested_start.is_some_and(|deadline| deadline <= timeline::native_time_us()) {
         return Err("start_deadline_missed".to_string());
     }
@@ -444,15 +479,21 @@ pub fn audio_play(
 pub fn audio_pause(
     app: AppHandle,
     state: State<'_, NativeAudioState>,
-    payload: Option<session::SessionCommand>,
+    payload: session::SessionCommand,
 ) -> Result<transport::AudioSnapshot, String> {
     let mut engine = state.engine()?;
-    engine.authorize(
-        session::SessionOwner::Playback,
-        &payload.unwrap_or_default(),
-        false,
-    )?;
-    engine.transport.pause();
+    if !engine.authorize(session::SessionOwner::Playback, &payload, false)? {
+        return Ok(engine.output_snapshot());
+    }
+    let generation = diagnostics::begin_operation(
+        diagnostics::DiagnosticOperationKind::Pause,
+        engine.transport.lane_count(),
+    );
+    engine.transport.set_diagnostics_generation(generation);
+    let snapshot = engine.transport.pause();
+    if !snapshot.native_playback_supported {
+        return engine.require_healthy_output(snapshot);
+    }
     engine
         .output_session
         .timeline()
@@ -460,22 +501,28 @@ pub fn audio_pause(
         .map_err(|_| "timeline_unavailable")?
         .pause();
     engine.emit_session(&app, session::AudioResource::Output);
-    Ok(engine.output_snapshot())
+    engine.require_healthy_output(snapshot)
 }
 
 #[tauri::command]
 pub fn audio_stop(
     app: AppHandle,
     state: State<'_, NativeAudioState>,
-    payload: Option<session::SessionCommand>,
+    payload: session::SessionCommand,
 ) -> Result<transport::AudioSnapshot, String> {
     let mut engine = state.engine()?;
-    engine.authorize(
-        session::SessionOwner::Playback,
-        &payload.unwrap_or_default(),
-        false,
-    )?;
-    engine.transport.stop();
+    if !engine.authorize(session::SessionOwner::Playback, &payload, false)? {
+        return Ok(engine.output_snapshot());
+    }
+    let generation = diagnostics::begin_operation(
+        diagnostics::DiagnosticOperationKind::Stop,
+        engine.transport.lane_count(),
+    );
+    engine.transport.set_diagnostics_generation(generation);
+    let snapshot = engine.transport.stop();
+    if !snapshot.native_playback_supported {
+        return engine.require_healthy_output(snapshot);
+    }
     engine
         .output_session
         .timeline()
@@ -483,7 +530,7 @@ pub fn audio_stop(
         .map_err(|_| "timeline_unavailable")?
         .stop();
     engine.emit_session(&app, session::AudioResource::Output);
-    Ok(engine.output_snapshot())
+    engine.require_healthy_output(snapshot)
 }
 
 #[tauri::command]
@@ -493,7 +540,9 @@ pub fn audio_seek(
     payload: transport::AudioSeekRequest,
 ) -> Result<transport::AudioSnapshot, String> {
     let mut engine = state.engine()?;
-    engine.authorize(session::SessionOwner::Playback, &payload.control, false)?;
+    if !engine.authorize(session::SessionOwner::Playback, &payload.control, false)? {
+        return Ok(engine.output_snapshot());
+    }
     let expected = payload
         .control
         .timeline_revision
@@ -510,9 +559,9 @@ pub fn audio_seek(
         engine.transport.lane_count(),
     );
     engine.transport.set_diagnostics_generation(generation);
-    engine.transport.seek(payload);
+    let snapshot = engine.transport.seek(payload);
     engine.emit_session(&app, session::AudioResource::Output);
-    Ok(engine.output_snapshot())
+    engine.require_healthy_output(snapshot)
 }
 
 #[tauri::command]
@@ -520,14 +569,12 @@ pub fn audio_set_lanes(
     app: AppHandle,
     state: State<'_, NativeAudioState>,
     payload: mixer::AudioLaneUpdate,
-    control: Option<session::SessionCommand>,
+    control: session::SessionCommand,
 ) -> Result<transport::AudioSnapshot, String> {
     let mut engine = state.engine()?;
-    engine.authorize(
-        session::SessionOwner::Playback,
-        &control.unwrap_or_default(),
-        false,
-    )?;
+    if !engine.authorize(session::SessionOwner::Playback, &control, false)? {
+        return Ok(engine.output_snapshot());
+    }
     let raw_lanes = payload.lanes;
     let playback_rate = payload.playback_rate;
     engine.mixer.set_lanes(raw_lanes.clone());
@@ -557,24 +604,9 @@ pub fn audio_set_lanes(
     engine
         .transport
         .set_lanes(raw_lanes, effective_lanes, playback_rate);
+    let snapshot = engine.transport.snapshot();
     engine.emit_session(&app, session::AudioResource::Output);
-    Ok(engine.output_snapshot())
-}
-
-#[tauri::command]
-pub fn audio_set_click(
-    state: State<'_, NativeAudioState>,
-    payload: transport::AudioClickRequest,
-    control: Option<session::SessionCommand>,
-) -> Result<transport::AudioSnapshot, String> {
-    let mut engine = state.engine()?;
-    engine.authorize(
-        session::SessionOwner::Playback,
-        &control.unwrap_or_default(),
-        false,
-    )?;
-    engine.transport.set_click(payload);
-    Ok(engine.output_snapshot())
+    engine.require_healthy_output(snapshot)
 }
 
 #[tauri::command]
@@ -688,9 +720,13 @@ pub fn audio_start_input(
     let input = engine.capture.start(app.clone(), payload)?;
     if let Some(code) = input.error.as_ref().map(|error| error.code) {
         let generation = engine.capture_session.snapshot().generation;
-        if let Some(event) = engine.capture_session.mark_terminal(generation, code) {
+        if let Some(event) = engine
+            .capture_session
+            .mark_terminal_with_capture_generation(generation, Some(input.capture_generation), code)
+        {
             let _ = app.emit(AUDIO_EVENT_TERMINAL, event);
         }
+        return Err(code.to_string());
     }
     engine.emit_session(&app, session::AudioResource::Capture);
     Ok(engine.input_snapshot(input))
@@ -700,13 +736,12 @@ pub fn audio_start_input(
 pub fn audio_stop_input(
     app: AppHandle,
     state: State<'_, NativeAudioState>,
-    payload: Option<session::SessionCommand>,
+    payload: session::SessionCommand,
 ) -> Result<capture::AudioInputState, String> {
     let mut engine = state.engine()?;
-    let command = payload.unwrap_or_default();
     let released = engine
         .capture_session
-        .release_capture(&command)
+        .release_capture(&payload)
         .map_err(str::to_string)?;
     let input = if released {
         engine.capture.stop()
@@ -727,11 +762,10 @@ pub fn audio_set_monitor(
     }
 
     let mut engine = state.engine()?;
-    engine.authorize(
-        session::SessionOwner::Capture,
-        &session::SessionCommand::default(),
-        false,
-    )?;
+    if !engine.authorize(session::SessionOwner::Capture, &payload.control, false)? {
+        let input = engine.capture.state();
+        return Ok(engine.input_snapshot(input));
+    }
     let input = engine.capture.set_monitor(payload);
     Ok(engine.input_snapshot(input))
 }
@@ -770,11 +804,10 @@ pub fn audio_schedule_cues(
 pub fn audio_cancel_cues(
     app: AppHandle,
     state: State<'_, NativeAudioState>,
-    payload: Option<session::SessionCommand>,
+    payload: session::SessionCommand,
     kind: Option<timeline::CueKind>,
 ) -> Result<session::SessionSnapshot, String> {
     let mut engine = state.engine()?;
-    let payload = payload.unwrap_or_default();
     let owner = engine
         .output_session
         .snapshot()
@@ -903,8 +936,13 @@ mod tests {
             ),
             report_sender: report_sender.clone(),
             report_receiver,
+            last_terminal_event: None,
         };
-        let command = session::SessionCommand::default();
+        let command = session::SessionCommand {
+            lease_id: Some("project-playback".into()),
+            operation_id: Some("prepare".into()),
+            ..Default::default()
+        };
         let session::Acquire::Release { token, lease, .. } = engine
             .output_session
             .begin_acquire(session::SessionOwner::Playback, &command)
@@ -935,11 +973,31 @@ mod tests {
             engine.output_session.snapshot().terminal_diagnostic,
             Some("output_stream_failure")
         );
+        let retry = session::SessionCommand {
+            generation: Some(generation),
+            timeline_revision: Some(engine.output_session.snapshot().timeline_revision),
+            operation_id: Some("play-retry".into()),
+            ..command
+        };
         assert!(engine
             .output_session
-            .authorize(session::SessionOwner::Playback, &command, true)
+            .authorize(session::SessionOwner::Playback, &retry, true)
             .unwrap());
-        assert!(engine.output_session.snapshot().generation > generation);
+        let restarted = engine.output_session.snapshot();
+        assert!(restarted.generation > generation);
+        assert_ne!(
+            restarted.timeline_revision,
+            retry.timeline_revision.unwrap()
+        );
+        let timeline = engine.output_session.timeline();
+        let mut timeline = timeline.lock().unwrap();
+        assert_eq!(
+            timeline.arm(retry.timeline_revision.unwrap(), None, None, 0),
+            Err("stale_timeline_revision")
+        );
+        timeline
+            .arm(restarted.timeline_revision, None, None, 0)
+            .expect("explicit retry arms with the restarted revision");
         assert!(capabilities.emits_events.contains(&AUDIO_EVENT_TERMINAL));
     }
 
@@ -1029,6 +1087,7 @@ mod tests {
             ),
             report_sender,
             report_receiver,
+            last_terminal_event: None,
         };
         let activate = |lease: &str, operation: &str| session::SessionCommand {
             lease_id: Some(lease.into()),
@@ -1099,6 +1158,66 @@ mod tests {
     }
 
     #[test]
+    fn capture_release_timeout_reports_the_runtime_capture_generation() {
+        let (report_sender, report_receiver) = mpsc::sync_channel(1);
+        let mut engine = NativeAudioEngine {
+            mixer: mixer::MixerState::default(),
+            transport: transport::TransportState::default(),
+            capture: capture::CaptureState::default(),
+            output_session: session::SessionCoordinator::new_for_resource(
+                session::AudioResource::Output,
+                session::AudioSource::ProjectPlayback,
+                true,
+                false,
+            ),
+            capture_session: session::SessionCoordinator::new_for_resource(
+                session::AudioResource::Capture,
+                session::AudioSource::TunerCapture,
+                false,
+                true,
+            ),
+            report_sender,
+            report_receiver,
+            last_terminal_event: None,
+        };
+        let initial = session::SessionCommand {
+            lease_id: Some("tuner-capture".into()),
+            operation_id: Some("start".into()),
+            ..Default::default()
+        };
+        let session_generation = engine
+            .acquire(None, session::SessionOwner::Capture, &initial, 0.0, 1.0)
+            .unwrap()
+            .expect("capture acquisition creates a generation");
+        for _ in 0..7 {
+            engine.capture.stop();
+        }
+        let capture_generation = engine.capture.state().capture_generation;
+        assert_ne!(capture_generation, session_generation);
+        engine.capture.fail_next_release_for_test();
+
+        let replacement = session::SessionCommand {
+            lease_id: Some("tuner-capture-retry".into()),
+            operation_id: Some("retry".into()),
+            ..Default::default()
+        };
+        assert_eq!(
+            engine
+                .acquire(None, session::SessionOwner::Capture, &replacement, 0.0, 1.0,)
+                .unwrap_err(),
+            "release_timeout"
+        );
+        let terminal = engine
+            .last_terminal_event
+            .as_ref()
+            .expect("release timeout emits one terminal event");
+        assert_eq!(terminal.resource, session::AudioResource::Capture);
+        assert_eq!(terminal.generation, session_generation);
+        assert_eq!(terminal.capture_generation, Some(capture_generation));
+        assert_eq!(terminal.code, "release_timeout");
+    }
+
+    #[test]
     #[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
     fn playback_acquire_and_prepare_preserve_standalone_auxiliary_runtime() {
         let capabilities = AudioCapabilities::detect();
@@ -1121,6 +1240,7 @@ mod tests {
             ),
             report_sender,
             report_receiver,
+            last_terminal_event: None,
         };
         engine
             .transport
@@ -1174,6 +1294,7 @@ mod tests {
             capabilities,
         );
         assert_eq!(prepared.id, "project-session");
+        assert_eq!(prepared.lease_id, "project-playback");
         assert!(engine.transport.has_auxiliary_runtime());
     }
 }

--- a/apps/desktop/src-tauri/src/native_audio/platform/android.rs
+++ b/apps/desktop/src-tauri/src/native_audio/platform/android.rs
@@ -12,7 +12,7 @@ pub fn current_platform() -> AudioPlatform {
         name: "android",
         backend: "android-aaudio",
         native_playback_supported: context_result.is_ok(),
-        fallback_reason: context_result.err(),
+        availability_reason: context_result.err(),
         mic_capture_supported: context_result.is_ok(),
         mic_monitoring_supported: false,
         system_input_volume_supported: false,

--- a/apps/desktop/src-tauri/src/native_audio/platform/desktop.rs
+++ b/apps/desktop/src-tauri/src/native_audio/platform/desktop.rs
@@ -9,7 +9,7 @@ pub fn current_platform() -> AudioPlatform {
         },
         backend: "desktop-cpal",
         native_playback_supported: true,
-        fallback_reason: None,
+        availability_reason: None,
         mic_capture_supported: true,
         mic_monitoring_supported: false,
         system_input_volume_supported: true,

--- a/apps/desktop/src-tauri/src/native_audio/platform/mod.rs
+++ b/apps/desktop/src-tauri/src/native_audio/platform/mod.rs
@@ -13,7 +13,7 @@ pub struct AudioPlatform {
     pub name: &'static str,
     pub backend: &'static str,
     pub native_playback_supported: bool,
-    pub fallback_reason: Option<&'static str>,
+    pub availability_reason: Option<&'static str>,
     pub mic_capture_supported: bool,
     pub mic_monitoring_supported: bool,
     pub system_input_volume_supported: bool,

--- a/apps/desktop/src-tauri/src/native_audio/platform/null.rs
+++ b/apps/desktop/src-tauri/src/native_audio/platform/null.rs
@@ -5,7 +5,7 @@ pub fn current_platform() -> AudioPlatform {
         name: "unsupported",
         backend: "null",
         native_playback_supported: false,
-        fallback_reason: Some("Native audio playback is unsupported on this platform."),
+        availability_reason: Some("Native audio playback is unsupported on this platform."),
         mic_capture_supported: false,
         mic_monitoring_supported: false,
         system_input_volume_supported: false,

--- a/apps/desktop/src-tauri/src/native_audio/session.rs
+++ b/apps/desktop/src-tauri/src/native_audio/session.rs
@@ -75,6 +75,9 @@ pub struct TerminalEvent {
     pub resource: AudioResource,
     pub source: AudioSource,
     pub generation: u64,
+    pub timeline_revision: u64,
+    pub capture_generation: Option<u64>,
+    pub position_seconds: f64,
     pub code: &'static str,
     pub native_time_us: u64,
 }
@@ -185,14 +188,10 @@ impl SessionCoordinator {
     }
 
     pub fn begin_acquire(&mut self, owner: SessionOwner, command: &SessionCommand) -> Acquire {
-        let lease = command.lease_id.clone().unwrap_or_else(|| {
-            if owner.is_output() {
-                "legacy-output"
-            } else {
-                "legacy-capture"
-            }
-            .to_string()
-        });
+        let lease = command
+            .lease_id
+            .clone()
+            .expect("acquisition commands are validated before coordination");
         if command.operation_id.as_ref().is_some_and(|operation| {
             self.lease.as_deref() == Some(&lease)
                 && self.owner == Some(owner)
@@ -246,11 +245,24 @@ impl SessionCoordinator {
         Ok(self.generation)
     }
 
+    #[cfg(test)]
     pub fn fail_release(&mut self, token: u64) -> Option<TerminalEvent> {
+        self.fail_release_with_capture_generation(token, None)
+    }
+
+    pub fn fail_release_with_capture_generation(
+        &mut self,
+        token: u64,
+        capture_generation: Option<u64>,
+    ) -> Option<TerminalEvent> {
         if token != self.release_token || self.status != SessionStatus::Releasing {
             return None;
         }
-        self.mark_terminal(self.generation, "release_timeout")
+        self.mark_terminal_with_capture_generation(
+            self.generation,
+            capture_generation,
+            "release_timeout",
+        )
     }
 
     pub fn authorize(
@@ -259,9 +271,7 @@ impl SessionCoordinator {
         command: &SessionCommand,
         explicit_attempt: bool,
     ) -> Result<bool, &'static str> {
-        if self.status == SessionStatus::Released && command.lease_id.is_none() {
-            return Ok(true);
-        }
+        command.validate_mutation(self.resource)?;
         if command
             .lease_id
             .as_deref()
@@ -283,6 +293,16 @@ impl SessionCoordinator {
         }) {
             return Ok(false);
         }
+        if let Some(revision) = command.timeline_revision {
+            let current = self
+                .timeline
+                .lock()
+                .map_err(|_| "timeline_unavailable")?
+                .revision();
+            if revision != current {
+                return Err("stale_timeline_revision");
+            }
+        }
         if self.status == SessionStatus::Terminal && explicit_attempt {
             self.generation = self.generation.wrapping_add(1).max(1);
             self.status = if owner.is_output() {
@@ -302,16 +322,6 @@ impl SessionCoordinator {
         ) {
             return Err("session_not_active");
         }
-        if let Some(revision) = command.timeline_revision {
-            let current = self
-                .timeline
-                .lock()
-                .map_err(|_| "timeline_unavailable")?
-                .revision();
-            if revision != current {
-                return Err("stale_timeline_revision");
-            }
-        }
         self.record(command);
         Ok(true)
     }
@@ -320,13 +330,8 @@ impl SessionCoordinator {
         if self.resource != AudioResource::Capture {
             return Err("session_owner_mismatch");
         }
+        command.validate_mutation(AudioResource::Capture)?;
         if self.status == SessionStatus::Released {
-            if command.lease_id.is_none()
-                && command.generation.is_none()
-                && command.operation_id.is_none()
-            {
-                return Ok(false);
-            }
             if command.operation_id.as_ref().is_some_and(|operation| {
                 self.released_operation.as_ref().is_some_and(
                     |(lease, generation, released_operation)| {
@@ -363,10 +368,7 @@ impl SessionCoordinator {
         {
             return Err("session_not_active");
         }
-        let released_lease = self
-            .lease
-            .take()
-            .unwrap_or_else(|| "legacy-capture".to_string());
+        let released_lease = self.lease.take().ok_or("session_not_active")?;
         self.status = SessionStatus::Released;
         self.owner = None;
         self.terminal = None;
@@ -383,19 +385,40 @@ impl SessionCoordinator {
     }
 
     pub fn mark_terminal(&mut self, generation: u64, code: &'static str) -> Option<TerminalEvent> {
+        self.mark_terminal_with_capture_generation(generation, None, code)
+    }
+
+    pub fn mark_terminal_with_capture_generation(
+        &mut self,
+        generation: u64,
+        capture_generation: Option<u64>,
+        code: &'static str,
+    ) -> Option<TerminalEvent> {
         if generation != self.generation || self.terminal_emitted {
             return None;
         }
         self.status = SessionStatus::Terminal;
         self.terminal = Some(code);
         self.terminal_emitted = true;
-        if let Ok(mut timeline) = self.timeline.lock() {
-            timeline.stop();
-        }
+        let (timeline_revision, position_seconds) = self
+            .timeline
+            .lock()
+            .map(|mut timeline| {
+                let revision = timeline.revision();
+                let position = timeline.position();
+                timeline.stop();
+                (revision, position)
+            })
+            .unwrap_or((0, 0.0));
         Some(TerminalEvent {
             resource: self.resource,
             source: self.source,
             generation,
+            timeline_revision,
+            capture_generation: (self.resource == AudioResource::Capture)
+                .then_some(capture_generation)
+                .flatten(),
+            position_seconds,
             code,
             native_time_us: timeline::native_time_us(),
         })
@@ -414,6 +437,48 @@ impl SessionCoordinator {
         if let Some(operation) = &command.operation_id {
             self.operations.insert((self.generation, operation.clone()));
         }
+    }
+}
+
+impl SessionCommand {
+    fn required_text(value: Option<&String>) -> Result<(), &'static str> {
+        value
+            .filter(|value| !value.trim().is_empty())
+            .map(|_| ())
+            .ok_or("missing_session_control")
+    }
+
+    pub fn validate_acquisition(&self) -> Result<(), &'static str> {
+        Self::required_text(self.lease_id.as_ref())?;
+        Self::required_text(self.operation_id.as_ref())?;
+        if self.generation.is_some() || self.timeline_revision.is_some() {
+            return Err("invalid_acquisition_control");
+        }
+        Ok(())
+    }
+
+    pub fn validate_mutation(&self, resource: AudioResource) -> Result<(), &'static str> {
+        Self::required_text(self.lease_id.as_ref())?;
+        Self::required_text(self.operation_id.as_ref())?;
+        if self.generation.is_none_or(|generation| generation == 0) {
+            return Err("missing_session_control");
+        }
+        match resource {
+            AudioResource::Output => {
+                if self
+                    .timeline_revision
+                    .is_none_or(|timeline_revision| timeline_revision == 0)
+                {
+                    return Err("missing_session_control");
+                }
+            }
+            AudioResource::Capture => {
+                if self.timeline_revision.is_some() {
+                    return Err("invalid_capture_control");
+                }
+            }
+        }
+        Ok(())
     }
 }
 
@@ -451,6 +516,7 @@ mod tests {
                 let old = acquire(&mut state, from, "old");
                 let command = SessionCommand {
                     lease_id: Some("new".into()),
+                    operation_id: Some("transfer".into()),
                     ..Default::default()
                 };
                 let Acquire::Release { token, lease, .. } = state.begin_acquire(to, &command)
@@ -465,6 +531,7 @@ mod tests {
                         to,
                         &SessionCommand {
                             generation: Some(old),
+                            timeline_revision: Some(1),
                             ..command
                         },
                         false
@@ -483,13 +550,13 @@ mod tests {
             lease_id: Some("same".into()),
             operation_id: Some("prepare".into()),
             generation: Some(generation),
-            timeline_revision: None,
+            timeline_revision: Some(1),
         };
         assert!(matches!(
             state.begin_acquire(SessionOwner::Capture, &same),
             Acquire::Idempotent
         ));
-        let next = SessionCommand {
+        let mut next = SessionCommand {
             operation_id: Some("next".into()),
             ..same.clone()
         };
@@ -498,6 +565,7 @@ mod tests {
             panic!()
         };
         assert!(state.fail_release(token).is_some());
+        next.timeline_revision = Some(state.snapshot().timeline_revision);
         assert_eq!(
             state.authorize(SessionOwner::Capture, &next, false),
             Err("session_not_active")
@@ -528,11 +596,82 @@ mod tests {
     }
 
     #[test]
-    fn released_legacy_command_remains_a_safe_noop() {
+    fn incomplete_mutation_control_is_rejected() {
         let mut state = SessionCoordinator::new(true, true);
-        assert!(state
-            .authorize(SessionOwner::Playback, &SessionCommand::default(), false)
-            .unwrap());
+        assert_eq!(
+            state.authorize(SessionOwner::Playback, &SessionCommand::default(), false),
+            Err("missing_session_control")
+        );
+    }
+
+    #[test]
+    fn acquisition_requires_identity_without_generation_metadata() {
+        assert_eq!(
+            SessionCommand::default().validate_acquisition(),
+            Err("missing_session_control")
+        );
+        assert!(SessionCommand {
+            lease_id: Some("project-playback".into()),
+            operation_id: Some("prepare-1".into()),
+            ..Default::default()
+        }
+        .validate_acquisition()
+        .is_ok());
+        assert_eq!(
+            SessionCommand {
+                lease_id: Some("project-playback".into()),
+                operation_id: Some("prepare-1".into()),
+                generation: Some(1),
+                timeline_revision: None,
+            }
+            .validate_acquisition(),
+            Err("invalid_acquisition_control")
+        );
+    }
+
+    #[test]
+    fn mutations_require_resource_specific_complete_metadata() {
+        let output = SessionCommand {
+            lease_id: Some("project-playback".into()),
+            operation_id: Some("pause-1".into()),
+            generation: Some(1),
+            timeline_revision: Some(1),
+        };
+        assert!(output.validate_mutation(AudioResource::Output).is_ok());
+        assert_eq!(
+            SessionCommand {
+                timeline_revision: None,
+                ..output.clone()
+            }
+            .validate_mutation(AudioResource::Output),
+            Err("missing_session_control")
+        );
+        assert_eq!(
+            SessionCommand {
+                generation: Some(0),
+                ..output.clone()
+            }
+            .validate_mutation(AudioResource::Output),
+            Err("missing_session_control")
+        );
+
+        let capture = SessionCommand {
+            timeline_revision: None,
+            ..output.clone()
+        };
+        assert!(capture.validate_mutation(AudioResource::Capture).is_ok());
+        assert_eq!(
+            output.validate_mutation(AudioResource::Capture),
+            Err("invalid_capture_control")
+        );
+        assert_eq!(
+            SessionCommand {
+                lease_id: Some(" ".into()),
+                ..capture
+            }
+            .validate_mutation(AudioResource::Capture),
+            Err("missing_session_control")
+        );
     }
 
     #[test]
@@ -607,5 +746,26 @@ mod tests {
         assert_eq!(snapshot.status, SessionStatus::Released);
         assert_eq!(snapshot.generation, generation);
         assert_eq!(snapshot.terminal_diagnostic, None);
+    }
+
+    #[test]
+    fn capture_terminal_uses_the_runtime_capture_generation() {
+        let mut state = SessionCoordinator::new_for_resource(
+            AudioResource::Capture,
+            AudioSource::TunerCapture,
+            false,
+            true,
+        );
+        let generation = acquire(&mut state, SessionOwner::Capture, "tuner-capture");
+        let terminal = state
+            .mark_terminal_with_capture_generation(
+                generation,
+                Some(generation + 7),
+                "stream-interruption",
+            )
+            .unwrap();
+
+        assert_eq!(terminal.generation, generation);
+        assert_eq!(terminal.capture_generation, Some(generation + 7));
     }
 }

--- a/apps/desktop/src-tauri/src/native_audio/transport.rs
+++ b/apps/desktop/src-tauri/src/native_audio/transport.rs
@@ -33,7 +33,9 @@ use symphonia::core::{
 use tauri::Emitter;
 
 use super::{
-    diagnostics::{self, DiagnosticCheckpoint, DiagnosticSafeCode},
+    diagnostics::{
+        self, DiagnosticCheckpoint, DiagnosticOutputStreamErrorKind, DiagnosticSafeCode,
+    },
     mixer::{AudioLaneRequest, AudioLaneRole, EffectiveAudioLane},
     session::{
         AudioResource, AudioSource, RuntimeReport, RuntimeReportKind, SessionCommand, SessionOwner,
@@ -85,7 +87,7 @@ pub struct AudioSessionRequest {
     pub duration_seconds: Option<f64>,
     pub playback_rate: Option<f64>,
     pub lanes: Vec<AudioLaneRequest>,
-    #[serde(default, flatten)]
+    #[serde(flatten)]
     pub control: SessionCommand,
     pub owner: Option<SessionOwner>,
 }
@@ -94,12 +96,13 @@ pub struct AudioSessionRequest {
 #[serde(rename_all = "camelCase")]
 pub struct AudioSession {
     pub id: String,
+    pub lease_id: String,
     pub native_playback_supported: bool,
-    pub fallback_reason: Option<String>,
+    pub availability_reason: Option<String>,
     pub lane_count: usize,
-    pub generation: Option<u64>,
-    pub timeline_revision: Option<u64>,
-    pub native_time_us: Option<u64>,
+    pub generation: u64,
+    pub timeline_revision: u64,
+    pub native_time_us: u64,
 }
 
 #[derive(Clone, Debug, Deserialize)]
@@ -107,7 +110,7 @@ pub struct AudioSession {
 pub struct AudioPlayRequest {
     pub start_time_seconds: Option<f64>,
     pub scheduled_start_time_seconds: Option<f64>,
-    #[serde(default, flatten)]
+    #[serde(flatten)]
     pub control: SessionCommand,
     pub start_at_native_us: Option<u64>,
     pub precount: Option<AudioPrecountRequest>,
@@ -124,19 +127,8 @@ pub struct AudioPrecountRequest {
 #[serde(rename_all = "camelCase")]
 pub struct AudioSeekRequest {
     pub time_seconds: f64,
-    #[serde(default, flatten)]
+    #[serde(flatten)]
     pub control: SessionCommand,
-}
-
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(rename_all = "camelCase")]
-pub struct AudioClickRequest {
-    pub enabled: bool,
-    pub bpm: Option<f64>,
-    pub beats_per_bar: Option<u32>,
-    pub accent_first_beat: Option<bool>,
-    pub gain: Option<f32>,
-    pub follow_transport: Option<bool>,
 }
 
 #[derive(Clone, Debug, Deserialize)]
@@ -148,7 +140,7 @@ pub struct StandaloneMetronomeRequest {
     pub accent_first_beat: bool,
     pub gain: f32,
     pub follow_playback: bool,
-    #[serde(default, flatten)]
+    #[serde(flatten)]
     pub control: SessionCommand,
 }
 
@@ -174,6 +166,9 @@ pub struct AudioPositionEvent {
     pub position_seconds: f64,
     pub duration_seconds: f64,
     pub state: &'static str,
+    pub generation: u64,
+    pub timeline_revision: u64,
+    pub native_time_us: u64,
 }
 
 #[derive(Clone, Debug, Serialize)]
@@ -182,6 +177,9 @@ pub struct AudioStateEvent {
     pub session_id: Option<String>,
     pub state: &'static str,
     pub position_seconds: f64,
+    pub generation: u64,
+    pub timeline_revision: u64,
+    pub native_time_us: u64,
 }
 
 #[derive(Clone, Debug, Serialize)]
@@ -189,6 +187,10 @@ pub struct AudioStateEvent {
 pub struct AudioErrorEvent {
     pub session_id: Option<String>,
     pub code: NativeAudioErrorCode,
+    pub generation: u64,
+    pub timeline_revision: u64,
+    pub native_time_us: u64,
+    pub position_seconds: f64,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
@@ -202,7 +204,7 @@ pub enum NativeAudioErrorCode {
 }
 
 impl NativeAudioErrorCode {
-    fn fallback_message(self) -> &'static str {
+    fn terminal_message(self) -> &'static str {
         match self {
             Self::DeviceChanged => "Native audio device changed.",
             Self::DeviceNotAvailable => "Native playback device is unavailable.",
@@ -232,13 +234,13 @@ pub struct AudioSnapshot {
     pub duration_seconds: f64,
     pub playback_rate: f64,
     pub native_playback_supported: bool,
-    pub fallback_reason: Option<String>,
+    pub availability_reason: Option<String>,
     pub lanes: Vec<EffectiveAudioLane>,
     pub buffer_health: Vec<AudioBufferHealth>,
     pub lease_id: Option<String>,
-    pub generation: Option<u64>,
-    pub timeline_revision: Option<u64>,
-    pub native_time_us: Option<u64>,
+    pub generation: u64,
+    pub timeline_revision: u64,
+    pub native_time_us: u64,
 }
 
 #[derive(Clone, Debug, Serialize)]
@@ -384,18 +386,16 @@ struct WorkerError {
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-enum NativePlaybackFallbackCause {
+enum NativePlaybackTerminalCause {
     PrebufferTimeout,
     SustainedUnderrun,
 }
 
-impl NativePlaybackFallbackCause {
+impl NativePlaybackTerminalCause {
     fn message(self) -> &'static str {
         match self {
             Self::PrebufferTimeout => "Native playback prebuffer timed out.",
-            Self::SustainedUnderrun => {
-                "Native playback underrun persisted; falling back to Web Audio."
-            }
+            Self::SustainedUnderrun => "Native playback stopped after sustained underruns.",
         }
     }
 
@@ -455,7 +455,7 @@ struct PlaybackShared {
     duration_seconds: f64,
     playback_rate: f64,
     native_playback_supported: bool,
-    fallback_reason: Option<String>,
+    availability_reason: Option<String>,
     sample_rate: u32,
     channels: usize,
     lanes: Vec<PlaybackLane>,
@@ -467,7 +467,7 @@ struct PlaybackShared {
     buffering: bool,
     sustained_underrun_frames: usize,
     underrun_error_pending: bool,
-    fallback_cause: Option<NativePlaybackFallbackCause>,
+    terminal_cause: Option<NativePlaybackTerminalCause>,
     diagnostics_generation: u64,
     diagnostics_gain_first_change_recorded: bool,
     timeline: Arc<Mutex<Timeline>>,
@@ -488,15 +488,15 @@ struct CueVoice {
 
 impl PlaybackShared {
     fn snapshot(&self) -> AudioSnapshot {
-        let fallback_reason = self
+        let availability_reason = self
             .terminal_error
-            .map(|code| code.fallback_message().to_string())
-            .or_else(|| self.fallback_reason.clone())
-            .or_else(|| self.fallback_cause.map(|cause| cause.message().to_string()));
+            .map(|code| code.terminal_message().to_string())
+            .or_else(|| self.availability_reason.clone())
+            .or_else(|| self.terminal_cause.map(|cause| cause.message().to_string()));
 
         let native_playback_supported = self.native_playback_supported
             && self.terminal_error.is_none()
-            && self.fallback_cause.is_none();
+            && self.terminal_cause.is_none();
 
         AudioSnapshot {
             session_id: self.session_id.clone(),
@@ -505,13 +505,13 @@ impl PlaybackShared {
             duration_seconds: self.duration_seconds,
             playback_rate: self.playback_rate,
             native_playback_supported,
-            fallback_reason,
+            availability_reason: availability_reason,
             lanes: self.snapshot_lanes.clone(),
             buffer_health: runtime_buffer_health(&self.snapshot_lanes, &self.lanes),
             lease_id: None,
-            generation: Some(self.generation),
-            timeline_revision: self.timeline.lock().ok().map(|state| state.revision()),
-            native_time_us: Some(timeline::native_time_us()),
+            generation: self.generation,
+            timeline_revision: self.timeline.lock().map_or(0, |state| state.revision()),
+            native_time_us: timeline::native_time_us(),
         }
     }
 
@@ -541,7 +541,7 @@ impl PlaybackShared {
             }
         }
 
-        !has_audible_lane || self.fallback_cause.is_none()
+        !has_audible_lane || self.terminal_cause.is_none()
     }
 }
 
@@ -571,6 +571,53 @@ fn output_stream_error_code(error: &cpal::Error) -> NativeAudioErrorCode {
 }
 
 #[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
+fn diagnostic_output_stream_error_kind(error: &cpal::Error) -> DiagnosticOutputStreamErrorKind {
+    match error.kind() {
+        ErrorKind::DeviceBusy => DiagnosticOutputStreamErrorKind::DeviceBusy,
+        ErrorKind::DeviceChanged => DiagnosticOutputStreamErrorKind::DeviceChanged,
+        ErrorKind::DeviceNotAvailable => DiagnosticOutputStreamErrorKind::DeviceNotAvailable,
+        ErrorKind::HostUnavailable => DiagnosticOutputStreamErrorKind::HostUnavailable,
+        ErrorKind::InvalidInput => DiagnosticOutputStreamErrorKind::InvalidInput,
+        ErrorKind::PermissionDenied => DiagnosticOutputStreamErrorKind::PermissionDenied,
+        ErrorKind::RealtimeDenied => DiagnosticOutputStreamErrorKind::RealtimeDenied,
+        ErrorKind::ResourceExhausted => DiagnosticOutputStreamErrorKind::ResourceExhausted,
+        ErrorKind::StreamInvalidated => DiagnosticOutputStreamErrorKind::StreamInvalidated,
+        ErrorKind::UnsupportedConfig => DiagnosticOutputStreamErrorKind::UnsupportedConfig,
+        ErrorKind::UnsupportedOperation => DiagnosticOutputStreamErrorKind::UnsupportedOperation,
+        ErrorKind::Xrun => DiagnosticOutputStreamErrorKind::Xrun,
+        ErrorKind::BackendError => DiagnosticOutputStreamErrorKind::BackendError,
+        ErrorKind::Other => DiagnosticOutputStreamErrorKind::Other,
+        _ => DiagnosticOutputStreamErrorKind::Unknown,
+    }
+}
+
+#[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
+fn handle_output_stream_error_with_policy(
+    shared: &mut PlaybackShared,
+    error: &cpal::Error,
+    recover_xruns: bool,
+) {
+    diagnostics::record_callback_output_stream_error_kind(
+        shared.diagnostics_generation,
+        diagnostic_output_stream_error_kind(error),
+    );
+    let code = output_stream_error_code(error);
+    let diagnostic_code = diagnostic_code_for_output_stream_error(code);
+    if recover_xruns && error.kind() == ErrorKind::Xrun {
+        diagnostics::record_callback_safe_code(shared.diagnostics_generation, diagnostic_code);
+    } else if code == NativeAudioErrorCode::DeviceChanged {
+        mark_device_changed(shared);
+    } else {
+        mark_terminal_runtime_error(shared, code, diagnostic_code);
+    }
+}
+
+#[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
+fn handle_output_stream_error(shared: &mut PlaybackShared, error: &cpal::Error) {
+    handle_output_stream_error_with_policy(shared, error, cfg!(target_os = "linux"));
+}
+
+#[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
 fn diagnostic_code_for_output_stream_error(code: NativeAudioErrorCode) -> DiagnosticSafeCode {
     match code {
         NativeAudioErrorCode::DeviceChanged => DiagnosticSafeCode::DeviceChanged,
@@ -584,7 +631,7 @@ fn diagnostic_code_for_output_stream_error(code: NativeAudioErrorCode) -> Diagno
 #[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
 fn mark_device_changed(shared: &mut PlaybackShared) {
     if shared.terminal_error.is_some()
-        || shared.fallback_cause.is_some()
+        || shared.terminal_cause.is_some()
         || shared.error_pending.is_some()
     {
         return;
@@ -629,7 +676,7 @@ pub struct TransportState {
     duration_seconds: f64,
     playback_rate: f64,
     native_playback_supported: bool,
-    fallback_reason: Option<String>,
+    availability_reason: Option<String>,
     raw_lanes: Vec<AudioLaneRequest>,
     lanes: Vec<EffectiveAudioLane>,
     click: ClickState,
@@ -659,7 +706,7 @@ impl Default for TransportState {
             duration_seconds: 0.0,
             playback_rate: DEFAULT_PLAYBACK_RATE,
             native_playback_supported: false,
-            fallback_reason: None,
+            availability_reason: None,
             raw_lanes: Vec::new(),
             lanes: Vec::new(),
             click: ClickState::default(),
@@ -745,7 +792,7 @@ impl TransportState {
             duration_seconds: 0.0,
             playback_rate: self.playback_rate,
             native_playback_supported: true,
-            fallback_reason: None,
+            availability_reason: None,
             sample_rate: 1_000,
             channels: 1,
             lanes: Vec::new(),
@@ -757,7 +804,7 @@ impl TransportState {
             buffering: false,
             sustained_underrun_frames: 0,
             underrun_error_pending: false,
-            fallback_cause: None,
+            terminal_cause: None,
             diagnostics_generation: 0,
             diagnostics_gain_first_change_recorded: false,
             timeline,
@@ -785,13 +832,13 @@ impl TransportState {
         #[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
         if self.runtime.as_ref().is_some_and(|runtime| {
             runtime.shared.lock().ok().is_some_and(|shared| {
-                shared.terminal_error.is_some() || shared.fallback_cause.is_some()
+                shared.terminal_error.is_some() || shared.terminal_cause.is_some()
             })
         }) {
             self.stop_runtime();
         }
         self.native_playback_supported = capabilities.native_playback_supported;
-        self.fallback_reason = capabilities.fallback_reason.map(str::to_string);
+        self.availability_reason = capabilities.availability_reason.map(str::to_string);
     }
 
     pub fn release_for_transfer(&mut self) -> Result<(), &'static str> {
@@ -859,6 +906,11 @@ impl TransportState {
         lanes: Vec<EffectiveAudioLane>,
         capabilities: AudioCapabilities,
     ) -> AudioSession {
+        let lease_id = request
+            .control
+            .lease_id
+            .clone()
+            .expect("session acquisition is validated before prepare");
         let duration_seconds = request.duration_seconds.unwrap_or(0.0).max(0.0);
         let playback_rate = normalize_playback_rate(request.playback_rate);
         #[cfg(all(
@@ -878,8 +930,8 @@ impl TransportState {
             .then(|| "Native playback is unsupported on this platform.".to_string());
         let native_playback_supported =
             capabilities.native_playback_supported && runtime_unavailable_reason.is_none();
-        let fallback_reason =
-            runtime_unavailable_reason.or_else(|| capabilities.fallback_reason.map(str::to_string));
+        let availability_reason = runtime_unavailable_reason
+            .or_else(|| capabilities.availability_reason.map(str::to_string));
         #[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
         let preserve_standalone_runtime = self.click.enabled && self.runtime.is_some();
         #[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
@@ -898,7 +950,7 @@ impl TransportState {
         self.raw_lanes = request.lanes.clone();
         self.lanes = lanes.clone();
         self.native_playback_supported = native_playback_supported;
-        self.fallback_reason = fallback_reason;
+        self.availability_reason = availability_reason;
         #[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
         {
             self.app = app;
@@ -924,15 +976,17 @@ impl TransportState {
 
         AudioSession {
             id: request.session_id,
+            lease_id,
             native_playback_supported: self.native_playback_supported,
-            fallback_reason: self.fallback_reason.clone(),
+            availability_reason: self.availability_reason.clone(),
             lane_count: self.lanes.len(),
-            generation: (self.generation != 0).then_some(self.generation),
+            generation: self.generation,
             timeline_revision: self
                 .timeline
                 .as_ref()
-                .and_then(|timeline| timeline.lock().ok().map(|state| state.revision())),
-            native_time_us: Some(timeline::native_time_us()),
+                .and_then(|timeline| timeline.lock().ok().map(|state| state.revision()))
+                .unwrap_or(0),
+            native_time_us: timeline::native_time_us(),
         }
     }
 
@@ -989,31 +1043,10 @@ impl TransportState {
                             shared.sustained_underrun_frames = 0;
                         }
                     }
-                    Err(cause) => mark_runtime_fallback(runtime, cause),
+                    Err(cause) => mark_runtime_terminal(runtime, cause),
                 }
             }
         }
-    }
-
-    pub fn set_click(&mut self, request: AudioClickRequest) -> AudioSnapshot {
-        self.click = ClickState {
-            enabled: request.enabled,
-            bpm: request.bpm.unwrap_or(120.0).clamp(30.0, 300.0),
-            beats_per_bar: request.beats_per_bar.unwrap_or(4).clamp(1, 12),
-            accent_first_beat: request.accent_first_beat.unwrap_or(true),
-            gain: request.gain.unwrap_or(0.75).clamp(0.0, 1.0),
-            follow_transport: request.follow_transport.unwrap_or(true),
-            ..self.click.clone()
-        };
-
-        #[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
-        if let Some(runtime) = &self.runtime {
-            if let Ok(mut shared) = runtime.shared.lock() {
-                shared.click = self.click.clone();
-            }
-        }
-
-        self.snapshot()
     }
 
     pub fn bind_auxiliary_runtime(
@@ -1055,12 +1088,36 @@ impl TransportState {
         request: StandaloneMetronomeRequest,
         capabilities: AudioCapabilities,
     ) -> Result<StandaloneMetronomeState, String> {
+        let acquisition = request.control.generation.is_none();
+        if !acquisition {
+            request
+                .control
+                .validate_mutation(AudioResource::Output)
+                .map_err(str::to_string)?;
+        } else {
+            request
+                .control
+                .validate_acquisition()
+                .map_err(str::to_string)?;
+        }
+        #[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
+        if acquisition && request.enabled && self.runtime_requires_replacement(false) {
+            self.stop_runtime();
+            self.click.enabled = false;
+            self.status = TransportStatus::Stopped;
+            self.started_at = None;
+            self.standalone_metronome.lease_id = None;
+            self.standalone_metronome.operations.clear();
+        }
+        if acquisition && self.standalone_metronome.lease_id.is_some() {
+            return Err("session_already_active".to_string());
+        }
         let previous_click = self.click.clone();
         let previous_control = self.standalone_metronome.clone();
         let previous_session_id = self.session_id.clone();
         let previous_generation = self.generation;
         let previous_native_playback_supported = self.native_playback_supported;
-        let previous_fallback_reason = self.fallback_reason.clone();
+        let previous_availability_reason = self.availability_reason.clone();
         let previous_status = self.status;
         let previous_position_seconds = self.position_seconds;
         let previous_started_at = self.started_at;
@@ -1073,7 +1130,7 @@ impl TransportState {
                 self.app = Some(app);
             }
             self.native_playback_supported = capabilities.native_playback_supported;
-            self.fallback_reason = capabilities.fallback_reason.map(str::to_string);
+            self.availability_reason = capabilities.availability_reason.map(str::to_string);
             if let Some(runtime) = &self.runtime {
                 if let Ok(mut shared) = runtime.shared.lock() {
                     shared.click = self.click.clone();
@@ -1102,7 +1159,7 @@ impl TransportState {
             self.session_id = previous_session_id;
             self.generation = previous_generation;
             self.native_playback_supported = previous_native_playback_supported;
-            self.fallback_reason = previous_fallback_reason;
+            self.availability_reason = previous_availability_reason;
             self.status = previous_status;
             self.position_seconds = previous_position_seconds;
             self.started_at = previous_started_at;
@@ -1129,7 +1186,7 @@ impl TransportState {
             .control
             .lease_id
             .clone()
-            .unwrap_or_else(|| "standalone-metronome".to_string());
+            .expect("metronome controls are validated before mutation");
         let operation_key = request
             .control
             .operation_id
@@ -1211,7 +1268,7 @@ impl TransportState {
         }
         if !self.native_playback_supported {
             return Err(self
-                .fallback_reason
+                .availability_reason
                 .clone()
                 .unwrap_or_else(|| "Native audio playback is unavailable.".to_string()));
         }
@@ -1227,10 +1284,10 @@ impl TransportState {
             let shared = runtime.shared.lock().ok()?;
             let reason = shared
                 .terminal_error
-                .map(|code| code.fallback_message().to_string())
+                .map(|code| code.terminal_message().to_string())
                 .or_else(|| {
                     shared
-                        .fallback_cause
+                        .terminal_cause
                         .map(|cause| cause.message().to_string())
                 })?;
             Some((shared.position_seconds, reason))
@@ -1241,7 +1298,7 @@ impl TransportState {
             self.status = TransportStatus::Paused;
             self.started_at = None;
             self.native_playback_supported = false;
-            self.fallback_reason = Some(reason.clone());
+            self.availability_reason = Some(reason.clone());
             self.stop_runtime();
             return Err(reason);
         }
@@ -1263,9 +1320,9 @@ impl TransportState {
                 self.status = TransportStatus::Paused;
                 self.started_at = None;
                 self.native_playback_supported = false;
-                self.fallback_reason = Some(cause.message().to_string());
+                self.availability_reason = Some(cause.message().to_string());
                 self.stop_runtime();
-                return Ok(self.snapshot());
+                return Err(cause.message().to_string());
             }
             self.status = TransportStatus::Playing;
             self.started_at = Some(Instant::now());
@@ -1279,7 +1336,7 @@ impl TransportState {
             shared.buffering = false;
             shared.sustained_underrun_frames = 0;
             shared.underrun_error_pending = false;
-            shared.fallback_cause = None;
+            shared.terminal_cause = None;
             return Ok(shared.snapshot());
         }
 
@@ -1300,15 +1357,15 @@ impl TransportState {
                 self.position_seconds = shared.position_seconds;
                 if let Some(reason) = shared
                     .terminal_error
-                    .map(|code| code.fallback_message().to_string())
+                    .map(|code| code.terminal_message().to_string())
                     .or_else(|| {
                         shared
-                            .fallback_cause
+                            .terminal_cause
                             .map(|cause| cause.message().to_string())
                     })
                 {
                     self.native_playback_supported = false;
-                    self.fallback_reason = Some(reason);
+                    self.availability_reason = Some(reason);
                 } else if self.click.enabled {
                     shared.status = TransportStatus::Paused;
                     shared.position_seconds = self.position_seconds;
@@ -1334,10 +1391,10 @@ impl TransportState {
             let shared = runtime.shared.lock().ok()?;
             let reason = shared
                 .terminal_error
-                .map(|code| code.fallback_message().to_string())
+                .map(|code| code.terminal_message().to_string())
                 .or_else(|| {
                     shared
-                        .fallback_cause
+                        .terminal_cause
                         .map(|cause| cause.message().to_string())
                 })?;
             Some((shared.position_seconds, reason))
@@ -1348,7 +1405,7 @@ impl TransportState {
             self.status = TransportStatus::Paused;
             self.started_at = None;
             self.native_playback_supported = false;
-            self.fallback_reason = Some(reason);
+            self.availability_reason = Some(reason);
             self.stop_runtime();
             return self.snapshot();
         }
@@ -1406,7 +1463,7 @@ impl TransportState {
                             shared.underrun_error_pending = false;
                         }
                     }
-                    Err(cause) => mark_runtime_fallback(runtime, cause),
+                    Err(cause) => mark_runtime_terminal(runtime, cause),
                 }
             }
             if let Ok(mut shared) = runtime.shared.lock() {
@@ -1433,16 +1490,17 @@ impl TransportState {
             duration_seconds: self.duration_seconds,
             playback_rate: self.playback_rate,
             native_playback_supported: self.native_playback_supported,
-            fallback_reason: self.fallback_reason.clone(),
+            availability_reason: self.availability_reason.clone(),
             lanes: self.lanes.clone(),
             buffer_health: empty_buffer_health(&self.lanes),
             lease_id: None,
-            generation: (self.generation != 0).then_some(self.generation),
+            generation: self.generation,
             timeline_revision: self
                 .timeline
                 .as_ref()
-                .and_then(|timeline| timeline.lock().ok().map(|state| state.revision())),
-            native_time_us: Some(timeline::native_time_us()),
+                .and_then(|timeline| timeline.lock().ok().map(|state| state.revision()))
+                .unwrap_or(0),
+            native_time_us: timeline::native_time_us(),
         }
     }
 
@@ -1468,24 +1526,12 @@ impl TransportState {
         if std::mem::take(&mut self.fail_next_runtime_start) {
             return Err("injected_runtime_start_failure".to_string());
         }
-        let runtime_finished = self.runtime.as_ref().is_some_and(|runtime| {
-            runtime
-                .audio_thread
-                .as_ref()
-                .is_some_and(JoinHandle::is_finished)
-                || runtime
-                    .reporter_thread
-                    .as_ref()
-                    .is_some_and(JoinHandle::is_finished)
-                || (require_project_runtime
-                    && runtime.worker_threads.iter().any(JoinHandle::is_finished))
-        });
         let runtime_kind_mismatch = require_project_runtime
             && self
                 .runtime
                 .as_ref()
                 .is_some_and(|runtime| runtime.auxiliary_only);
-        if runtime_finished || runtime_kind_mismatch {
+        if runtime_kind_mismatch {
             self.stop_runtime();
         }
         if self.runtime.is_some() {
@@ -1544,10 +1590,30 @@ impl TransportState {
                     DiagnosticSafeCode::RuntimeStartFailure,
                 );
                 self.native_playback_supported = false;
-                self.fallback_reason = Some(error.clone());
+                self.availability_reason = Some(error.clone());
                 Err(error)
             }
         }
+    }
+
+    #[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
+    fn runtime_requires_replacement(&self, require_project_runtime: bool) -> bool {
+        self.runtime.as_ref().is_some_and(|runtime| {
+            let terminal = runtime.shared.lock().ok().is_some_and(|shared| {
+                shared.terminal_error.is_some() || shared.terminal_cause.is_some()
+            });
+            terminal
+                || runtime
+                    .audio_thread
+                    .as_ref()
+                    .is_some_and(JoinHandle::is_finished)
+                || runtime
+                    .reporter_thread
+                    .as_ref()
+                    .is_some_and(JoinHandle::is_finished)
+                || (require_project_runtime
+                    && runtime.worker_threads.iter().any(JoinHandle::is_finished))
+        })
     }
 
     fn stop_runtime(&mut self) {
@@ -1607,7 +1673,7 @@ fn seek_runtime_workers(
 #[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
 fn wait_for_runtime_prebuffer(
     runtime: &PlaybackRuntime,
-) -> Result<(), NativePlaybackFallbackCause> {
+) -> Result<(), NativePlaybackTerminalCause> {
     let started_at = Instant::now();
     loop {
         let (ready, generation) = runtime
@@ -1621,18 +1687,18 @@ fn wait_for_runtime_prebuffer(
         }
         if started_at.elapsed() >= PREBUFFER_TIMEOUT {
             diagnostics::record_safe_code(generation, DiagnosticSafeCode::PrebufferTimeout);
-            return Err(NativePlaybackFallbackCause::PrebufferTimeout);
+            return Err(NativePlaybackTerminalCause::PrebufferTimeout);
         }
         thread::sleep(PREBUFFER_POLL_INTERVAL);
     }
 }
 
 #[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
-fn mark_runtime_fallback(runtime: &PlaybackRuntime, cause: NativePlaybackFallbackCause) {
+fn mark_runtime_terminal(runtime: &PlaybackRuntime, cause: NativePlaybackTerminalCause) {
     if let Ok(mut shared) = runtime.shared.lock() {
         shared.status = TransportStatus::Paused;
         shared.buffering = false;
-        shared.fallback_cause = Some(cause);
+        shared.terminal_cause = Some(cause);
         shared.underrun_error_pending = true;
     }
 }
@@ -1955,10 +2021,10 @@ fn update_underrun_state(shared: &mut PlaybackShared, audible_underrun: bool, fr
         .saturating_add(frame_count.max(1));
     let threshold_frames =
         (shared.sample_rate as f64 * SUSTAINED_UNDERRUN_ERROR_SECONDS).ceil() as usize;
-    if shared.fallback_cause.is_none() && shared.sustained_underrun_frames >= threshold_frames {
+    if shared.terminal_cause.is_none() && shared.sustained_underrun_frames >= threshold_frames {
         shared.status = TransportStatus::Paused;
         shared.buffering = false;
-        shared.fallback_cause = Some(NativePlaybackFallbackCause::SustainedUnderrun);
+        shared.terminal_cause = Some(NativePlaybackTerminalCause::SustainedUnderrun);
         shared.underrun_error_pending = true;
         diagnostics::record_callback_safe_code(
             shared.diagnostics_generation,
@@ -2270,7 +2336,7 @@ fn start_native_runtime(
         duration_seconds,
         playback_rate,
         native_playback_supported: true,
-        fallback_reason: None,
+        availability_reason: None,
         sample_rate,
         channels,
         lanes,
@@ -2282,7 +2348,7 @@ fn start_native_runtime(
         buffering: false,
         sustained_underrun_frames: 0,
         underrun_error_pending: false,
-        fallback_cause: None,
+        terminal_cause: None,
         diagnostics_generation,
         diagnostics_gain_first_change_recorded: false,
         timeline,
@@ -2468,16 +2534,7 @@ where
             },
             move |error| {
                 if let Ok(mut shared) = error_shared.lock() {
-                    let code = output_stream_error_code(&error);
-                    if code == NativeAudioErrorCode::DeviceChanged {
-                        mark_device_changed(&mut shared);
-                    } else {
-                        mark_terminal_runtime_error(
-                            &mut shared,
-                            code,
-                            diagnostic_code_for_output_stream_error(code),
-                        );
-                    }
+                    handle_output_stream_error(&mut shared, &error);
                 }
             },
             None,
@@ -2504,7 +2561,7 @@ fn emit_runtime_events(app: &AppHandle, shared: &Arc<Mutex<PlaybackShared>>) -> 
             }
         }
         let requires_error_handling =
-            shared.terminal_error.is_some() || shared.fallback_cause.is_some();
+            shared.terminal_error.is_some() || shared.terminal_cause.is_some();
         let terminal = (!shared.terminal_reported)
             .then(|| {
                 shared
@@ -2512,8 +2569,8 @@ fn emit_runtime_events(app: &AppHandle, shared: &Arc<Mutex<PlaybackShared>>) -> 
                     .map(NativeAudioErrorCode::safe_code)
                     .or_else(|| {
                         shared
-                            .fallback_cause
-                            .map(NativePlaybackFallbackCause::safe_code)
+                            .terminal_cause
+                            .map(NativePlaybackTerminalCause::safe_code)
                     })
             })
             .flatten();
@@ -2537,6 +2594,9 @@ fn emit_runtime_events(app: &AppHandle, shared: &Arc<Mutex<PlaybackShared>>) -> 
             position_seconds: snapshot.position_seconds,
             duration_seconds: snapshot.duration_seconds,
             state: snapshot.state,
+            generation: snapshot.generation,
+            timeline_revision: snapshot.timeline_revision,
+            native_time_us: snapshot.native_time_us,
         },
     );
     let _ = app.emit(
@@ -2545,6 +2605,9 @@ fn emit_runtime_events(app: &AppHandle, shared: &Arc<Mutex<PlaybackShared>>) -> 
             session_id: snapshot.session_id.clone(),
             state: snapshot.state,
             position_seconds: snapshot.position_seconds,
+            generation: snapshot.generation,
+            timeline_revision: snapshot.timeline_revision,
+            native_time_us: snapshot.native_time_us,
         },
     );
     if ended {
@@ -2564,6 +2627,10 @@ fn emit_runtime_events(app: &AppHandle, shared: &Arc<Mutex<PlaybackShared>>) -> 
             AudioErrorEvent {
                 session_id: snapshot.session_id,
                 code,
+                generation: snapshot.generation,
+                timeline_revision: snapshot.timeline_revision,
+                native_time_us: snapshot.native_time_us,
+                position_seconds: snapshot.position_seconds,
             },
         );
     }
@@ -2579,6 +2646,9 @@ fn emit_runtime_events(app: &AppHandle, shared: &Arc<Mutex<PlaybackShared>>) -> 
                 resource: AudioResource::Output,
                 source: AudioSource::OutputRuntime,
                 generation: reporter.0,
+                timeline_revision: snapshot.timeline_revision,
+                capture_generation: None,
+                position_seconds: snapshot.position_seconds,
                 code,
                 native_time_us: timeline::native_time_us(),
             },
@@ -3505,8 +3575,7 @@ mod tests {
             mic_monitoring_supported: false,
             system_input_volume_supported: false,
             emits_events: Vec::new(),
-            fallback_required: false,
-            fallback_reason: None,
+            availability_reason: None,
         }
     }
 
@@ -3519,8 +3588,15 @@ mod tests {
             mic_monitoring_supported: false,
             system_input_volume_supported: false,
             emits_events: Vec::new(),
-            fallback_required: true,
-            fallback_reason: Some(reason),
+            availability_reason: Some(reason),
+        }
+    }
+
+    fn acquisition_control() -> SessionCommand {
+        SessionCommand {
+            lease_id: Some("project-playback".to_string()),
+            operation_id: Some("prepare-test".to_string()),
+            ..Default::default()
         }
     }
 
@@ -3565,7 +3641,7 @@ mod tests {
             duration_seconds: 10.0,
             playback_rate: 1.0,
             native_playback_supported: true,
-            fallback_reason: None,
+            availability_reason: None,
             sample_rate,
             channels,
             lanes: vec![stream_lane("lane", ring, target_gain)],
@@ -3584,7 +3660,7 @@ mod tests {
             buffering: false,
             sustained_underrun_frames: 0,
             underrun_error_pending: false,
-            fallback_cause: None,
+            terminal_cause: None,
             diagnostics_generation: 0,
             diagnostics_gain_first_change_recorded: false,
             timeline: Arc::new(Mutex::new(timeline)),
@@ -3724,58 +3800,139 @@ mod tests {
             (
                 ErrorKind::DeviceChanged,
                 NativeAudioErrorCode::DeviceChanged,
+                DiagnosticOutputStreamErrorKind::DeviceChanged,
             ),
             (
                 ErrorKind::DeviceNotAvailable,
                 NativeAudioErrorCode::DeviceNotAvailable,
+                DiagnosticOutputStreamErrorKind::DeviceNotAvailable,
             ),
             (
                 ErrorKind::StreamInvalidated,
                 NativeAudioErrorCode::StreamInvalidated,
+                DiagnosticOutputStreamErrorKind::StreamInvalidated,
             ),
             (
                 ErrorKind::DeviceBusy,
                 NativeAudioErrorCode::OutputStreamFailure,
+                DiagnosticOutputStreamErrorKind::DeviceBusy,
             ),
             (
                 ErrorKind::HostUnavailable,
                 NativeAudioErrorCode::OutputStreamFailure,
+                DiagnosticOutputStreamErrorKind::HostUnavailable,
             ),
             (
                 ErrorKind::InvalidInput,
                 NativeAudioErrorCode::OutputStreamFailure,
+                DiagnosticOutputStreamErrorKind::InvalidInput,
             ),
             (
                 ErrorKind::PermissionDenied,
                 NativeAudioErrorCode::OutputStreamFailure,
+                DiagnosticOutputStreamErrorKind::PermissionDenied,
             ),
             (
                 ErrorKind::RealtimeDenied,
                 NativeAudioErrorCode::OutputStreamFailure,
+                DiagnosticOutputStreamErrorKind::RealtimeDenied,
             ),
             (
                 ErrorKind::ResourceExhausted,
                 NativeAudioErrorCode::OutputStreamFailure,
+                DiagnosticOutputStreamErrorKind::ResourceExhausted,
             ),
             (
                 ErrorKind::UnsupportedConfig,
                 NativeAudioErrorCode::OutputStreamFailure,
+                DiagnosticOutputStreamErrorKind::UnsupportedConfig,
             ),
             (
                 ErrorKind::UnsupportedOperation,
                 NativeAudioErrorCode::OutputStreamFailure,
+                DiagnosticOutputStreamErrorKind::UnsupportedOperation,
             ),
-            (ErrorKind::Xrun, NativeAudioErrorCode::OutputStreamFailure),
+            (
+                ErrorKind::Xrun,
+                NativeAudioErrorCode::OutputStreamFailure,
+                DiagnosticOutputStreamErrorKind::Xrun,
+            ),
             (
                 ErrorKind::BackendError,
                 NativeAudioErrorCode::OutputStreamFailure,
+                DiagnosticOutputStreamErrorKind::BackendError,
             ),
-            (ErrorKind::Other, NativeAudioErrorCode::OutputStreamFailure),
+            (
+                ErrorKind::Other,
+                NativeAudioErrorCode::OutputStreamFailure,
+                DiagnosticOutputStreamErrorKind::Other,
+            ),
         ];
 
-        for (kind, expected) in classified {
-            assert_eq!(output_stream_error_code(&cpal::Error::new(kind)), expected);
+        for (kind, expected_code, expected_diagnostic) in classified {
+            let error = cpal::Error::new(kind);
+            assert_eq!(output_stream_error_code(&error), expected_code);
+            assert_eq!(
+                diagnostic_output_stream_error_kind(&error),
+                expected_diagnostic
+            );
         }
+    }
+
+    #[test]
+    #[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
+    fn linux_xrun_policy_preserves_playing_runtime_until_a_fatal_output_error() {
+        let mut shared =
+            shared_with_lane(Arc::new(Mutex::new(RingBuffer::new(1_000))), 1_000, 1, 1.0);
+        let session_id = shared.session_id.clone();
+        let generation = shared.generation;
+
+        handle_output_stream_error_with_policy(
+            &mut shared,
+            &cpal::Error::new(ErrorKind::Xrun),
+            true,
+        );
+
+        assert_eq!(shared.session_id, session_id);
+        assert_eq!(shared.generation, generation);
+        assert_eq!(shared.status, TransportStatus::Playing);
+        assert_eq!(shared.error_pending, None);
+        assert_eq!(shared.terminal_error, None);
+
+        handle_output_stream_error_with_policy(
+            &mut shared,
+            &cpal::Error::new(ErrorKind::BackendError),
+            true,
+        );
+        handle_output_stream_error_with_policy(
+            &mut shared,
+            &cpal::Error::new(ErrorKind::DeviceNotAvailable),
+            true,
+        );
+
+        assert_eq!(shared.status, TransportStatus::Paused);
+        assert_eq!(
+            shared.error_pending,
+            Some(NativeAudioErrorCode::OutputStreamFailure)
+        );
+        assert_eq!(
+            shared.terminal_error,
+            Some(NativeAudioErrorCode::OutputStreamFailure)
+        );
+
+        let mut advisory =
+            shared_with_lane(Arc::new(Mutex::new(RingBuffer::new(1_000))), 1_000, 1, 1.0);
+        handle_output_stream_error_with_policy(
+            &mut advisory,
+            &cpal::Error::new(ErrorKind::DeviceChanged),
+            true,
+        );
+        assert_eq!(advisory.status, TransportStatus::Playing);
+        assert_eq!(advisory.terminal_error, None);
+        assert_eq!(
+            advisory.error_pending,
+            Some(NativeAudioErrorCode::DeviceChanged)
+        );
     }
 
     #[test]
@@ -3783,13 +3940,17 @@ mod tests {
         let event = AudioErrorEvent {
             session_id: Some("session-123".to_string()),
             code: NativeAudioErrorCode::StreamInvalidated,
+            generation: 4,
+            timeline_revision: 7,
+            native_time_us: 99,
+            position_seconds: 1.25,
         };
 
         let serialized = serde_json::to_string(&event).expect("serialize event");
 
         assert_eq!(
             serialized,
-            r#"{"sessionId":"session-123","code":"stream_invalidated"}"#
+            r#"{"sessionId":"session-123","code":"stream_invalidated","generation":4,"timelineRevision":7,"nativeTimeUs":99,"positionSeconds":1.25}"#
         );
         assert!(!serialized.contains("message"));
         assert!(!serialized.contains("/private/audio.wav"));
@@ -3818,7 +3979,7 @@ mod tests {
 
         let mut shared =
             shared_with_lane(Arc::new(Mutex::new(RingBuffer::new(1_000))), 1_000, 1, 1.0);
-        shared.fallback_cause = Some(NativePlaybackFallbackCause::SustainedUnderrun);
+        shared.terminal_cause = Some(NativePlaybackTerminalCause::SustainedUnderrun);
         shared.underrun_error_pending = true;
 
         mark_device_changed(&mut shared);
@@ -3854,7 +4015,7 @@ mod tests {
         );
 
         let requires_error_handling =
-            shared.terminal_error.is_some() || shared.fallback_cause.is_some();
+            shared.terminal_error.is_some() || shared.terminal_cause.is_some();
 
         assert!(!should_emit_ended(
             shared.ended_pending,
@@ -3905,7 +4066,7 @@ mod tests {
                 duration_seconds: Some(30.0),
                 playback_rate: Some(1.0),
                 lanes: Vec::new(),
-                control: SessionCommand::default(),
+                control: acquisition_control(),
                 owner: None,
             },
             Vec::new(),
@@ -3931,7 +4092,7 @@ mod tests {
                 duration_seconds: Some(30.0),
                 playback_rate: Some(1.0),
                 lanes: Vec::new(),
-                control: SessionCommand::default(),
+                control: acquisition_control(),
                 owner: None,
             },
             Vec::new(),
@@ -4000,7 +4161,7 @@ mod tests {
         assert_eq!(error, "Native playback output failed.");
         assert!(!snapshot.native_playback_supported);
         assert_eq!(
-            snapshot.fallback_reason.as_deref(),
+            snapshot.availability_reason.as_deref(),
             Some("Native playback output failed.")
         );
         assert_eq!(snapshot.state, "paused");
@@ -4031,12 +4192,12 @@ mod tests {
 
     #[test]
     #[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
-    fn stop_releases_failed_runtime_and_preserves_fallback_handoff_state() {
+    fn stop_releases_failed_runtime_and_preserves_terminal_handoff_state() {
         let mut shared =
             shared_with_lane(Arc::new(Mutex::new(RingBuffer::new(1_000))), 1_000, 1, 1.0);
         shared.position_seconds = 4.25;
         shared.status = TransportStatus::Paused;
-        shared.fallback_cause = Some(NativePlaybackFallbackCause::SustainedUnderrun);
+        shared.terminal_cause = Some(NativePlaybackTerminalCause::SustainedUnderrun);
         let (audio_stop_sender, _audio_stop_receiver) = mpsc::channel();
         let (reporter_stop_sender, _reporter_stop_receiver) = mpsc::channel();
         let mut state = TransportState::default();
@@ -4061,8 +4222,8 @@ mod tests {
         assert_seconds_close(snapshot.position_seconds, 4.25);
         assert!(!snapshot.native_playback_supported);
         assert_eq!(
-            snapshot.fallback_reason.as_deref(),
-            Some("Native playback underrun persisted; falling back to Web Audio.")
+            snapshot.availability_reason.as_deref(),
+            Some("Native playback stopped after sustained underruns.")
         );
     }
 
@@ -4145,7 +4306,7 @@ mod tests {
                 duration_seconds: Some(30.0),
                 playback_rate: Some(1.0),
                 lanes: Vec::new(),
-                control: SessionCommand::default(),
+                control: acquisition_control(),
                 owner: None,
             },
             Vec::new(),
@@ -4170,7 +4331,7 @@ mod tests {
                 duration_seconds: Some(30.0),
                 playback_rate: Some(1.0),
                 lanes: Vec::new(),
-                control: SessionCommand::default(),
+                control: acquisition_control(),
                 owner: None,
             },
             Vec::new(),
@@ -4195,7 +4356,7 @@ mod tests {
                 duration_seconds: Some(30.0),
                 playback_rate: Some(1.0),
                 lanes: Vec::new(),
-                control: SessionCommand::default(),
+                control: acquisition_control(),
                 owner: None,
             },
             Vec::new(),
@@ -4267,7 +4428,7 @@ mod tests {
                 duration_seconds: Some(30.0),
                 playback_rate: Some(0.75),
                 lanes: Vec::new(),
-                control: SessionCommand::default(),
+                control: acquisition_control(),
                 owner: None,
             },
             Vec::new(),
@@ -4275,7 +4436,7 @@ mod tests {
         );
 
         assert!(session.native_playback_supported);
-        assert_eq!(session.fallback_reason.as_deref(), None);
+        assert_eq!(session.availability_reason.as_deref(), None);
     }
 
     #[test]
@@ -4288,7 +4449,7 @@ mod tests {
                 duration_seconds: Some(30.0),
                 playback_rate: Some(1.0),
                 lanes: Vec::new(),
-                control: SessionCommand::default(),
+                control: acquisition_control(),
                 owner: None,
             },
             Vec::new(),
@@ -4312,7 +4473,7 @@ mod tests {
                 duration_seconds: Some(30.0),
                 playback_rate: Some(1.0),
                 lanes: Vec::new(),
-                control: SessionCommand::default(),
+                control: acquisition_control(),
                 owner: None,
             },
             Vec::new(),
@@ -4382,7 +4543,7 @@ mod tests {
         assert_eq!(shared.status, TransportStatus::Stopped);
         assert!(shared.ended_pending);
         assert_seconds_close(shared.position_seconds, 0.0);
-        assert!(shared.fallback_cause.is_none());
+        assert!(shared.terminal_cause.is_none());
     }
 
     #[test]
@@ -4425,7 +4586,7 @@ mod tests {
                 duration_seconds: Some(30.0),
                 playback_rate: Some(1.0),
                 lanes: Vec::new(),
-                control: SessionCommand::default(),
+                control: acquisition_control(),
                 owner: None,
             },
             Vec::new(),
@@ -4462,7 +4623,7 @@ mod tests {
                 duration_seconds: Some(30.0),
                 playback_rate: Some(1.0),
                 lanes: Vec::new(),
-                control: SessionCommand::default(),
+                control: acquisition_control(),
                 owner: None,
             },
             Vec::new(),
@@ -4500,7 +4661,7 @@ mod tests {
                 duration_seconds: Some(loop_end),
                 playback_rate: Some(1.0),
                 lanes: Vec::new(),
-                control: SessionCommand::default(),
+                control: acquisition_control(),
                 owner: None,
             },
             Vec::new(),
@@ -4702,7 +4863,7 @@ mod tests {
     }
 
     #[test]
-    fn sustained_underrun_marks_native_fallback_without_advancing() {
+    fn sustained_underrun_marks_native_terminal_without_advancing() {
         let ring = Arc::new(Mutex::new(RingBuffer::new(1_000)));
         let mut shared = shared_with_lane(ring, 10, 1, 1.0);
         let mut output = vec![0.0; 5];
@@ -4712,13 +4873,13 @@ mod tests {
 
         assert_eq!(shared.status, TransportStatus::Paused);
         assert_eq!(
-            shared.fallback_cause,
-            Some(NativePlaybackFallbackCause::SustainedUnderrun)
+            shared.terminal_cause,
+            Some(NativePlaybackTerminalCause::SustainedUnderrun)
         );
         assert!(!snapshot.native_playback_supported);
         assert_eq!(
-            snapshot.fallback_reason.as_deref(),
-            Some("Native playback underrun persisted; falling back to Web Audio.")
+            snapshot.availability_reason.as_deref(),
+            Some("Native playback stopped after sustained underruns.")
         );
         assert_eq!(shared.position_seconds, 0.0);
     }
@@ -4767,12 +4928,7 @@ mod tests {
             .apply_standalone_metronome(&standalone_request(true, "start", None, None))
             .unwrap();
         let duplicate = transport
-            .apply_standalone_metronome(&standalone_request(
-                true,
-                "start",
-                Some(started.generation),
-                Some(started.revision),
-            ))
+            .apply_standalone_metronome(&standalone_request(true, "start", None, None))
             .unwrap();
         assert_eq!(duplicate.revision, started.revision);
         let updated = transport
@@ -4826,6 +4982,28 @@ mod tests {
     }
 
     #[test]
+    fn standalone_metronome_rejects_missing_or_partial_control() {
+        let mut transport = TransportState::default();
+        let mut missing = standalone_request(true, "start", None, None);
+        missing.control.lease_id = None;
+        assert_eq!(
+            transport
+                .set_standalone_metronome_inner(None, missing, capabilities())
+                .unwrap_err(),
+            "missing_session_control"
+        );
+
+        let partial = standalone_request(true, "update", Some(1), None);
+        assert_eq!(
+            transport
+                .set_standalone_metronome_inner(None, partial, capabilities())
+                .unwrap_err(),
+            "missing_session_control"
+        );
+        assert!(!transport.click.enabled);
+    }
+
+    #[test]
     #[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
     fn standalone_enable_rolls_back_control_when_runtime_start_fails() {
         let mut transport = TransportState::default();
@@ -4870,6 +5048,129 @@ mod tests {
 
         assert_eq!(transport.generation, 2);
         assert_eq!(standalone.generation, 1);
+    }
+
+    #[test]
+    #[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
+    fn standalone_rejects_acquisition_while_active() {
+        let mut transport = TransportState::default();
+        let started = transport
+            .set_standalone_metronome_inner(
+                None,
+                standalone_request(true, "start", None, None),
+                capabilities(),
+            )
+            .unwrap();
+
+        assert_eq!(
+            transport
+                .set_standalone_metronome_inner(
+                    None,
+                    standalone_request(true, "stale-start", None, None),
+                    capabilities(),
+                )
+                .unwrap_err(),
+            "session_already_active"
+        );
+        assert_eq!(
+            transport.standalone_metronome.generation,
+            started.generation
+        );
+        assert_eq!(transport.standalone_metronome.revision, started.revision);
+    }
+
+    #[test]
+    #[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
+    fn standalone_terminal_retry_reaps_runtime_and_advances_generation() {
+        let mut transport = TransportState::default();
+        let started = transport
+            .set_standalone_metronome_inner(
+                None,
+                standalone_request(true, "start", None, None),
+                capabilities(),
+            )
+            .unwrap();
+        transport.install_test_auxiliary_runtime();
+        let failed_runtime = transport.runtime.as_ref().unwrap().shared.clone();
+        failed_runtime.lock().unwrap().terminal_error =
+            Some(NativeAudioErrorCode::OutputStreamFailure);
+
+        let retried = transport
+            .set_standalone_metronome_inner(
+                None,
+                standalone_request(true, "retry", None, None),
+                capabilities(),
+            )
+            .unwrap();
+
+        assert!(retried.enabled);
+        assert!(retried.generation > started.generation);
+        assert!(transport.runtime.is_none());
+        transport.install_test_auxiliary_runtime();
+        let fresh_runtime = transport.runtime.as_ref().unwrap();
+        assert!(!Arc::ptr_eq(&failed_runtime, &fresh_runtime.shared));
+        let shared = fresh_runtime.shared.lock().unwrap();
+        assert_eq!(shared.generation, retried.generation);
+        assert!(shared.terminal_error.is_none());
+        assert!(shared.native_playback_supported);
+    }
+
+    #[test]
+    #[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
+    fn standalone_stop_rejects_delayed_acquisition_without_restarting_audio() {
+        let mut transport = TransportState::default();
+        let started = transport
+            .set_standalone_metronome_inner(
+                None,
+                standalone_request(true, "start", None, None),
+                capabilities(),
+            )
+            .unwrap();
+        let stopped = transport
+            .set_standalone_metronome_inner(
+                None,
+                standalone_request(
+                    false,
+                    "stop",
+                    Some(started.generation),
+                    Some(started.revision),
+                ),
+                capabilities(),
+            )
+            .unwrap();
+        assert!(!stopped.enabled);
+
+        assert_eq!(
+            transport
+                .set_standalone_metronome_inner(
+                    None,
+                    standalone_request(true, "delayed-start", None, None),
+                    capabilities(),
+                )
+                .unwrap_err(),
+            "session_already_active"
+        );
+        assert!(!transport.click.enabled);
+        assert!(transport.runtime.is_none());
+        assert_eq!(
+            transport.standalone_metronome.generation,
+            stopped.generation
+        );
+
+        let restarted = transport
+            .set_standalone_metronome_inner(
+                None,
+                standalone_request(
+                    true,
+                    "restart",
+                    Some(stopped.generation),
+                    Some(stopped.revision),
+                ),
+                capabilities(),
+            )
+            .expect("correlated explicit restart remains valid");
+        assert!(restarted.enabled);
+        assert!(restarted.generation > stopped.generation);
     }
 
     #[test]
@@ -4978,7 +5279,7 @@ mod tests {
                 duration_seconds: Some(10.0),
                 playback_rate: Some(1.0),
                 lanes: Vec::new(),
-                control: SessionCommand::default(),
+                control: acquisition_control(),
                 owner: None,
             },
             Vec::new(),

--- a/apps/desktop/src/App.mobile.test.tsx
+++ b/apps/desktop/src/App.mobile.test.tsx
@@ -887,13 +887,13 @@ describe("Desktop app mobile capability gates", () => {
     await waitFor(() => expect(chordScrollTo).toHaveBeenCalled());
   });
 
-  it("keeps mobile fallback status beside an interactive scrubber and clocks", async () => {
+  it("keeps mobile Web Audio status beside an interactive scrubber and clocks", async () => {
     enableAndroidRuntime();
     renderApp(["/projects/proj_123"]);
 
     fireEvent.click(await screen.findByRole("tab", { name: "Playback" }));
     act(() => {
-      markPlaybackStarting("web-fallback");
+      markPlaybackStarting("web");
       updateBrowserWakeLockStatus({
         phase: "failed",
         backend: "browser-screen-wake-lock",
@@ -902,9 +902,7 @@ describe("Desktop app mobile capability gates", () => {
       });
     });
 
-    const status = await screen.findByText(
-      "Native playback unavailable. Starting Web Audio fallback…",
-    );
+    const status = await screen.findByText("Starting playback…");
     const scrubber = screen.getByRole("slider", { name: "Playback position" });
     const statusStack = status.closest<HTMLElement>(".transport__status-stack");
     const scrubberLabel = scrubber.closest("label");

--- a/apps/desktop/src/App.project-media-controls.test.tsx
+++ b/apps/desktop/src/App.project-media-controls.test.tsx
@@ -10,6 +10,7 @@ import {
   emitMockNativePlaybackPosition,
   emitMockSystemMediaPlaybackControl,
   findAudioByArtifactId,
+  getMockAudioContexts,
   getMockInvoke,
   mockEnsureWebMediaTransport,
   getMockMediaSession,
@@ -109,16 +110,6 @@ function expectNoNativePlaybackCommandCalls() {
   expect(invokeCalls("audio_set_lanes")).toHaveLength(0);
 }
 
-function invokeCallIndexAfter(
-  startIndex: number,
-  command: string,
-  predicate: (args: unknown) => boolean = () => true,
-) {
-  return getMockInvoke().mock.calls.findIndex(
-    ([name, args], index) => index > startIndex && name === command && predicate(args),
-  );
-}
-
 async function waitForWebOwnerControls() {
   await waitFor(() => {
     expect(hasSystemMediaPlaybackState("playing")).toBe(true);
@@ -140,8 +131,7 @@ async function startForcedWebPlayback(user: ReturnType<typeof userEvent.setup>) 
   setMockNativeAudioState({
     capabilities: {
       nativePlaybackSupported: true,
-      fallbackRequired: false,
-      fallbackReason: null,
+      availabilityReason: null,
       backend: "desktop-cpal",
     },
   });
@@ -301,11 +291,10 @@ describe("Desktop app project media controls", () => {
     setMockNativeAudioState({
       capabilities: {
         nativePlaybackSupported: true,
-        fallbackRequired: false,
-        fallbackReason: null,
+        availabilityReason: null,
         backend: "desktop-cpal",
       },
-      stopFallbackReason: "Native output stopped after an invalidated stream.",
+      stopError: "Native output stopped after an invalidated stream.",
     });
     renderApp(["/projects/proj_123"]);
 
@@ -338,8 +327,7 @@ describe("Desktop app project media controls", () => {
     setMockNativeAudioState({
       capabilities: {
         nativePlaybackSupported: true,
-        fallbackRequired: false,
-        fallbackReason: null,
+        availabilityReason: null,
         backend: "desktop-cpal",
       },
     });
@@ -367,7 +355,7 @@ describe("Desktop app project media controls", () => {
     restoreTauriRuntime();
   });
 
-  it("waits for lazy transport before exposing native fallback media sources", async () => {
+  it("waits for lazy transport before exposing forced Web media sources", async () => {
     vi.stubEnv("VITE_TUNEFORGE_FORCE_WEB_AUDIO", "1");
     const transport = deferWebMediaTransport();
     const restoreTauriRuntime = mockTauriRuntime();
@@ -375,11 +363,10 @@ describe("Desktop app project media controls", () => {
     setMockNativeAudioState({
       capabilities: {
         nativePlaybackSupported: true,
-        fallbackRequired: false,
-        fallbackReason: null,
+        availabilityReason: null,
         backend: "desktop-cpal",
       },
-      playFallbackReason: "Native playback could not start.",
+      playError: "Native playback could not start.",
     });
     renderApp(["/projects/proj_123"]);
 
@@ -442,8 +429,7 @@ describe("Desktop app project media controls", () => {
     setMockNativeAudioState({
       capabilities: {
         nativePlaybackSupported: true,
-        fallbackRequired: false,
-        fallbackReason: null,
+        availabilityReason: null,
         backend: "desktop-cpal",
       },
     });
@@ -482,8 +468,7 @@ describe("Desktop app project media controls", () => {
     setMockNativeAudioState({
       capabilities: {
         nativePlaybackSupported: true,
-        fallbackRequired: false,
-        fallbackReason: null,
+        availabilityReason: null,
         backend: "desktop-cpal",
       },
     });
@@ -509,15 +494,14 @@ describe("Desktop app project media controls", () => {
     restoreTauriRuntime();
   });
 
-  it("routes late system media listeners through the Web Audio owner after fallback", async () => {
+  it("routes late system Play through one fresh native attempt after a terminal error", async () => {
     deferNextMockSystemMediaControlListen();
     const restoreTauriRuntime = mockTauriRuntime();
     const user = userEvent.setup();
     setMockNativeAudioState({
       capabilities: {
         nativePlaybackSupported: true,
-        fallbackRequired: false,
-        fallbackReason: null,
+        availabilityReason: null,
         backend: "desktop-cpal",
       },
     });
@@ -537,33 +521,28 @@ describe("Desktop app project media controls", () => {
         state: "playing",
       });
     });
-    vi.stubEnv("VITE_TUNEFORGE_FORCE_WEB_AUDIO", "1");
     act(() => {
       emitMockNativePlaybackError({
         sessionId,
         code: "output_stream_failure",
+        positionSeconds: 21,
       });
     });
 
-    const sourceAudio = await waitFor(() => findAudioByArtifactId("art_source"));
-    markAudioReady(sourceAudio);
-    await waitForWebOwnerControls();
-
-    const nativePauseCount = invokeCalls("audio_pause").length;
-    act(() => {
-      emitMockSystemMediaPlaybackControl({ action: "pause" });
-    });
     await waitFor(() => expect(screen.getByRole("button", { name: "Play playback" })).toBeInTheDocument());
-    expect(invokeCalls("audio_pause")).toHaveLength(nativePauseCount);
+    expect(document.querySelector("audio[src]")).toBeNull();
+    expect(readPlaybackLiveDiagnostics()).toMatchObject({ currentState: "error", currentPath: "none" });
 
     resolveDeferredMockSystemMediaControlListen();
     await Promise.resolve();
 
+    const nativePlayCount = invokeCalls("audio_play").length;
     act(() => {
       emitMockSystemMediaPlaybackControl({ action: "play" });
     });
     await waitFor(() => expect(screen.getByRole("button", { name: "Pause playback" })).toBeInTheDocument());
-    expect(invokeCalls("audio_pause")).toHaveLength(nativePauseCount);
+    expect(invokeCalls("audio_play")).toHaveLength(nativePlayCount + 1);
+    expect(readPlaybackLiveDiagnostics()).toMatchObject({ currentState: "playing", currentPath: "native" });
     restoreTauriRuntime();
   });
 
@@ -574,11 +553,10 @@ describe("Desktop app project media controls", () => {
     setMockNativeAudioState({
       capabilities: {
         nativePlaybackSupported: true,
-        fallbackRequired: false,
-        fallbackReason: null,
+        availabilityReason: null,
         backend: "desktop-cpal",
       },
-      playFallbackReason: "Native playback could not start.",
+      playError: "Native playback could not start.",
     });
     renderApp(["/projects/proj_123"]);
 
@@ -597,14 +575,13 @@ describe("Desktop app project media controls", () => {
     restoreTauriRuntime();
   });
 
-  it("does not activate Web Audio controls when native release fails during runtime fallback", async () => {
+  it("does not activate Web Audio controls when native release fails after a terminal error", async () => {
     const restoreTauriRuntime = mockTauriRuntime();
     const user = userEvent.setup();
     setMockNativeAudioState({
       capabilities: {
         nativePlaybackSupported: true,
-        fallbackRequired: false,
-        fallbackReason: null,
+        availabilityReason: null,
         backend: "desktop-cpal",
       },
     });
@@ -621,6 +598,7 @@ describe("Desktop app project media controls", () => {
       emitMockNativePlaybackError({
         sessionId,
         code: "output_stream_failure",
+        positionSeconds: 42,
       });
     });
 
@@ -631,14 +609,13 @@ describe("Desktop app project media controls", () => {
     restoreTauriRuntime();
   });
 
-  it("clears native controls before activating Web Audio controls on runtime fallback", async () => {
+  it("clears native controls and freezes position after a runtime error", async () => {
     const restoreTauriRuntime = mockTauriRuntime();
     const user = userEvent.setup();
     setMockNativeAudioState({
       capabilities: {
         nativePlaybackSupported: true,
-        fallbackRequired: false,
-        fallbackReason: null,
+        availabilityReason: null,
         backend: "desktop-cpal",
       },
     });
@@ -661,15 +638,15 @@ describe("Desktop app project media controls", () => {
     await waitFor(() => expect(screen.getByLabelText("Playback position")).toHaveValue("42"));
 
     const releaseCount = nativePowerProtectionCallCount(false);
-    vi.stubEnv("VITE_TUNEFORGE_FORCE_WEB_AUDIO", "1");
     act(() => {
       emitMockNativePlaybackError({
         sessionId,
         code: "output_stream_failure",
+        positionSeconds: 42,
       });
     });
     expect(readPlaybackLiveDiagnostics()).toMatchObject({
-      currentState: "starting",
+      currentState: "error",
       currentPath: "none",
       nativeSessionLaneCount: null,
       nativeBufferHealth: [],
@@ -682,18 +659,9 @@ describe("Desktop app project media controls", () => {
       expect(invokeCalls("system_media_clear_state").length).toBeGreaterThan(0);
     });
 
-    const sourceAudio = await waitFor(() => findAudioByArtifactId("art_source"));
-    markAudioReady(sourceAudio);
-    await waitFor(() => expect(screen.getByRole("button", { name: "Pause playback" })).toBeInTheDocument());
-    await waitFor(() => expect(sourceAudio.currentTime).toBeCloseTo(42, 3));
-    await waitForWebOwnerControls();
-    const clearIndex = invokeCallIndexAfter(0, "system_media_clear_state");
-    expect(clearIndex).toBeGreaterThan(-1);
-    const webUpdateIndex = invokeCallIndexAfter(clearIndex, "system_media_update_state", (args) => {
-      const payload = (args as { payload?: { playbackState?: string } } | undefined)?.payload;
-      return payload?.playbackState === "playing";
-    });
-    expect(webUpdateIndex).toBeGreaterThan(clearIndex);
+    expect(screen.getByLabelText("Playback position")).toHaveValue("42");
+    expect(document.querySelector("audio[src]")).toBeNull();
+    expect(getMockAudioContexts()).toHaveLength(0);
     restoreTauriRuntime();
   });
 
@@ -703,8 +671,7 @@ describe("Desktop app project media controls", () => {
     setMockNativeAudioState({
       capabilities: {
         nativePlaybackSupported: true,
-        fallbackRequired: false,
-        fallbackReason: null,
+        availabilityReason: null,
         backend: "desktop-cpal",
       },
     });
@@ -734,14 +701,13 @@ describe("Desktop app project media controls", () => {
     restoreTauriRuntime();
   });
 
-  it("prepares once on the first explicit Play after a terminal event", async () => {
+  it("freezes native playback on a current terminal and retries only after explicit Play", async () => {
     const restoreTauriRuntime = mockTauriRuntime();
     const user = userEvent.setup();
     setMockNativeAudioState({
       capabilities: {
         nativePlaybackSupported: true,
-        fallbackRequired: false,
-        fallbackReason: null,
+        availabilityReason: null,
         backend: "desktop-cpal",
       },
     });
@@ -751,28 +717,73 @@ describe("Desktop app project media controls", () => {
     await openPlaybackWorkspace(user);
     await user.click(screen.getByRole("button", { name: "Play playback" }));
     await waitForNativeControls();
+    const sessionId = latestNativeSessionId();
+    act(() => emitMockNativePlaybackPosition({
+      sessionId,
+      positionSeconds: 42,
+      durationSeconds: 182,
+      state: "playing",
+    }));
+    await waitFor(() => expect(screen.getByLabelText("Playback position")).toHaveValue("42"));
     const nativePlayCount = invokeCalls("audio_play").length;
     const prepareCount = invokeCalls("audio_prepare_session").length;
 
-    await user.click(screen.getByRole("button", { name: "Pause playback" }));
-    await waitFor(() =>
-      expect(screen.getByRole("button", { name: "Play playback" })).toBeInTheDocument(),
-    );
+    act(() => emitMockNativeAudioTerminal({
+      resource: "capture",
+      source: "capture_runtime",
+      generation: 1,
+      captureGeneration: 1,
+      positionSeconds: 9,
+      code: "capture_stream_failure",
+      nativeTimeUs: 9,
+    }));
+    act(() => emitMockNativeAudioTerminal({
+      resource: "output",
+      source: "output_runtime",
+      generation: 2,
+      positionSeconds: 9,
+      code: "output_stream_failure",
+      nativeTimeUs: 9,
+    }));
+    expect(screen.getByRole("button", { name: "Pause playback" })).toBeInTheDocument();
+    expect(screen.getByLabelText("Playback position")).toHaveValue("42");
+
     act(() => {
       emitMockNativeAudioTerminal({
         resource: "output",
         source: "output_runtime",
         generation: 1,
+        positionSeconds: 42,
         code: "output_stream_failure",
         nativeTimeUs: 10,
       });
     });
 
+    expect(screen.getByRole("button", { name: "Play playback" })).toBeInTheDocument();
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      "Playback stopped. Check your audio output, then press Play to retry.",
+    );
     expect(readPlaybackLiveDiagnostics()).toMatchObject({
       currentState: "error",
       currentPath: "none",
       nativeSessionLaneCount: null,
     });
+    expect(screen.getByLabelText("Playback position")).toHaveValue("42");
+    expect(invokeCalls("audio_play")).toHaveLength(nativePlayCount);
+    expect(invokeCalls("audio_prepare_session")).toHaveLength(prepareCount);
+    expect(document.querySelector("audio[src]")).toBeNull();
+    expect(getMockAudioContexts()).toHaveLength(0);
+    expect(mockEnsureWebMediaTransport).not.toHaveBeenCalled();
+
+    act(() => emitMockNativeAudioTerminal({
+      resource: "output",
+      source: "output_runtime",
+      generation: 1,
+      positionSeconds: 9,
+      code: "output_stream_failure",
+      nativeTimeUs: 11,
+    }));
+    expect(screen.getByLabelText("Playback position")).toHaveValue("42");
     expect(invokeCalls("audio_play")).toHaveLength(nativePlayCount);
 
     await user.click(screen.getByRole("button", { name: "Play playback" }));
@@ -784,6 +795,68 @@ describe("Desktop app project media controls", () => {
       currentPath: "native",
     });
     restoreTauriRuntime();
+  });
+
+  it("keeps a terminal state when an in-flight native Play completes late", async () => {
+    const restoreTauriRuntime = mockTauriRuntime();
+    const mockInvoke = getMockInvoke();
+    const defaultInvoke = mockInvoke.getMockImplementation();
+    if (!defaultInvoke) {
+      throw new Error("Mock invoke implementation was not installed.");
+    }
+    let releaseNativePlay!: () => void;
+    const nativePlayGate = new Promise<void>((resolve) => {
+      releaseNativePlay = resolve;
+    });
+    mockInvoke.mockImplementation(async (command: string, args?: Record<string, unknown>) => {
+      if (command === "audio_play") {
+        await nativePlayGate;
+      }
+      return defaultInvoke(command, args);
+    });
+
+    try {
+      setMockNativeAudioState({ capabilities: {
+        nativePlaybackSupported: true, availabilityReason: null, backend: "desktop-cpal",
+      } });
+      renderApp(["/projects/proj_123"]);
+      expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
+      await openPlaybackWorkspace(userEvent.setup());
+      fireEvent.click(screen.getByRole("button", { name: "Play playback" }));
+      await waitFor(() => expect(invokeCalls("audio_play")).toHaveLength(1));
+      expect(readPlaybackLiveDiagnostics()).toMatchObject({ currentState: "starting" });
+
+      act(() => emitMockNativeAudioTerminal({
+        resource: "output",
+        source: "output_runtime",
+        generation: 1,
+        timelineRevision: 1,
+        positionSeconds: 17,
+        code: "output_stream_failure",
+        nativeTimeUs: 10,
+      }));
+      expect(screen.getByRole("button", { name: "Play playback" })).toBeInTheDocument();
+      expect(screen.getByLabelText("Playback position")).toHaveValue("17");
+      expect(readPlaybackLiveDiagnostics()).toMatchObject({ currentState: "error", currentPath: "none" });
+
+      await act(async () => {
+        releaseNativePlay();
+        await nativePlayGate;
+      });
+      await waitFor(() => expect(readPlaybackLiveDiagnostics()).toMatchObject({
+        currentState: "error", currentPath: "none",
+      }));
+      expect(screen.getByRole("button", { name: "Play playback" })).toBeInTheDocument();
+      expect(screen.getByLabelText("Playback position")).toHaveValue("17");
+      expect(invokeCalls("audio_play")).toHaveLength(1);
+      expect(document.querySelector("audio[src]")).toBeNull();
+      expect(getMockAudioContexts()).toHaveLength(0);
+      expect(mockEnsureWebMediaTransport).not.toHaveBeenCalled();
+    } finally {
+      releaseNativePlay();
+      mockInvoke.mockImplementation(defaultInvoke);
+      restoreTauriRuntime();
+    }
   });
 
   it("retries a failed native play only after another explicit Play", async () => {
@@ -807,8 +880,7 @@ describe("Desktop app project media controls", () => {
       setMockNativeAudioState({
         capabilities: {
           nativePlaybackSupported: true,
-          fallbackRequired: false,
-          fallbackReason: null,
+          availabilityReason: null,
           backend: "desktop-cpal",
         },
       });
@@ -842,6 +914,44 @@ describe("Desktop app project media controls", () => {
     }
   });
 
+  it("fails closed when native prepare omits the expected playback lease", async () => {
+    const restoreTauriRuntime = mockTauriRuntime();
+    const user = userEvent.setup();
+    const mockInvoke = getMockInvoke();
+    const defaultInvoke = mockInvoke.getMockImplementation();
+    if (!defaultInvoke) {
+      throw new Error("Mock invoke implementation was not installed.");
+    }
+    mockInvoke.mockImplementation(async (command: string, args?: Record<string, unknown>) => {
+      const result = await defaultInvoke(command, args);
+      if (command === "audio_prepare_session") {
+        return { ...(result as Record<string, unknown>), leaseId: "" };
+      }
+      return result;
+    });
+
+    try {
+      setMockNativeAudioState({ capabilities: {
+        nativePlaybackSupported: true, availabilityReason: null, backend: "desktop-cpal",
+      } });
+      renderApp(["/projects/proj_123"]);
+      expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
+      await openPlaybackWorkspace(user);
+
+      await user.click(screen.getByRole("button", { name: "Play playback" }));
+      await waitFor(() => expect(readPlaybackLiveDiagnostics()).toMatchObject({
+        currentState: "error", currentPath: "none",
+      }));
+      expect(invokeCalls("audio_prepare_session")).toHaveLength(1);
+      expect(invokeCalls("audio_play")).toHaveLength(0);
+      expect(document.querySelector("audio[src]")).toBeNull();
+      expect(getMockAudioContexts()).toHaveLength(0);
+    } finally {
+      mockInvoke.mockImplementation(defaultInvoke);
+      restoreTauriRuntime();
+    }
+  });
+
   it("coalesces repeated Play clicks while native playback is starting", async () => {
     const restoreTauriRuntime = mockTauriRuntime();
     const mockInvoke = getMockInvoke();
@@ -864,8 +974,7 @@ describe("Desktop app project media controls", () => {
       setMockNativeAudioState({
         capabilities: {
           nativePlaybackSupported: true,
-          fallbackRequired: false,
-          fallbackReason: null,
+          availabilityReason: null,
           backend: "desktop-cpal",
         },
       });
@@ -915,8 +1024,7 @@ describe("Desktop app project media controls", () => {
       setMockNativeAudioState({
         capabilities: {
           nativePlaybackSupported: true,
-          fallbackRequired: false,
-          fallbackReason: null,
+          availabilityReason: null,
           backend: "desktop-cpal",
         },
       });
@@ -988,8 +1096,7 @@ describe("Desktop app project media controls", () => {
       setMockNativeAudioState({
         capabilities: {
           nativePlaybackSupported: true,
-          fallbackRequired: false,
-          fallbackReason: null,
+          availabilityReason: null,
           backend: "desktop-cpal",
         },
       });
@@ -1001,7 +1108,6 @@ describe("Desktop app project media controls", () => {
       expect(hasNativePowerProtection(true)).toBe(false);
 
       const sessionId = latestNativeSessionId();
-      vi.stubEnv("VITE_TUNEFORGE_FORCE_WEB_AUDIO", "1");
       act(() => {
         emitMockNativePlaybackError({
           sessionId,
@@ -1009,9 +1115,8 @@ describe("Desktop app project media controls", () => {
         });
       });
 
-      const sourceAudio = await waitFor(() => findAudioByArtifactId("art_source"));
-      markAudioReady(sourceAudio);
-      await waitForWebOwnerControls();
+      await waitFor(() => expect(screen.getByRole("button", { name: "Play playback" })).toBeInTheDocument());
+      expect(document.querySelector("audio[src]")).toBeNull();
       expect(window.localStorage.getItem("tuneforge.playback-native-error")).toBe(
         "Native playback stream was interrupted.",
       );
@@ -1019,8 +1124,8 @@ describe("Desktop app project media controls", () => {
       nativePlayBlock.release?.();
       await Promise.resolve();
       expect(readPlaybackLiveDiagnostics()).toMatchObject({
-        currentState: "playing",
-        currentPath: "web-forced",
+        currentState: "error",
+        currentPath: "none",
       });
     } finally {
       nativePlayBlock.release?.();
@@ -1227,8 +1332,7 @@ describe("Desktop app project media controls", () => {
     setMockNativeAudioState({
       capabilities: {
         nativePlaybackSupported: true,
-        fallbackRequired: false,
-        fallbackReason: null,
+        availabilityReason: null,
         backend: "desktop-cpal",
       },
     });

--- a/apps/desktop/src/App.project-playback-stems.test.tsx
+++ b/apps/desktop/src/App.project-playback-stems.test.tsx
@@ -2,6 +2,7 @@ import { act, fireEvent, screen, waitFor, within } from "@testing-library/react"
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  emitMockNativeAudioTerminal,
   resetAppTestHarness,
   flushPendingPreview,
   findAudioByArtifactId,
@@ -1045,6 +1046,86 @@ describe("Desktop app project playback stems", () => {
     await waitFor(() => expect(invokeCalls("audio_play")).toHaveLength(3));
     expect(invokeCalls("audio_set_lanes")).toHaveLength(laneCount);
     restoreTauriRuntime();
+  });
+
+  it("keeps a terminal state when an in-flight native lane update completes late", async () => {
+    const restoreTauriRuntime = enableNativePlayback();
+    const invoke = getMockInvoke();
+    const originalInvoke = invoke.getMockImplementation();
+    if (!originalInvoke) {
+      throw new Error("Mock invoke implementation was not installed.");
+    }
+    let releaseLaneUpdate!: () => void;
+    const laneUpdateGate = new Promise<void>((resolve) => {
+      releaseLaneUpdate = resolve;
+    });
+    let finishLaneUpdate!: () => void;
+    const laneUpdateFinished = new Promise<void>((resolve) => {
+      finishLaneUpdate = resolve;
+    });
+    const user = userEvent.setup();
+
+    try {
+      renderApp(["/projects/proj_123"]);
+      expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
+      await generateStems(user);
+      await openPlaybackWorkspace(user);
+      const stemList = await screen.findByRole("group", { name: "Playback stem list" });
+      await user.click(
+        within(stemList).getAllByRole("button", { name: /Vocals/i })[0] as HTMLElement,
+      );
+      await user.click(screen.getByRole("button", { name: "Play playback" }));
+      await waitFor(() => expect(invokeCalls("audio_play")).toHaveLength(1));
+      const laneUpdateCount = invokeCalls("audio_set_lanes").length;
+
+      invoke.mockImplementation(async (command, args) => {
+        if (command === "audio_set_lanes") {
+          await laneUpdateGate;
+          const snapshot = await originalInvoke(command, args);
+          finishLaneUpdate();
+          return snapshot;
+        }
+        return originalInvoke(command, args);
+      });
+      await user.click(screen.getByRole("button", { name: "Mute Drums" }));
+      await waitFor(() =>
+        expect(invokeCalls("audio_set_lanes")).toHaveLength(laneUpdateCount + 1),
+      );
+      const laneCalls = invokeCalls("audio_set_lanes");
+      const laneControl = (laneCalls[laneCalls.length - 1]?.[1] as {
+        control?: { generation?: number; timelineRevision?: number };
+      } | undefined)?.control;
+
+      act(() => emitMockNativeAudioTerminal({
+        resource: "output",
+        source: "output_runtime",
+        generation: laneControl?.generation,
+        timelineRevision: laneControl?.timelineRevision,
+        positionSeconds: 41,
+        code: "output_stream_failure",
+        nativeTimeUs: 10,
+      }));
+      expect(screen.getByRole("button", { name: "Play playback" })).toBeInTheDocument();
+      expect(screen.getByRole("alert")).toHaveTextContent(
+        "Playback stopped. Check your audio output, then press Play to retry.",
+      );
+      expect(screen.getByLabelText("Playback position")).toHaveValue("41");
+
+      await act(async () => {
+        releaseLaneUpdate();
+        await laneUpdateFinished;
+      });
+      await waitFor(() => expect(screen.getByRole("button", { name: "Play playback" })).toBeInTheDocument());
+      expect(screen.getByRole("alert")).toHaveTextContent(
+        "Playback stopped. Check your audio output, then press Play to retry.",
+      );
+      expect(screen.getByLabelText("Playback position")).toHaveValue("41");
+      expect(invokeCalls("audio_play")).toHaveLength(1);
+    } finally {
+      releaseLaneUpdate();
+      invoke.mockImplementation(originalInvoke);
+      restoreTauriRuntime();
+    }
   });
 
   it("keeps a paused native handoff paused after its deferred Play completes", async () => {

--- a/apps/desktop/src/App.project-precount.test.tsx
+++ b/apps/desktop/src/App.project-precount.test.tsx
@@ -98,8 +98,7 @@ function enableNativePlayback() {
   setMockNativeAudioState({
     capabilities: {
       nativePlaybackSupported: true,
-      fallbackRequired: false,
-      fallbackReason: null,
+      availabilityReason: null,
       backend: "desktop-cpal",
     },
   });
@@ -639,7 +638,7 @@ describe("Desktop app project playback pre-count", () => {
       durationSeconds: 182,
       playbackRate: 1,
       nativePlaybackSupported: true,
-      fallbackReason: null,
+      availabilityReason: null,
       lanes: [],
       bufferHealth: [],
     });
@@ -650,7 +649,7 @@ describe("Desktop app project playback pre-count", () => {
       durationSeconds: 182,
       playbackRate: 1,
       nativePlaybackSupported: true,
-      fallbackReason: null,
+      availabilityReason: null,
       lanes: [],
       bufferHealth: [],
     });
@@ -684,7 +683,7 @@ describe("Desktop app project playback pre-count", () => {
       durationSeconds: 182,
       playbackRate: 1,
       nativePlaybackSupported: true,
-      fallbackReason: null,
+      availabilityReason: null,
       lanes: [],
       bufferHealth: [],
     });
@@ -718,7 +717,7 @@ describe("Desktop app project playback pre-count", () => {
       durationSeconds: 182,
       playbackRate: 1,
       nativePlaybackSupported: true,
-      fallbackReason: null,
+      availabilityReason: null,
       lanes: [],
       bufferHealth: [],
     });
@@ -754,7 +753,7 @@ describe("Desktop app project playback pre-count", () => {
       durationSeconds: 182,
       playbackRate: 1,
       nativePlaybackSupported: true,
-      fallbackReason: null,
+      availabilityReason: null,
       lanes: [],
       bufferHealth: [],
     });
@@ -797,7 +796,7 @@ describe("Desktop app project playback pre-count", () => {
       durationSeconds: 182,
       playbackRate: 1,
       nativePlaybackSupported: true,
-      fallbackReason: null,
+      availabilityReason: null,
       lanes: [],
       bufferHealth: [],
       timelineRevision: 2,
@@ -835,7 +834,7 @@ describe("Desktop app project playback pre-count", () => {
       durationSeconds: 182,
       playbackRate: 1,
       nativePlaybackSupported: true,
-      fallbackReason: null,
+      availabilityReason: null,
       lanes: [],
       bufferHealth: [],
     });
@@ -846,7 +845,7 @@ describe("Desktop app project playback pre-count", () => {
       durationSeconds: 182,
       playbackRate: 1,
       nativePlaybackSupported: true,
-      fallbackReason: null,
+      availabilityReason: null,
       lanes: [],
       bufferHealth: [],
     });
@@ -894,7 +893,7 @@ describe("Desktop app project playback pre-count", () => {
       durationSeconds: 182,
       playbackRate: 1,
       nativePlaybackSupported: true,
-      fallbackReason: null,
+      availabilityReason: null,
       lanes: [],
       bufferHealth: [],
       timelineRevision: 2,
@@ -910,7 +909,7 @@ describe("Desktop app project playback pre-count", () => {
       durationSeconds: 182,
       playbackRate: 1,
       nativePlaybackSupported: true,
-      fallbackReason: null,
+      availabilityReason: null,
       lanes: [],
       bufferHealth: [],
       timelineRevision: 4,
@@ -952,7 +951,7 @@ describe("Desktop app project playback pre-count", () => {
       durationSeconds: 182,
       playbackRate: 1,
       nativePlaybackSupported: true,
-      fallbackReason: null,
+      availabilityReason: null,
       lanes: [],
       bufferHealth: [],
     });
@@ -963,7 +962,7 @@ describe("Desktop app project playback pre-count", () => {
       durationSeconds: 182,
       playbackRate: 1,
       nativePlaybackSupported: true,
-      fallbackReason: null,
+      availabilityReason: null,
       lanes: [],
       bufferHealth: [],
     });
@@ -1014,7 +1013,7 @@ describe("Desktop app project playback pre-count", () => {
       durationSeconds: 182,
       playbackRate: 1,
       nativePlaybackSupported: true,
-      fallbackReason: null,
+      availabilityReason: null,
       lanes: [],
       bufferHealth: [],
       timelineRevision: 3,
@@ -1050,13 +1049,70 @@ describe("Desktop app project playback pre-count", () => {
     await user.click(screen.getByLabelText("Enable pre-count"));
     await user.click(screen.getByRole("button", { name: "Play playback" }));
     await waitFor(() => expect(readPlaybackE2ETelemetry().countIn.active).toBe(true));
+    const playCount = getMockInvoke().mock.calls.filter(([command]) => command === "audio_play").length;
     act(() => emitMockNativeAudioTerminal({
       resource: "output", source: "output_runtime", generation: 1,
-      code: "output_stream_failure", nativeTimeUs: 3_000_000,
+      positionSeconds: 1.25, code: "output_stream_failure", nativeTimeUs: 3_000_000,
     }));
     expect(readPlaybackE2ETelemetry().countIn).toMatchObject({ active: false, lastCancelled: {
       reason: "unavailable", cancelledAtContextTimeSeconds: 3,
     } });
+    expect(screen.getByRole("button", { name: "Play playback" })).toBeInTheDocument();
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      "Playback stopped. Check your audio output, then press Play to retry.",
+    );
+    expect(screen.getByLabelText("Playback position")).toHaveValue("1.25");
+    expect(getMockInvoke().mock.calls.filter(([command]) => command === "audio_play")).toHaveLength(playCount);
+    expect(document.querySelector("audio[src]")).toBeNull();
+    expect(getMockAudioContexts()).toHaveLength(0);
+    restoreTauriRuntime();
+  });
+
+  it("fully cancels native pre-count after a lane update failure and retries on the next Play", async () => {
+    const restoreTauriRuntime = enableNativePlayback();
+    const user = userEvent.setup();
+    setupTempoAnalysis();
+    renderApp(["/projects/proj_123"]);
+    await screen.findByRole("heading", { name: "Demo Song" });
+    await openPlaybackWorkspace(user);
+    await user.click(screen.getByLabelText("Enable pre-count"));
+    await user.click(screen.getByRole("button", { name: "Play playback" }));
+    await waitFor(() => expect(readPlaybackE2ETelemetry().countIn.active).toBe(true));
+
+    const invoke = getMockInvoke();
+    const originalInvoke = invoke.getMockImplementation();
+    if (!originalInvoke) {
+      throw new Error("Mock invoke implementation was not installed.");
+    }
+    const laneUpdate = createDeferred<Record<string, unknown>>();
+    let deferLaneUpdate = true;
+    invoke.mockImplementation(async (command, args) => {
+      if (command === "audio_set_lanes" && deferLaneUpdate) {
+        deferLaneUpdate = false;
+        return laneUpdate.promise;
+      }
+      return originalInvoke(command, args);
+    });
+
+    const laneUpdateCount = invokeCalls("audio_set_lanes").length;
+    await user.click(screen.getByRole("button", { name: "Increase pre-count clicks" }));
+    await waitFor(() => expect(invokeCalls("audio_set_lanes")).toHaveLength(laneUpdateCount + 1));
+    expect(readPlaybackE2ETelemetry().countIn.active).toBe(true);
+    laneUpdate.reject(new Error("output_stream_failure"));
+    await waitFor(() => expect(readPlaybackE2ETelemetry().countIn.active).toBe(false));
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      "Playback stopped. Check your audio output, then press Play to retry.",
+    );
+
+    const prepareCount = invokeCalls("audio_prepare_session").length;
+    const playCount = invokeCalls("audio_play").length;
+    await user.click(screen.getByRole("button", { name: "Play playback" }));
+    await waitFor(() => expect(invokeCalls("audio_prepare_session")).toHaveLength(prepareCount + 1));
+    await waitFor(() => expect(readPlaybackE2ETelemetry().countIn.active).toBe(true));
+    expect(invokeCalls("audio_play")).toHaveLength(playCount + 1);
+    expect(document.querySelector("audio[src]")).toBeNull();
+
+    invoke.mockImplementation(originalInvoke);
     restoreTauriRuntime();
   });
 
@@ -1077,7 +1133,7 @@ describe("Desktop app project playback pre-count", () => {
       durationSeconds: 182,
       playbackRate: 1,
       nativePlaybackSupported: true,
-      fallbackReason: null,
+      availabilityReason: null,
       lanes: [],
       bufferHealth: [],
     });
@@ -1088,7 +1144,7 @@ describe("Desktop app project playback pre-count", () => {
       durationSeconds: 182,
       playbackRate: 1,
       nativePlaybackSupported: true,
-      fallbackReason: null,
+      availabilityReason: null,
       lanes: [],
       bufferHealth: [],
     });
@@ -1136,7 +1192,7 @@ describe("Desktop app project playback pre-count", () => {
       durationSeconds: 182,
       playbackRate: 1,
       nativePlaybackSupported: true,
-      fallbackReason: null,
+      availabilityReason: null,
       lanes: [],
       bufferHealth: [],
       timelineRevision: 2,
@@ -1158,7 +1214,7 @@ describe("Desktop app project playback pre-count", () => {
       durationSeconds: 182,
       playbackRate: 1,
       nativePlaybackSupported: true,
-      fallbackReason: null,
+      availabilityReason: null,
       lanes: [],
       bufferHealth: [],
       timelineRevision: 4,
@@ -1195,7 +1251,7 @@ describe("Desktop app project playback pre-count", () => {
       durationSeconds: 182,
       playbackRate: 1,
       nativePlaybackSupported: true,
-      fallbackReason: null,
+      availabilityReason: null,
       lanes: [],
       bufferHealth: [],
     });
@@ -1206,7 +1262,7 @@ describe("Desktop app project playback pre-count", () => {
       durationSeconds: 182,
       playbackRate: 1,
       nativePlaybackSupported: true,
-      fallbackReason: null,
+      availabilityReason: null,
       lanes: [],
       bufferHealth: [],
     });
@@ -1254,7 +1310,7 @@ describe("Desktop app project playback pre-count", () => {
       durationSeconds: 182,
       playbackRate: 1,
       nativePlaybackSupported: true,
-      fallbackReason: null,
+      availabilityReason: null,
       lanes: [],
       bufferHealth: [],
       timelineRevision: 2,

--- a/apps/desktop/src/App.project-tempo.test.tsx
+++ b/apps/desktop/src/App.project-tempo.test.tsx
@@ -205,8 +205,7 @@ describe("Desktop app project playback tempo", () => {
     setMockNativeAudioState({
       capabilities: {
         nativePlaybackSupported: true,
-        fallbackRequired: false,
-        fallbackReason: null,
+        availabilityReason: null,
         backend: "desktop-cpal",
       },
     });
@@ -233,8 +232,7 @@ describe("Desktop app project playback tempo", () => {
     setMockNativeAudioState({
       capabilities: {
         nativePlaybackSupported: true,
-        fallbackRequired: false,
-        fallbackReason: null,
+        availabilityReason: null,
         backend: "desktop-cpal",
       },
     });
@@ -282,11 +280,10 @@ describe("Desktop app project playback tempo", () => {
     setMockNativeAudioState({
       capabilities: {
         nativePlaybackSupported: true,
-        fallbackRequired: false,
-        fallbackReason: null,
+        availabilityReason: null,
         backend: "desktop-cpal",
       },
-      playFallbackReason: "Native playback underrun persisted; falling back to Web Audio.",
+      playError: "Native playback underrun persisted.",
     });
     renderApp(["/projects/proj_123"]);
 
@@ -309,13 +306,13 @@ describe("Desktop app project playback tempo", () => {
     expect(document.querySelector("audio[data-artifact-id='art_source']")).toBeNull();
     expect(getMockAudioContexts()).toHaveLength(0);
     expect(window.localStorage.getItem("tuneforge.playback-native-error")).toBe(
-      "Native playback underrun persisted; falling back to Web Audio.",
+      "Native playback underrun persisted.",
     );
     expect(screen.getByRole("button", { name: "Play playback" })).toBeInTheDocument();
     restoreTauriRuntime();
   });
 
-  it("keeps Web Audio telemetry when delayed native stop cleanup resolves after fallback", async () => {
+  it("keeps terminal telemetry when delayed native stop cleanup resolves", async () => {
     const restoreTauriRuntime = mockTauriRuntime();
     const user = userEvent.setup();
     const mockInvoke = getMockInvoke();
@@ -348,8 +345,7 @@ describe("Desktop app project playback tempo", () => {
       setMockNativeAudioState({
         capabilities: {
           nativePlaybackSupported: true,
-          fallbackRequired: false,
-          fallbackReason: null,
+          availabilityReason: null,
           backend: "desktop-cpal",
         },
       });
@@ -365,27 +361,25 @@ describe("Desktop app project playback tempo", () => {
         }),
       );
 
-      vi.stubEnv("VITE_TUNEFORGE_FORCE_WEB_AUDIO", "1");
       emitMockNativePlaybackError({
         sessionId: latestNativeSessionId(),
         code: "output_stream_failure",
       });
       await waitFor(() => expect(nativeStopBlock.resolve).not.toBeNull());
-      const sourceAudio = findAudioByArtifactId("art_source");
-      markAudioReady(sourceAudio);
       await waitFor(() =>
         expect(readPlaybackE2ETelemetry()).toMatchObject({
-          activePath: "web-audio",
-          transportState: "playing",
+          activePath: "none",
+          transportState: "stopped",
         }),
       );
+      expect(document.querySelector("audio[src]")).toBeNull();
 
       nativeStopBlock.resolve?.();
       await nativeStopSettled;
       await Promise.resolve();
       expect(readPlaybackE2ETelemetry()).toMatchObject({
-        activePath: "web-audio",
-        transportState: "playing",
+        activePath: "none",
+        transportState: "stopped",
       });
     } finally {
       nativeStopBlock.resolve?.();
@@ -394,15 +388,14 @@ describe("Desktop app project playback tempo", () => {
     }
   });
 
-  it("stops without fallback after a runtime underrun error", async () => {
+  it("stops without Web Audio after a runtime underrun error", async () => {
     const restoreTauriRuntime = mockTauriRuntime();
     const user = userEvent.setup();
     setupTempoAnalysis(120);
     setMockNativeAudioState({
       capabilities: {
         nativePlaybackSupported: true,
-        fallbackRequired: false,
-        fallbackReason: null,
+        availabilityReason: null,
         backend: "desktop-cpal",
       },
     });
@@ -448,6 +441,7 @@ describe("Desktop app project playback tempo", () => {
       emitMockNativePlaybackError({
         sessionId,
         code: "output_stream_failure",
+        positionSeconds: 42.25,
       });
     });
 

--- a/apps/desktop/src/App.settings-theme.test.tsx
+++ b/apps/desktop/src/App.settings-theme.test.tsx
@@ -26,6 +26,13 @@ describe("Desktop app settings theme", () => {
   beforeEach(resetAppTestHarness);
   afterEach(() => vi.unstubAllEnvs());
 
+  function mockTauriRuntime() {
+    Object.defineProperty(window, "__TAURI_INTERNALS__", {
+      configurable: true,
+      value: { invoke: mockInvoke },
+    });
+  }
+
   async function openPlaybackWorkspace(user: ReturnType<typeof userEvent.setup>) {
     await user.click(screen.getByRole("tab", { name: "Playback" }));
   }
@@ -315,6 +322,7 @@ describe("Desktop app settings theme", () => {
 
   it("persists theme and visible UI preferences", async () => {
     const user = userEvent.setup();
+    mockTauriRuntime();
     setMockNativeAudioState({
       capabilities: {
         backend: "desktop-cpal",
@@ -322,7 +330,7 @@ describe("Desktop app settings theme", () => {
         nativePlaybackSupported: false,
       },
       snapshot: {
-        fallbackReason: "buffer underrun on native lane vocals",
+        availabilityReason: "buffer underrun on native lane vocals",
         bufferHealth: [
           {
             laneId: "vocals",
@@ -372,8 +380,6 @@ describe("Desktop app settings theme", () => {
     expect(screen.getByText(/^Unavailable —/)).toBeInTheDocument();
     expect(screen.getByText("Native microphone failed.")).toBeInTheDocument();
     expect(screen.getByText("Native output failed.")).toBeInTheDocument();
-    expect(screen.getByText("Latest Native Fallback Cause")).toBeInTheDocument();
-    expect(screen.getAllByText("None").length).toBeGreaterThan(0);
     expect(screen.getByText("Native Playback Buffer Health")).toBeInTheDocument();
     expect(screen.getByText("No active native lanes")).toBeInTheDocument();
     expect(screen.getByText("Not started")).toBeInTheDocument();
@@ -404,6 +410,7 @@ describe("Desktop app settings theme", () => {
 
   it("shows forced Web Audio diagnostics", async () => {
     const user = userEvent.setup();
+    mockTauriRuntime();
     vi.stubEnv("VITE_TUNEFORGE_FORCE_WEB_AUDIO", "1");
     setMockNativeAudioState({
       capabilities: {
@@ -419,14 +426,33 @@ describe("Desktop app settings theme", () => {
 
     expect(await screen.findByText("/tmp/tuneforge")).toBeInTheDocument();
     expect(screen.getByText("Web Audio forced at build time")).toBeInTheDocument();
-    expect(screen.getByText("Forced Web Audio")).toBeInTheDocument();
-    expect(screen.getByText("Available (desktop-cpal)")).toBeInTheDocument();
-    expect(screen.getByText("Native (desktop-cpal)")).toBeInTheDocument();
+    expect(screen.getAllByText("Web Audio (forced)").length).toBeGreaterThan(0);
     expect(screen.getByText("Not playing")).toBeInTheDocument();
-    expect(mockInvoke).toHaveBeenCalledWith("audio_get_capabilities");
+    expect(mockInvoke).not.toHaveBeenCalledWith("audio_get_capabilities");
+    expect(mockInvoke).not.toHaveBeenCalledWith("native_audio_diagnostics_availability");
+    expect(mockInvoke).not.toHaveBeenCalledWith("native_audio_diagnostics_read");
+    expect(mockInvoke).not.toHaveBeenCalledWith("audio_get_input_state");
+    expect(mockInvoke).not.toHaveBeenCalledWith("audio_get_input_permission_status");
+  });
+
+  it("keeps browser diagnostics in Web Audio mode when the forced flag is present", async () => {
+    const user = userEvent.setup();
+    vi.stubEnv("VITE_TUNEFORGE_FORCE_WEB_AUDIO", "1");
+    renderApp(["/settings"]);
+
+    expect(await screen.findByRole("heading", { name: "Control Room" })).toBeInTheDocument();
+    await user.click(screen.getByText("Show diagnostics"));
+
+    expect(screen.getAllByText("Web Audio").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("None").length).toBeGreaterThan(0);
+    expect(screen.queryByText("Web Audio (forced)")).not.toBeInTheDocument();
+    expect(screen.queryByText("Web Audio forced at build time")).not.toBeInTheDocument();
+    expect(mockInvoke).not.toHaveBeenCalledWith("audio_get_capabilities");
+    expect(mockInvoke).not.toHaveBeenCalledWith("native_audio_diagnostics_availability");
   });
 
   it("hides native audio diagnostics when the diagnostic environment is disabled", async () => {
+    mockTauriRuntime();
     renderApp(["/settings"]);
 
     expect(await screen.findByRole("heading", { name: "Control Room" })).toBeInTheDocument();
@@ -438,6 +464,7 @@ describe("Desktop app settings theme", () => {
 
   it("resets and exports enabled local native audio diagnostics", async () => {
     const user = userEvent.setup();
+    mockTauriRuntime();
     const defaultInvoke = mockInvoke.getMockImplementation();
     if (!defaultInvoke) {
       throw new Error("Mock invoke implementation was not installed.");
@@ -499,6 +526,7 @@ describe("Desktop app settings theme", () => {
 
   it("keeps Android capture capability, live state, and history distinct", async () => {
     const user = userEvent.setup();
+    mockTauriRuntime();
     setMockNativeAudioState({
       capabilities: { platform: "android", backend: "android-aaudio", micCaptureSupported: true },
       inputPermission: { state: "blocked", error: null },
@@ -517,7 +545,7 @@ describe("Desktop app settings theme", () => {
     await user.click(await screen.findByText("Show diagnostics"));
 
     expect(await screen.findByText("Available (android-aaudio)")).toBeInTheDocument();
-    expect(screen.getByText("Native required")).toBeInTheDocument();
+    expect(screen.getAllByText("Native required").length).toBeGreaterThan(0);
     expect(screen.getByText("Blocked")).toBeInTheDocument();
     expect(screen.getAllByText("Inactive").length).toBeGreaterThan(0);
     expect(screen.getAllByText("None").length).toBeGreaterThan(0);

--- a/apps/desktop/src/App.tools-metronome.test.tsx
+++ b/apps/desktop/src/App.tools-metronome.test.tsx
@@ -291,8 +291,7 @@ describe("Desktop app tools metronome", () => {
   it("schedules normal-Tauri follow cues with the project control tuple", async () => {
     (window as Window & { __TAURI_INTERNALS__?: unknown }).__TAURI_INTERNALS__ = {};
     setMockNativeAudioState({ capabilities: {
-      nativePlaybackSupported: true, fallbackRequired: false,
-      fallbackReason: null, backend: "desktop-cpal",
+      nativePlaybackSupported: true,      availabilityReason: null, backend: "desktop-cpal",
     } });
     setProjectAnalysis("proj_123", timingAnalysis);
     const user = userEvent.setup();
@@ -371,11 +370,47 @@ describe("Desktop app tools metronome", () => {
     delete (window as Window & { __TAURI_INTERNALS__?: unknown }).__TAURI_INTERNALS__;
   });
 
+  it("fails closed on missing native ownership and retries only from Start", async () => {
+    (window as Window & { __TAURI_INTERNALS__?: unknown }).__TAURI_INTERNALS__ = {};
+    setMockNativeAudioState({ capabilities: {
+      nativePlaybackSupported: true, availabilityReason: null, backend: "desktop-cpal",
+    } });
+    const invoke = getMockInvoke();
+    const originalInvoke = invoke.getMockImplementation()!;
+    let startAttempts = 0;
+    invoke.mockImplementation(async (command, args) => {
+      if (command === "audio_set_standalone_metronome") {
+        startAttempts += 1;
+        return {
+          enabled: true, bpm: 100, beatsPerBar: 4, accentFirstBeat: true,
+          gain: 0.8, followPlayback: true, leaseId: null,
+          generation: 0, revision: 0, nativeTimeUs: 1,
+        };
+      }
+      return originalInvoke(command, args);
+    });
+    const user = userEvent.setup();
+    renderApp(["/tools?tool=metronome"]);
+    await screen.findByRole("heading", { name: "Metronome" });
+
+    await user.click(screen.getByRole("button", { name: "Start" }));
+    await waitFor(() => expect(screen.getByRole("button", { name: "Start" })).toBeInTheDocument());
+    expect(startAttempts).toBe(1);
+    expect(getMockAudioContexts()).toHaveLength(0);
+
+    await user.click(screen.getByLabelText("Follow project playback"));
+    await user.click(screen.getByLabelText("Follow project playback"));
+    expect(startAttempts).toBe(1);
+
+    await user.click(screen.getByRole("button", { name: "Start" }));
+    await waitFor(() => expect(startAttempts).toBe(2));
+    delete (window as Window & { __TAURI_INTERNALS__?: unknown }).__TAURI_INTERNALS__;
+  });
+
   it("serializes rapid native settings and stop using the latest revision", async () => {
     (window as Window & { __TAURI_INTERNALS__?: unknown }).__TAURI_INTERNALS__ = {};
     setMockNativeAudioState({ capabilities: {
-      nativePlaybackSupported: true, fallbackRequired: false,
-      fallbackReason: null, backend: "desktop-cpal",
+      nativePlaybackSupported: true,      availabilityReason: null, backend: "desktop-cpal",
     } });
     const firstStart = createDeferred<{
       enabled: boolean; bpm: number; beatsPerBar: number; accentFirstBeat: boolean;
@@ -424,8 +459,7 @@ describe("Desktop app tools metronome", () => {
   it("reconciles a failed native settings update by stopping the active metronome", async () => {
     (window as Window & { __TAURI_INTERNALS__?: unknown }).__TAURI_INTERNALS__ = {};
     setMockNativeAudioState({ capabilities: {
-      nativePlaybackSupported: true, fallbackRequired: false,
-      fallbackReason: null, backend: "desktop-cpal",
+      nativePlaybackSupported: true,      availabilityReason: null, backend: "desktop-cpal",
     } });
     const invoke = getMockInvoke();
     const originalInvoke = invoke.getMockImplementation()!;
@@ -433,6 +467,7 @@ describe("Desktop app tools metronome", () => {
     renderApp(["/tools?tool=metronome"]);
     await screen.findByRole("heading", { name: "Metronome" });
     await user.click(screen.getByRole("button", { name: "Start" }));
+    fireEvent.change(screen.getByLabelText("Metronome volume"), { target: { value: "0.7" } });
     await waitFor(() => expect(invoke.mock.calls.filter(
       ([command]) => command === "audio_set_standalone_metronome",
     ).length).toBeGreaterThanOrEqual(2));
@@ -460,8 +495,7 @@ describe("Desktop app tools metronome", () => {
   it("replaces followed cues from the authoritative completed native seek position", async () => {
     (window as Window & { __TAURI_INTERNALS__?: unknown }).__TAURI_INTERNALS__ = {};
     setMockNativeAudioState({ capabilities: {
-      nativePlaybackSupported: true, fallbackRequired: false,
-      fallbackReason: null, backend: "desktop-cpal",
+      nativePlaybackSupported: true,      availabilityReason: null, backend: "desktop-cpal",
     } });
     setProjectAnalysis("proj_123", timingAnalysis);
     const user = userEvent.setup();
@@ -483,7 +517,7 @@ describe("Desktop app tools metronome", () => {
     invoke.mockImplementation(async (command, args) => command === "audio_seek" ? {
       sessionId: preparedSessionId, state: "playing", positionSeconds: authoritativePosition,
       durationSeconds: 182, playbackRate: 1, nativePlaybackSupported: true,
-      fallbackReason: null, lanes: [], bufferHealth: [], leaseId: "project-playback",
+      availabilityReason: null, lanes: [], bufferHealth: [], leaseId: "project-playback",
       generation: 1, timelineRevision: 2, nativeTimeUs: 10,
     } : originalInvoke!(command, args));
     const beforeSeek = invoke.mock.calls.filter(([name]) => name === "audio_schedule_cues").length;
@@ -507,8 +541,7 @@ describe("Desktop app tools metronome", () => {
   it("ignores a native seek snapshot from a mismatched session", async () => {
     (window as Window & { __TAURI_INTERNALS__?: unknown }).__TAURI_INTERNALS__ = {};
     setMockNativeAudioState({ capabilities: {
-      nativePlaybackSupported: true, fallbackRequired: false,
-      fallbackReason: null, backend: "desktop-cpal",
+      nativePlaybackSupported: true,      availabilityReason: null, backend: "desktop-cpal",
     } });
     setProjectAnalysis("proj_123", timingAnalysis);
     const user = userEvent.setup();

--- a/apps/desktop/src/App.tools-tuner.test.tsx
+++ b/apps/desktop/src/App.tools-tuner.test.tsx
@@ -94,6 +94,7 @@ describe("Desktop app tools tuner", () => {
 
   it("keeps tuner preferences synced between tools and settings", async () => {
     const user = userEvent.setup();
+    mockTauriRuntime();
     setMockNativeAudioState({
       capabilities: {
         micCaptureSupported: true,
@@ -177,6 +178,7 @@ describe("Desktop app tools tuner", () => {
 
   it("controls the selected native microphone volume", async () => {
     const user = userEvent.setup();
+    mockTauriRuntime();
     setMockNativeAudioState({
       capabilities: {
         micCaptureSupported: true,
@@ -508,6 +510,7 @@ describe("Desktop app tools tuner", () => {
 
   it("does not query native microphone devices while the tuner is idle until the picker is opened", async () => {
     const setIntervalSpy = vi.spyOn(window, "setInterval");
+    mockTauriRuntime();
     setMockNativeAudioState({
       capabilities: {
         micCaptureSupported: true,
@@ -537,6 +540,7 @@ describe("Desktop app tools tuner", () => {
   });
 
   it("runs a follow-up refresh when devices change during active native discovery", async () => {
+    mockTauriRuntime();
     setMockNativeAudioState({
       capabilities: {
         micCaptureSupported: true,
@@ -680,10 +684,24 @@ describe("Desktop app tools tuner", () => {
       "Native microphone capture could not start. Check the microphone and choose Retry.",
     );
     expect(screen.getByRole("button", { name: "Retry" })).toBeInTheDocument();
+
+    setMockNativeAudioState({ startError: null });
+    await refreshMicrophoneOptions("USB Interface");
+    const attemptsBeforeSelection = getMockInvoke().mock.calls.filter(
+      ([command]) => command === "audio_start_input",
+    ).length;
+    await user.selectOptions(screen.getByLabelText("Microphone source"), "cpal:1:usb");
+
+    await waitFor(() => expect(screen.getByText("Listening")).toBeInTheDocument());
+    expect(getMockInvoke().mock.calls.filter(
+      ([command]) => command === "audio_start_input",
+    )).toHaveLength(attemptsBeforeSelection + 1);
+    expect(getMockMediaDevices().getUserMedia).not.toHaveBeenCalled();
   });
 
   it("never falls back to Web Audio when packaged Android native capture fails", async () => {
     const user = userEvent.setup();
+    mockTauriRuntime();
     window.localStorage.setItem(
       "tuneforge.tuner-microphone-devices",
       JSON.stringify([{ deviceId: "cached", label: "Cached browser microphone" }]),
@@ -711,6 +729,7 @@ describe("Desktop app tools tuner", () => {
 
   it("continues Android startup after a prompted permission grant", async () => {
     const user = userEvent.setup();
+    mockTauriRuntime();
     setMockNativeAudioState({
       capabilities: { platform: "android", backend: "android-aaudio", micCaptureSupported: true },
       inputPermission: { state: "prompt", error: null },
@@ -749,6 +768,7 @@ describe("Desktop app tools tuner", () => {
 
   it("keeps Android permission denial recoverable without starting capture", async () => {
     const user = userEvent.setup();
+    mockTauriRuntime();
     const denial = {
       code: "permission-denied",
       message: "Microphone permission was denied.",
@@ -786,6 +806,7 @@ describe("Desktop app tools tuner", () => {
 
   it("reports permanently blocked Android permission without prompting or fallback", async () => {
     const user = userEvent.setup();
+    mockTauriRuntime();
     setMockNativeAudioState({
       capabilities: { platform: "android", backend: "android-aaudio", micCaptureSupported: true },
       inputPermission: {
@@ -809,6 +830,7 @@ describe("Desktop app tools tuner", () => {
 
   it("stops Android capture on a generation-matched terminal state event", async () => {
     const user = userEvent.setup();
+    mockTauriRuntime();
     setMockNativeAudioState({
       capabilities: {
         platform: "android",
@@ -847,26 +869,14 @@ describe("Desktop app tools tuner", () => {
     expect(getMockMediaDevices().getUserMedia).not.toHaveBeenCalled();
   });
 
-  it("falls back to system-default Web Audio when a native microphone selection fails", async () => {
+  it("uses Web microphone selection without native calls outside Tauri", async () => {
     const user = userEvent.setup();
     getMockMediaDevices().revealLabels();
-    setMockNativeAudioState({
-      capabilities: {
-        micCaptureSupported: true,
-        backend: "desktop-cpal",
-      },
-      inputDevices: {
-        supported: true,
-        devices: [{ id: "cpal:0:built-in", label: "Built-in Microphone", isDefault: false }],
-        error: null,
-      },
-      startError: "Native microphone failed.",
-    });
     renderApp(["/tools"]);
 
     expect(await screen.findByRole("heading", { name: "Tools" })).toBeInTheDocument();
     await refreshMicrophoneOptions("Built-in Microphone");
-    await user.selectOptions(screen.getByLabelText("Microphone source"), "cpal:0:built-in");
+    await user.selectOptions(screen.getByLabelText("Microphone source"), "built-in");
     await user.click(screen.getByRole("button", { name: "Start" }));
 
     await waitFor(() => expect(screen.getByRole("button", { name: "Stop" })).toBeInTheDocument());
@@ -880,10 +890,11 @@ describe("Desktop app tools tuner", () => {
       video: false,
     });
     expect(screen.getByLabelText("Microphone source")).toHaveValue("");
-    expect(screen.queryByRole("option", { name: "Built-in Microphone" })).not.toBeInTheDocument();
-    expect(window.localStorage.getItem("tuneforge.tuner-native-capture-error")).toBe(
-      "Selected microphone requires native input capture, but native capture is unavailable.",
-    );
+    expect(screen.getByRole("option", { name: "Built-in Microphone" })).toBeDisabled();
+    expect(getMockInvoke()).not.toHaveBeenCalledWith("audio_get_capabilities");
+    expect(getMockInvoke()).not.toHaveBeenCalledWith("audio_list_input_devices");
+    expect(getMockInvoke()).not.toHaveBeenCalledWith("audio_start_input", expect.anything());
+    expect(window.localStorage.getItem("tuneforge.tuner-native-capture-error")).toBeNull();
     expect(window.localStorage.getItem("tuneforge.tuner-input-capture-backend")).toContain(
       '"web"',
     );
@@ -898,7 +909,7 @@ describe("Desktop app tools tuner", () => {
     renderApp(["/tools"]);
 
     expect(await screen.findByRole("heading", { name: "Tools" })).toBeInTheDocument();
-    expect(await screen.findByRole("option", { name: "USB Interface" })).toBeDisabled();
+    expect(await screen.findByRole("option", { name: "USB Interface" })).toBeEnabled();
     expect(getMockMediaDevices().getUserMedia).not.toHaveBeenCalled();
   });
 

--- a/apps/desktop/src/features/projects/playback.race-regressions.test.tsx
+++ b/apps/desktop/src/features/projects/playback.race-regressions.test.tsx
@@ -1,4 +1,5 @@
 import {
+  advanceMockAnimationFrames,
   emitMockNativeAudioCue,
   emitMockNativePlaybackPosition,
   getMockAudioContexts,
@@ -7,12 +8,14 @@ import {
   markAudioReady,
   mockListen,
   resetAppTestHarness,
+  setMockAudioContextInitialState,
   setMockNativeAudioState,
 } from "../../test/appTestHarness";
 import { act, cleanup, render, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { PlaybackProvider } from "./playback";
 import {
+  PlaybackContext,
   usePlayback,
   type PlaybackContextValue,
   type ProjectPlaybackSession,
@@ -80,6 +83,33 @@ function bufferedSession(
   });
 }
 
+function activePlaybackContextValue(
+  targetSession: ProjectPlaybackSession,
+  playbackTimeSeconds: number,
+): PlaybackContextValue {
+  const snapshot = {
+    session: targetSession,
+    playbackTimeSeconds,
+    playbackDurationSeconds: 30,
+    isPrecounting: false,
+    isPlaying: true,
+  };
+  return {
+    ...snapshot,
+    getPlaybackSnapshot: () => snapshot,
+    activateStemPlayback: async () => undefined,
+    primeWebAudioForGesture: async () => undefined,
+    registerProjectSession: () => undefined,
+    togglePlayback: async () => undefined,
+    playPlayback: async () => undefined,
+    pausePlayback: () => undefined,
+    stopPlayback: () => undefined,
+    dismissSession: () => undefined,
+    seekBy: () => undefined,
+    seekTo: () => undefined,
+  };
+}
+
 function deferred<T>() {
   let resolve!: (value: T) => void;
   const promise = new Promise<T>((nextResolve) => {
@@ -110,6 +140,22 @@ function calls(command: string) {
   return getMockInvoke().mock.calls.filter(([name]) => name === command);
 }
 
+function standaloneMetronomeResult(args: unknown) {
+  const payload = (args as { payload?: Record<string, unknown> })?.payload;
+  return {
+    enabled: payload?.enabled,
+    bpm: payload?.bpm,
+    beatsPerBar: payload?.beatsPerBar,
+    accentFirstBeat: payload?.accentFirstBeat,
+    gain: payload?.gain,
+    followPlayback: payload?.followPlayback,
+    leaseId: "standalone-metronome",
+    generation: 1,
+    revision: 1,
+    nativeTimeUs: 1,
+  };
+}
+
 beforeEach(() => {
   resetAppTestHarness();
 });
@@ -134,6 +180,40 @@ function enableNativePlayback() {
     },
   });
 }
+
+describe("stem playback activation backend selection", () => {
+  it("does not create a Web Audio context in normal Tauri", async () => {
+    enableNativePlayback();
+    await setup(bufferedSession());
+
+    expect(getMockAudioContexts()).toHaveLength(0);
+    await act(async () => playback.activateStemPlayback());
+
+    expect(getMockAudioContexts()).toHaveLength(0);
+  });
+
+  for (const runtime of ["browser", "forced Web Audio"] as const) {
+    it(`activates Web Audio in ${runtime}`, async () => {
+      setMockAudioContextInitialState("suspended");
+      if (runtime === "forced Web Audio") {
+        vi.stubEnv("VITE_TUNEFORGE_FORCE_WEB_AUDIO", "1");
+        enableNativePlayback();
+      }
+      await setup(bufferedSession());
+
+      const contextsBeforeActivation = getMockAudioContexts();
+      const contextCount = contextsBeforeActivation.length;
+      const resumeCount = contextsBeforeActivation[contextCount - 1]?.resume.mock.calls.length ?? 0;
+      await act(async () => playback.activateStemPlayback());
+
+      expect(getMockAudioContexts()).toHaveLength(Math.max(1, contextCount));
+      const contextsAfterActivation = getMockAudioContexts();
+      expect(contextsAfterActivation[contextsAfterActivation.length - 1]?.resume).toHaveBeenCalledTimes(
+        resumeCount + 1,
+      );
+    });
+  }
+});
 
 describe("native playback race regressions", () => {
   for (const action of ["stop", "pause"] as const) {
@@ -264,7 +344,7 @@ describe("native playback race regressions", () => {
     expect(playback.isPlaying).toBe(false);
   });
 
-  it("restores playing state when the current native Pause is rejected", async () => {
+  it("fails closed when the current native Pause is rejected", async () => {
     enableNativePlayback();
     await setup();
     await act(async () => playback.playPlayback());
@@ -279,8 +359,12 @@ describe("native playback race regressions", () => {
     await flush();
 
     expect(calls("audio_pause")).toHaveLength(1);
-    expect(calls("audio_stop")).toHaveLength(0);
-    expect(playback.isPlaying).toBe(true);
+    expect(calls("audio_stop")).toHaveLength(1);
+    expect((calls("audio_stop")[0]?.[1] as { payload?: object })?.payload).toMatchObject({
+      generation: 1,
+      timelineRevision: 1,
+    });
+    expect(playback.isPlaying).toBe(false);
   });
 
   it("uses each completed native revision across rapid seeks", async () => {
@@ -571,6 +655,13 @@ describe("native playback race regressions", () => {
 
   it("restarts a native EOF loop with loop count-in and followed metronome active", async () => {
     enableNativePlayback();
+    const invoke = getMockInvoke();
+    const originalInvoke = invoke.getMockImplementation()!;
+    invoke.mockImplementation(async (command, args) =>
+      command === "audio_set_standalone_metronome"
+        ? standaloneMetronomeResult(args)
+        : originalInvoke(command, args),
+    );
     render(
       <PlaybackProvider>
         <Harness />
@@ -586,7 +677,7 @@ describe("native playback race regressions", () => {
     })));
     await flush();
     await act(async () => playback.playPlayback());
-    await act(async () => metronome.setFollowPlaybackEnabled(true));
+    await act(async () => metronome.startMetronome());
     const snapshot = await getMockInvoke()("audio_get_snapshot") as Record<string, unknown>;
     const ended = { ...snapshot, state: "stopped", positionSeconds: 30 };
 
@@ -846,6 +937,70 @@ describe("buffered Web playback race regressions", () => {
     expect(getMockAudioContexts().flatMap((context) => context.createdSources)).toHaveLength(1);
   });
 
+  const schedulingCases: Array<[
+    string,
+    ProjectPlaybackSession["timingGrid"],
+    number,
+    typeof session,
+  ]> = [
+    [
+      "buffered timing-grid",
+      {
+        beats_per_bar: 4,
+        meter: "4/4",
+        source: "detected",
+        downbeat_source: null,
+        downbeat_confidence: null,
+        meter_confidence: null,
+        beats: [
+          { index: 0, seconds: 0, bar_index: 0, beat_in_bar: 1 },
+          { index: 1, seconds: 0.04, bar_index: 0, beat_in_bar: 2 },
+        ],
+        bars: [],
+      },
+      0,
+      bufferedSession,
+    ],
+    ["HTML media uniform", null, 0.56, session],
+  ];
+  for (const runtime of ["browser", "forced Web"] as const) {
+    for (const [label, timingGrid, playbackTimeSeconds, makeSession] of schedulingCases) {
+      for (const rate of [0.5, 1.5]) {
+        it(`${runtime} ${label} schedules source beats in wall time at ${rate}x`, async () => {
+          if (runtime === "forced Web") {
+            vi.stubEnv("VITE_TUNEFORGE_FORCE_WEB_AUDIO", "1");
+            enableNativePlayback();
+          }
+          const targetSession = makeSession({
+            tempoOriginalBpm: 120,
+            tempoTargetBpm: 120 * rate,
+            timingGrid,
+          });
+          render(
+            <PlaybackContext.Provider
+              value={activePlaybackContextValue(targetSession, playbackTimeSeconds)}
+            >
+              <MetronomeProvider>
+                <MetronomeHarness />
+              </MetronomeProvider>
+            </PlaybackContext.Provider>,
+          );
+          await act(async () => metronome.startMetronome());
+          act(() => advanceMockAnimationFrames(1));
+
+          const context = getMockAudioContexts()[0]!;
+          const scheduledTimes = context.createdOscillators.flatMap((candidate) =>
+            candidate.start.mock.calls.map(([time]) => Number(time)),
+          );
+          const observedDelay = timingGrid
+            ? scheduledTimes[1]! - scheduledTimes[0]!
+            : scheduledTimes[0]! - context.currentTime;
+          expect(observedDelay).toBeCloseTo(0.04 / rate, 6);
+        });
+      }
+    }
+  }
+
 });
 
 describe("followed native metronome races", () => {
@@ -858,6 +1013,9 @@ describe("followed native metronome races", () => {
     const originalInvoke = invoke.getMockImplementation()!;
     invoke.mockImplementation(async (command, args) => {
       const payload = (args as { payload?: Record<string, unknown> })?.payload;
+      if (command === "audio_set_standalone_metronome") {
+        return standaloneMetronomeResult(args);
+      }
       const result = await originalInvoke(command, args);
       if (command === "audio_schedule_cues") {
         cueCount = (payload?.cues as unknown[]).length;
@@ -883,7 +1041,7 @@ describe("followed native metronome races", () => {
     act(() => playback.registerProjectSession(session()));
     await flush();
     await act(async () => playback.playPlayback());
-    await act(async () => metronome.setFollowPlaybackEnabled(true));
+    await act(async () => metronome.startMetronome());
     await flush();
     expect(cueCount).toBeGreaterThan(0);
 

--- a/apps/desktop/src/features/projects/playback.test.tsx
+++ b/apps/desktop/src/features/projects/playback.test.tsx
@@ -259,7 +259,7 @@ describe("PlaybackProvider", () => {
     fireEvent.playing(media as HTMLAudioElement);
     expect(readPlaybackLiveDiagnostics()).toMatchObject({
       currentState: "playing",
-      currentPath: "web-fallback",
+      currentPath: "web",
     });
 
     fireEvent.stalled(media as HTMLAudioElement);
@@ -271,7 +271,7 @@ describe("PlaybackProvider", () => {
 
     expect(readPlaybackLiveDiagnostics()).toMatchObject({
       currentState: "playing",
-      currentPath: "web-fallback",
+      currentPath: "web",
     });
     expect(readRememberedWebPlaybackError()).toBeNull();
   });
@@ -285,8 +285,7 @@ describe("PlaybackProvider", () => {
       capabilities: {
         backend: "android-aaudio",
         nativePlaybackSupported: true,
-        fallbackRequired: false,
-        fallbackReason: null,
+        availabilityReason: null,
       },
     });
     let playback: PlaybackContextValue | null = null;
@@ -318,7 +317,7 @@ describe("PlaybackProvider", () => {
         state: "paused",
         positionSeconds: 12.5,
         nativePlaybackSupported: false,
-        fallbackReason: "Native stream failed at /Users/person/My Song.wav.",
+        availabilityReason: "Native stream failed at /Users/person/My Song.wav.",
       },
     });
     act(() => {
@@ -344,7 +343,7 @@ describe("PlaybackProvider", () => {
     Object.defineProperty(window, "__TAURI_INTERNALS__", { configurable: true, value: {} });
     setMockNativeAudioState({ capabilities: {
       backend: "android-aaudio", nativePlaybackSupported: true,
-      fallbackRequired: false, fallbackReason: null,
+availabilityReason: null,
     } });
     let playback: PlaybackContextValue | null = null;
     const firstSession = makePlaybackSession("art_source", { stageTitle: "Source Track" });
@@ -388,8 +387,7 @@ describe("PlaybackProvider", () => {
       capabilities: {
         backend: "android-aaudio",
         nativePlaybackSupported: true,
-        fallbackRequired: false,
-        fallbackReason: null,
+        availabilityReason: null,
       },
     });
     let playback: PlaybackContextValue | null = null;
@@ -469,25 +467,35 @@ describe("PlaybackProvider", () => {
     });
 
     const endedHandler = mockListen.mock.calls.find(([event]) => event === "audio://ended")?.[1];
+    const endedPayload = {
+      sessionId: "proj_123:native:art_source",
+      leaseId: "project-playback",
+      generation: 1,
+      timelineRevision: 1,
+      nativeTimeUs: 1,
+      state: "stopped",
+      positionSeconds: 0,
+      durationSeconds: 182,
+      playbackRate: 1,
+      nativePlaybackSupported: true,
+      availabilityReason: null,
+      lanes: [],
+      bufferHealth: [],
+    };
     act(() => {
       endedHandler?.({
         event: "audio://ended",
         id: 1,
-        payload: {
-          sessionId: "proj_123:native:art_source",
-          leaseId: "project-playback",
-          generation: 1,
-          timelineRevision: 1,
-          nativeTimeUs: 1,
-          state: "stopped",
-          positionSeconds: 0,
-          durationSeconds: 182,
-          playbackRate: 1,
-          nativePlaybackSupported: true,
-          fallbackReason: null,
-          lanes: [],
-          bufferHealth: [],
-        },
+        payload: { ...endedPayload, generation: 99 },
+      });
+    });
+    expect(readPlaybackLiveDiagnostics().currentPath).toBe("native");
+
+    act(() => {
+      endedHandler?.({
+        event: "audio://ended",
+        id: 1,
+        payload: endedPayload,
       });
     });
     await flushPlaybackWork();

--- a/apps/desktop/src/features/projects/playback.tsx
+++ b/apps/desktop/src/features/projects/playback.tsx
@@ -28,7 +28,7 @@ import {
   type NativeAudioCue,
   type NativeAudioCueEvent,
   type NativeAudioLaneRequest,
-  type NativeAudioSessionControl,
+  type NativeAudioOutputControl,
   type NativeAudioSessionSnapshot,
   type NativeAudioSnapshot,
 } from "../../lib/nativeAudio";
@@ -42,7 +42,6 @@ import {
   nativePlaybackErrorMessage,
   playbackErrorMessage,
   rememberNativePlaybackError,
-  rememberNativeFallbackCause,
   rememberWebPlaybackError,
   resetLivePlaybackDiagnostics,
   updateNativePlaybackDiagnostics,
@@ -151,15 +150,8 @@ type NativeOutputAuthority = {
 };
 
 type PendingWebPlayback = {
-  fallbackCause: string | null;
-  mode: "fallback" | "forced";
   signature: string;
   startTimeSeconds: number;
-};
-
-type PendingNativeRecovery = {
-  generation: number;
-  sessionId: string;
 };
 
 type WebMediaSourceEnablementOwner = {
@@ -439,8 +431,6 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
   } | null>(null);
   const nativeCapabilitiesPromiseRef = useRef<ReturnType<typeof getNativeAudioCapabilities> | null>(null);
   const nativeBackendRef = useRef<string | null>(null);
-  const pendingNativeFallbackCauseRef = useRef<string | null>(null);
-  const pendingNativeRecoveryRef = useRef<PendingNativeRecovery | null>(null);
   const pendingWebPlaybackRef = useRef<PendingWebPlayback | null>(null);
   const webStallTimersRef = useRef(new Map<HTMLAudioElement, number>());
   const webMediaSourcesEnabledRef = useRef(initialWebMediaSourcesEnabled);
@@ -617,7 +607,7 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
     return true;
   });
 
-  function nativeControl(includeRevision = true) {
+  function nativeControl() {
     const authority = nativeOutputAuthorityRef.current;
     if (!authority) {
       throw new Error("Native session metadata is unavailable.");
@@ -628,7 +618,7 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
       leaseId: "project-playback",
       operationId: `project-playback-${native.operationSequence}`,
       generation: authority.generation,
-      ...(includeRevision ? { timelineRevision: authority.timelineRevision } : {}),
+      timelineRevision: authority.timelineRevision,
     };
   }
 
@@ -687,7 +677,7 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
   }
 
   const enqueueNativeOutputMutation = useStableCallback(function enqueueNativeOutputMutation(
-    execute: (control: NativeAudioSessionControl) => Promise<NativeAudioSnapshot>,
+    execute: (control: NativeAudioOutputControl) => Promise<NativeAudioSnapshot>,
     { allowStaleIntent = false }: { allowStaleIntent?: boolean } = {},
   ) {
     const tag = allowStaleIntent ? nativeOutputOwnerTag() : nativeOutputMutationTag();
@@ -969,7 +959,6 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
     error: unknown,
   ) {
     const message = playbackErrorMessage(error);
-    pendingNativeFallbackCauseRef.current = message;
     rememberNativePlaybackError(message);
     return message;
   });
@@ -980,8 +969,7 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
     if (!targetSession) {
       return false;
     }
-    const sessionSignature = nativeSessionSignature(targetSession);
-    if (nativePlaybackRef.current.blockedSessionSignature === sessionSignature) {
+    if (nativePlaybackRef.current.blockedSessionSignature !== null) {
       return false;
     }
     const artifactIds = getSessionPlaybackArtifactIds(targetSession);
@@ -999,7 +987,7 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
       capabilities.backend === "android-null"
     ) {
       recordNativePlaybackFailure(
-        capabilities?.fallbackReason ?? "Native playback is unavailable.",
+        capabilities?.availabilityReason ?? "Native playback is unavailable.",
       );
       return false;
     }
@@ -1052,6 +1040,52 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
       });
     nativeStopPromiseRef.current = stopPromise;
     return stopPromise;
+  });
+
+  const failNativePlaybackCommand = useStableCallback(function failNativePlaybackCommand(
+    error: unknown,
+    primaryMessage: string,
+    positionSeconds: number = playbackTimeSecondsRef.current,
+  ) {
+    const activeSession = sessionRef.current;
+    nativeControlGenerationRef.current += 1;
+    recordNativePlaybackFailure(error);
+    cancelPrecount("unavailable");
+    clearPendingTransition();
+    allowFreshPlaybackRef.current = true;
+    pendingNativePlayRef.current = null;
+    pendingNativePauseRef.current = null;
+    if (activeSession) {
+      nativePlaybackRef.current.blockedSessionSignature = nativeSessionSignature(activeSession);
+    }
+    const stoppedTime = clampTime(
+      positionSeconds,
+      playbackDurationSecondsRef.current || activeSession?.durationHintSeconds || 0,
+    );
+    void requestNativeStop();
+    markNativePlaybackInactive();
+    nativePlaybackRef.current = {
+      ...nativePlaybackRef.current,
+      preparePromise: null,
+      prepareSignature: null,
+      sessionSignature: null,
+      playbackSignature: null,
+      generation: null,
+      timelineRevision: null,
+    };
+    clearPlaybackControlBackend();
+    setIsPrecounting(false);
+    setIsPlaying(false);
+    setPlaybackTimeSeconds(stoppedTime);
+    if (activeSession) {
+      syncStemElementTimes(activeSession.visibleStemArtifactIds, stoppedTime);
+      getRenderedMediaElements(activeSession).forEach((element) => {
+        element.pause();
+        element.currentTime = stoppedTime;
+      });
+    }
+    markPlaybackError(primaryMessage);
+    void releaseSystemMediaControls().catch(() => undefined);
   });
 
   const pauseRenderedMediaElements = useStableCallback(function pauseRenderedMediaElements(
@@ -1141,6 +1175,7 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
         lanes,
       });
       if (
+        preparedSession.leaseId !== "project-playback" ||
         typeof preparedSession.generation !== "number" ||
         typeof preparedSession.timelineRevision !== "number"
       ) {
@@ -1173,7 +1208,7 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
           };
         }
         recordNativePlaybackFailure(
-          preparedSession.fallbackReason ?? "Native playback prepare fell back to Web Audio.",
+          preparedSession.availabilityReason ?? "Native playback is unavailable.",
         );
         return false;
       }
@@ -1393,7 +1428,7 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
           transportState: snapshot.state,
         });
         recordNativePlaybackFailure(
-          snapshot.fallbackReason ?? "Native playback start fell back to Web Audio.",
+          snapshot.availabilityReason ?? "Native playback is unavailable.",
         );
         nativePlaybackRef.current.blockedSessionSignature = sessionSignature;
         markNativePlaybackInactive();
@@ -1687,7 +1722,7 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
   });
 
   const activateStemPlayback = useCallback(async () => {
-    if (!canUseStemClock()) {
+    if ((isTauriRuntime() && !isWebAudioBackendForced()) || !canUseStemClock()) {
       return;
     }
 
@@ -2058,15 +2093,10 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
     markWebPlaybackStartResult(true);
     setPlaybackControlBackend("web");
     setIsPlaying(true);
-    if (!isWebAudioBackendForced()) {
-      rememberNativeFallbackCause(
-        pendingNativeFallbackCauseRef.current ?? "Native playback is unavailable.",
-      );
-    }
     markPlaybackConfirmed({
       backend: "web",
       detail: null,
-      mode: isWebAudioBackendForced() ? "forced" : "fallback",
+      mode: isTauriRuntime() && isWebAudioBackendForced() ? "forced" : "browser",
     });
     scheduleStemClock(targetPlaybackState);
     return true;
@@ -2194,7 +2224,10 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
           }
         })
         .catch((error) => {
-          rememberNativePlaybackError(playbackErrorMessage(error));
+          failNativePlaybackCommand(
+            error,
+            "Playback stopped. Check your audio output, then press Play to retry.",
+          );
         });
     }
   });
@@ -2278,18 +2311,30 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
       setPlaybackTimeSeconds(snapshot.positionSeconds);
       const cues = nativePlayCueProvider.current?.(snapshot.positionSeconds);
       if (cues) {
-        void updateFollowedMetronomeCues(cues).catch(() => undefined);
+        void updateFollowedMetronomeCues(cues).catch((error) => {
+          if (
+            nativeControlGenerationRef.current === seekGeneration &&
+            nativePlaybackRef.current.sessionSignature === seekSessionSignature
+          ) {
+            failNativePlaybackCommand(
+              error,
+              "Playback stopped. Check your audio output, then press Play to retry.",
+              snapshot.positionSeconds,
+            );
+          }
+        });
       }
       return snapshot;
-    } catch {
+    } catch (error) {
       if (
         nativeControlGenerationRef.current === seekGeneration &&
         nativePlaybackRef.current.sessionSignature === seekSessionSignature
       ) {
-        void requestNativeStop();
-        markNativePlaybackInactive();
-        clearPlaybackControlBackend();
-        setIsPlaying(false);
+        failNativePlaybackCommand(
+          error,
+          "Playback stopped. Check your audio output, then press Play to retry.",
+          timeSeconds,
+        );
       }
       return null;
     }
@@ -2478,21 +2523,11 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
     if (!targetSession || !elements.length) {
       return;
     }
-    const mode = isWebAudioBackendForced() ? "forced" : "fallback";
-    const fallbackCause =
-      mode === "fallback"
-        ? pendingNativeFallbackCauseRef.current ?? "Native playback is unavailable."
-        : null;
-    if (fallbackCause) {
-      rememberNativeFallbackCause(fallbackCause);
-    }
     pendingWebPlaybackRef.current = {
-      fallbackCause,
-      mode,
       signature: playbackSignature(targetSession),
       startTimeSeconds: elements[0]?.currentTime ?? playbackTimeSecondsRef.current,
     };
-    markPlaybackStarting(mode === "forced" ? "web-forced" : "web-fallback");
+    markPlaybackStarting(isTauriRuntime() && isWebAudioBackendForced() ? "web-forced" : "web");
   });
 
   const playWebMediaElements = useStableCallback(async function playWebMediaElements(
@@ -2547,13 +2582,12 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
       return;
     }
     pendingWebPlaybackRef.current = null;
-    pendingNativeFallbackCauseRef.current = null;
     setPlaybackControlBackend("web");
     setIsPlaying(true);
     markPlaybackConfirmed({
       backend: "web",
       detail: null,
-      mode: attempt.mode,
+      mode: isTauriRuntime() && isWebAudioBackendForced() ? "forced" : "browser",
     });
   });
 
@@ -2668,6 +2702,14 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
         }
         if (started) {
           clearPendingTransition();
+          return;
+        }
+        if (isTauriRuntime() && !isWebAudioBackendForced()) {
+          clearPendingTransition();
+          setIsPlaying(false);
+          markPlaybackError(
+            "Playback could not start. Check your audio output, then press Play to retry.",
+          );
           return;
         }
         pendingTransition = latestPendingTransition;
@@ -2862,10 +2904,6 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
     loopEpochRef.current += 1;
     playbackIntentEpochRef.current += 1;
     allowFreshPlaybackRef.current = false;
-    if (pendingNativeRecoveryRef.current) {
-      pendingNativeRecoveryRef.current = null;
-      nativeControlGenerationRef.current += 1;
-    }
     cancelPrecount("playback-stopped");
     const pendingTransition = pendingTransitionRef.current;
     const pendingTransitionWasPlaying = pendingTransition?.shouldPlay === true;
@@ -2944,7 +2982,7 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
           }
           if (!snapshot.nativePlaybackSupported) {
             recordNativePlaybackFailure(
-              snapshot.fallbackReason ?? "Native playback became unavailable while pausing.",
+              snapshot.availabilityReason ?? "Native playback became unavailable while pausing.",
             );
             nativePlaybackRef.current.blockedSessionSignature = pausedSessionSignature;
             setPlaybackTimeSeconds(snapshot.positionSeconds);
@@ -2952,7 +2990,7 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
             clearPlaybackControlBackend();
             setIsPlaying(false);
             markPlaybackError(
-              "Native playback became unavailable. Press Play to continue with Web Audio.",
+              "Playback stopped. Check your audio output, then press Play to retry.",
             );
             void requestNativeStop();
             void releaseSystemMediaControls().catch(() => undefined);
@@ -2967,7 +3005,7 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
           markNativePlaybackInactive();
           markPlaybackPaused();
         })
-        .catch(() => {
+        .catch((error) => {
           const pauseStillCurrent =
             pendingNativePauseRef.current?.generation === pauseGeneration;
           if (pauseStillCurrent) {
@@ -2980,11 +3018,10 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
             nativeSessionSignature(sessionRef.current) === pausedSessionSignature &&
             playbackControlBackendRef.current === "native"
           ) {
-            setIsPlaying(true);
-            markPlaybackConfirmed({
-              backend: "native",
-              detail: nativeBackendRef.current,
-            });
+            failNativePlaybackCommand(
+              error,
+              "Playback stopped. Check your audio output, then press Play to retry.",
+            );
           }
         });
       return;
@@ -3015,6 +3052,7 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
     cancelPrecount,
     clearPlaybackControlBackend,
     enqueueNativeOutputMutation,
+    failNativePlaybackCommand,
     getActiveMediaElements,
     markNativePlaybackInactive,
     recordNativePlaybackFailure,
@@ -3070,7 +3108,9 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
       return;
     }
     if (isTauriRuntime() && !isWebAudioBackendForced()) {
-      markPlaybackError("Native playback could not start. Press Play to retry.");
+      markPlaybackError(
+        "Playback could not start. Check your audio output, then press Play to retry.",
+      );
       return;
     }
 
@@ -3205,7 +3245,9 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
       if (!started) {
         setIsPrecounting(false);
         setIsPlaying(false);
-        markPlaybackError("Native playback could not start. Press Play to retry.");
+        markPlaybackError(
+          "Playback could not start. Check your audio output, then press Play to retry.",
+        );
       }
       return true;
     }
@@ -3369,9 +3411,7 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
       return;
     }
 
-    if (
-      nativePlaybackRef.current.blockedSessionSignature === nativeSessionSignature(targetSession)
-    ) {
+    if (nativePlaybackRef.current.blockedSessionSignature !== null) {
       nativePlaybackRef.current.blockedSessionSignature = null;
     }
 
@@ -3477,7 +3517,6 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
     loopEpochRef.current += 1;
     playbackIntentEpochRef.current += 1;
     allowFreshPlaybackRef.current = true;
-    pendingNativeRecoveryRef.current = null;
     nativeControlGenerationRef.current += 1;
     cancelPrecount("playback-stopped");
     clearPendingTransition();
@@ -3552,7 +3591,7 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
     if (previousSession && previousSession.projectId !== nextSession.projectId) {
       loopEpochRef.current += 1;
       playbackIntentEpochRef.current += 1;
-      pendingNativeRecoveryRef.current = null;
+      invalidateNativeOutputMutations();
       nativeControlGenerationRef.current += 1;
       if (
         nativePlaybackRef.current.sessionSignature !== null &&
@@ -3610,8 +3649,9 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
         setSession(nextSession);
         setPlaybackTimeSeconds(nextTime);
         setPlaybackDurationSeconds(nextSession.durationHintSeconds || playbackDurationSecondsRef.current);
+        const laneMutationTag = nativeOutputMutationTag();
 
-        const fallbackFromNativeLaneUpdate = (message: string) => {
+        const failNativeLaneUpdate = (message: string) => {
           const latestSession = sessionRef.current;
           if (
             !latestSession ||
@@ -3621,32 +3661,17 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
             return;
           }
 
-          recordNativePlaybackFailure(message);
-          nativePlaybackRef.current.blockedSessionSignature = nextNativeSessionSignature;
-          markNativePlaybackInactive();
-          const fallbackTime = clampTime(
+          const stoppedTime = clampTime(
             playbackTimeSecondsRef.current,
             playbackDurationSecondsRef.current || latestSession.durationHintSeconds || 0,
           );
-          void requestNativeStop();
-          syncStemElementTimes(latestSession.visibleStemArtifactIds, fallbackTime);
-          getRenderedMediaElements(latestSession).forEach((element) => {
-            element.pause();
-            element.currentTime = fallbackTime;
-          });
-          setPlaybackTimeSeconds(fallbackTime);
-          clearPlaybackControlBackend();
-          setIsPlaying(false);
-          if (shouldPlay) {
-            markPlaybackStarting("web-fallback");
-            void releaseSystemMediaControls()
-              .then(() => {
-                void playPlaybackImmediately();
-              })
-              .catch(() => markPlaybackError("Playback stopped. Fallback could not start."));
-            return;
-          }
-          void releaseSystemMediaControls().catch((error) => recordNativePlaybackFailure(error));
+          failNativePlaybackCommand(
+            message,
+            shouldPlay
+              ? "Playback stopped. Check your audio output, then press Play to retry."
+              : "Playback could not update. Check your audio output, then press Play to retry.",
+            stoppedTime,
+          );
         };
 
         void enqueueNativeLaneMutation(nextSession)
@@ -3654,16 +3679,18 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
             const latestSession = sessionRef.current;
             if (
               !snapshot ||
+              !laneMutationTag ||
+              !nativeOutputMutationIsCurrent(laneMutationTag) ||
               !latestSession ||
               playbackSignature(latestSession) !== nextSignature ||
-              nativeSessionSignature(latestSession) !== nextNativeSessionSignature
+              nativeSessionSignature(latestSession) !== nextNativeSessionSignature ||
+              !recordNativeSnapshot(snapshot)
             ) {
               return;
             }
-            recordNativeSnapshot(snapshot);
             if (!snapshot.nativePlaybackSupported) {
-              fallbackFromNativeLaneUpdate(
-                snapshot.fallbackReason ?? "Native playback lane update fell back to Web Audio.",
+              failNativeLaneUpdate(
+                snapshot.availabilityReason ?? "Native playback lane update failed.",
               );
               return;
             }
@@ -3693,7 +3720,7 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
             setIsPlaying(snapshot.state === "playing");
           })
           .catch((error) => {
-            fallbackFromNativeLaneUpdate(playbackErrorMessage(error));
+            failNativeLaneUpdate(playbackErrorMessage(error));
           });
         return;
       }
@@ -3774,14 +3801,13 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
     closePlaybackAudioContext,
     disposeStemPlaybackState,
     enqueueNativeLaneMutation,
+    failNativePlaybackCommand,
     getActiveMediaElements,
     getRenderedMediaElements,
     markNativePlaybackInactive,
     playbackResetTimeForSession,
     playbackStartTimeForSession,
-    playPlaybackImmediately,
     readMasterTime,
-    recordNativePlaybackFailure,
     recordNativeSnapshot,
     requestNativeStop,
     setIsPlaying,
@@ -3820,7 +3846,6 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
 
   useEffect(
     () => () => {
-      pendingNativeRecoveryRef.current = null;
       nativeControlGenerationRef.current += 1;
       cancelPrecount("unavailable");
       closePlaybackAudioContext();
@@ -3873,7 +3898,7 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
         }
         recordNativeSnapshot(snapshot);
       } catch {
-        // Transport error events own playback failure and fallback handling.
+        // Transport error events own playback failure handling.
       } finally {
         requestInFlight = false;
       }
@@ -3889,7 +3914,7 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
   }, [isPlaying, playbackControlBackend, recordNativeSnapshot]);
 
   useEffect(() => {
-    if (!isTauriRuntime()) {
+    if (!isTauriRuntime() || isWebAudioBackendForced()) {
       return;
     }
 
@@ -3900,7 +3925,9 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
           !activeSession ||
           !nativePlaybackRef.current.active ||
           nativePrecountRef.current !== null ||
-          position.sessionId !== nativePlaybackRef.current.sessionSignature
+          position.sessionId !== nativePlaybackRef.current.sessionSignature ||
+          position.generation !== nativePlaybackRef.current.generation ||
+          position.timelineRevision !== nativePlaybackRef.current.timelineRevision
         ) {
           return;
         }
@@ -3951,8 +3978,8 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
           !activeSession ||
           snapshot.sessionId !== nativePlaybackRef.current.sessionSignature ||
           nativeSessionSignature(activeSession) !== snapshot.sessionId ||
-          (typeof snapshot.generation === "number" &&
-            snapshot.generation !== nativePlaybackRef.current.generation)
+          snapshot.generation !== nativePlaybackRef.current.generation ||
+          snapshot.timelineRevision !== nativePlaybackRef.current.timelineRevision
         ) {
           return;
         }
@@ -4012,11 +4039,26 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
           !activeSession ||
           terminal.resource !== "output" ||
           terminal.generation !== nativePlaybackRef.current.generation ||
+          terminal.timelineRevision !== nativePlaybackRef.current.timelineRevision ||
           nativeSessionSignature(activeSession) !== nativePlaybackRef.current.sessionSignature
         ) return;
+        const stoppedTime = clampTime(
+          terminal.positionSeconds,
+          playbackDurationSecondsRef.current || activeSession.durationHintSeconds || 0,
+        );
         const activePrecount = nativePrecountRef.current;
         if (activePrecount) countInTelemetryRef.current = { ...countInTelemetryRef.current, active: false,
           lastCancelled: playbackCountInCancelledEvent(activePrecount.telemetry, terminal.nativeTimeUs / 1_000_000, "unavailable") };
+        loopEpochRef.current += 1;
+        playbackIntentEpochRef.current += 1;
+        nativeControlGenerationRef.current += 1;
+        invalidateNativeOutputMutations();
+        precountSequenceRef.current += 1;
+        allowFreshPlaybackRef.current = true;
+        clearPendingTransition();
+        pendingNativePlayRef.current = null;
+        pendingNativePauseRef.current = null;
+        pendingWebPlaybackRef.current = null;
         nativePrecountRef.current = null;
         nativePlaybackRef.current = {
           ...nativePlaybackRef.current,
@@ -4030,14 +4072,24 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
           timelineRevision: null,
         };
         clearPlaybackControlBackend();
+        setPlaybackTimeSeconds(stoppedTime);
         setIsPrecounting(false);
         setIsPlaying(false);
-        markPlaybackError("Native playback stopped. Press Play to retry.");
+        syncStemElementTimes(activeSession?.visibleStemArtifactIds ?? [], stoppedTime);
+        getRenderedMediaElements(activeSession).forEach((element) => {
+          element.pause();
+          element.currentTime = stoppedTime;
+        });
+        markPlaybackError("Playback stopped. Check your audio output, then press Play to retry.");
+        writePlaybackE2ETelemetry({
+          activePath: "none",
+          transportState: "paused",
+          positionSeconds: stoppedTime,
+        });
       }),
       listenNativeAudioErrors((error) => {
         const activeSession = sessionRef.current;
         const pendingNativePlay = pendingNativePlayRef.current;
-        const pendingNativePause = pendingNativePauseRef.current;
         const matchingPendingPlay = Boolean(
           activeSession &&
             pendingNativePlay &&
@@ -4046,14 +4098,11 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
             pendingNativePlay.playbackSignature === playbackSignature(activeSession),
         );
         const ownsPausedNativeSession = playbackControlBackendRef.current === "native";
-        const matchingPendingPause = Boolean(
-          pendingNativePause &&
-            pendingNativePause.generation === nativeControlGenerationRef.current &&
-            pendingNativePause.sessionSignature === error.sessionId,
-        );
         if (
           !activeSession ||
           error.sessionId !== nativePlaybackRef.current.sessionSignature ||
+          error.generation !== nativePlaybackRef.current.generation ||
+          error.timelineRevision !== nativePlaybackRef.current.timelineRevision ||
           nativeSessionSignature(activeSession) !== error.sessionId ||
           (!nativePlaybackRef.current.active &&
             !matchingPendingPlay &&
@@ -4066,82 +4115,22 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
           rememberNativePlaybackError(message);
           return;
         }
-        if (!isWebAudioBackendForced()) {
-          recordNativePlaybackFailure(message);
-          nativePlaybackRef.current.blockedSessionSignature = error.sessionId;
-          markNativePlaybackInactive();
-          clearPlaybackControlBackend();
-          setIsPlaying(false);
-          markPlaybackError("Native playback stopped. Press Play to retry.");
-          return;
-        }
-        const shouldContinuePlayback =
-          (nativePlaybackRef.current.active || matchingPendingPlay) &&
-          !matchingPendingPause;
-        nativeControlGenerationRef.current += 1;
-        pendingNativePlayRef.current = null;
-        pendingNativePauseRef.current = null;
-        recordNativePlaybackFailure(message);
-        const fallbackTime = clampTime(
-          playbackTimeSecondsRef.current,
+        const stoppedTime = clampTime(
+          error.positionSeconds,
           playbackDurationSecondsRef.current || activeSession.durationHintSeconds || 0,
         );
-        nativePlaybackRef.current.blockedSessionSignature = nativeSessionSignature(activeSession);
-        markNativePlaybackInactive();
-        clearPlaybackControlBackend();
-        setIsPlaying(false);
-        if (shouldContinuePlayback) {
-          markPlaybackStarting("web-fallback");
-        } else {
-          markPlaybackError(
-            "Native playback became unavailable. Press Play to continue with Web Audio.",
-          );
-        }
-        void requestNativeStop();
-        nativePlaybackRef.current = {
-          ...nativePlaybackRef.current,
-          preparePromise: null,
-          prepareSignature: null,
-          sessionSignature: null,
-          playbackSignature: null,
-        };
-        const fallbackGeneration = nativeControlGenerationRef.current;
-        pendingNativeRecoveryRef.current = {
-          generation: fallbackGeneration,
-          sessionId: nativeSessionSignature(activeSession),
-        };
-        syncStemElementTimes(activeSession.visibleStemArtifactIds, fallbackTime);
-        getRenderedMediaElements(activeSession).forEach((element) => {
-          element.pause();
-          element.currentTime = fallbackTime;
-        });
-        setPlaybackTimeSeconds(fallbackTime);
+        failNativePlaybackCommand(
+          message,
+          error.code === "decoder_worker_failure"
+            ? "Playback stopped because the audio decoder failed. Press Play to retry."
+            : "Playback stopped. Check your audio output, then press Play to retry.",
+          stoppedTime,
+        );
         writePlaybackE2ETelemetry({
           activePath: "none",
           transportState: "paused",
-          positionSeconds: fallbackTime,
+          positionSeconds: stoppedTime,
         });
-        if (!shouldContinuePlayback) {
-          void releaseSystemMediaControls().catch(() => undefined);
-          return;
-        }
-        void releaseSystemMediaControls()
-          .then(() => {
-            const currentSession = sessionRef.current;
-            if (
-              nativeControlGenerationRef.current !== fallbackGeneration ||
-              pendingNativeRecoveryRef.current?.generation !== fallbackGeneration ||
-              pendingNativeRecoveryRef.current.sessionId !== error.sessionId ||
-              !currentSession ||
-              nativeSessionSignature(currentSession) !== error.sessionId ||
-              nativePlaybackRef.current.blockedSessionSignature !== error.sessionId
-            ) {
-              return;
-            }
-            pendingNativeRecoveryRef.current = null;
-            void playPlaybackImmediately();
-          })
-          .catch(() => markPlaybackError("Playback stopped. Fallback could not start."));
       }),
     ]);
 
@@ -4153,11 +4142,12 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
   }, [
     clearPlaybackControlBackend,
     completeNativePrecount,
+    clearPendingTransition,
+    failNativePlaybackCommand,
     getRenderedMediaElements,
     getPlayableLoopRange,
     markNativePlaybackInactive,
     playbackResetTimeForSession,
-    playPlaybackImmediately,
     recordNativePlaybackFailure,
     recordNativeSnapshot,
     requestNativeStop,

--- a/apps/desktop/src/features/projects/playbackEffects.ts
+++ b/apps/desktop/src/features/projects/playbackEffects.ts
@@ -99,7 +99,7 @@ export function useSystemPlaybackMediaControls({
   ]);
 
   useEffect(() => {
-    if (backend === "none" || !session || !isTauriRuntime()) {
+    if (!session || !isTauriRuntime()) {
       return;
     }
 

--- a/apps/desktop/src/features/settings/SettingsView.tsx
+++ b/apps/desktop/src/features/settings/SettingsView.tsx
@@ -8,7 +8,6 @@ import { DURABLE_AUDIO_CAPABILITIES_QUERY_KEY } from "../../lib/durableAudio";
 import {
   getPlaybackDiagnosticsVersion,
   readPlaybackLiveDiagnostics,
-  readRememberedNativeFallbackCause,
   readRememberedNativePlaybackError,
   readRememberedPlaybackBackend,
   readRememberedWebPlaybackError,
@@ -418,8 +417,8 @@ function nativePlaybackCapabilityLabel(capabilities: NativeAudioCapabilities | u
   if (capabilities.nativePlaybackSupported && capabilities.backend !== "android-null") {
     return `Native (${capabilities.backend})`;
   }
-  const reason = capabilities.fallbackReason
-    ? ` — ${redactPlaybackDiagnosticText(capabilities.fallbackReason)}`
+  const reason = capabilities.availabilityReason
+    ? ` — ${redactPlaybackDiagnosticText(capabilities.availabilityReason)}`
     : "";
   return `Unavailable${reason}`;
 }
@@ -441,7 +440,7 @@ function lastPlaybackBackendLabel(backend: PlaybackBackend | null) {
     ? `Native (${backend.detail ?? "unknown"})`
     : backend.mode === "forced"
       ? "Web Audio (forced)"
-      : "Web Audio (fallback)";
+      : "Web Audio";
 }
 
 function currentPlaybackStateLabel(
@@ -461,8 +460,8 @@ function currentPlaybackPathLabel(
   if (diagnostics.currentPath === "web-forced") {
     return "Web Audio (forced)";
   }
-  if (diagnostics.currentPath === "web-fallback") {
-    return "Web Audio (fallback)";
+  if (diagnostics.currentPath === "web") {
+    return "Web Audio";
   }
   return "None";
 }
@@ -731,7 +730,9 @@ export function SettingsView() {
   const [availabilityRetrying, setAvailabilityRetrying] = useState(false);
   const [isNativeValidationBusy, setIsNativeValidationBusy] = useState(false);
   const [nativeValidationStatus, setNativeValidationStatus] = useState<SnapshotStatus | null>(null);
-  const webAudioForced = isWebAudioBackendForced();
+  const tauriRuntime = typeof window !== "undefined" && "__TAURI_INTERNALS__" in window;
+  const webAudioForced = tauriRuntime && isWebAudioBackendForced();
+  const normalTauriAudio = tauriRuntime && !webAudioForced;
   const androidRuntime = isAndroidRuntime();
   useSyncExternalStore(
     subscribePlaybackDiagnostics,
@@ -774,23 +775,27 @@ export function SettingsView() {
     staleTime: Infinity,
   });
   const nativeAudioQuery = useQuery({
+    enabled: normalTauriAudio,
     queryKey: ["native-audio-capabilities"],
     queryFn: getNativeAudioCapabilities,
   });
   const nativeDiagnosticsAvailabilityQuery = useQuery({
+    enabled: normalTauriAudio,
     queryKey: ["native-audio-diagnostics-availability"],
     queryFn: getNativeAudioDiagnosticsAvailability,
   });
   const nativeDiagnosticsQuery = useQuery({
-    enabled: nativeDiagnosticsAvailabilityQuery.data?.enabled === true,
+    enabled: normalTauriAudio && nativeDiagnosticsAvailabilityQuery.data?.enabled === true,
     queryKey: ["native-audio-diagnostics"],
     queryFn: readNativeAudioDiagnostics,
   });
   const nativeInputQuery = useQuery({
+    enabled: normalTauriAudio,
     queryKey: ["native-audio-input-state"],
     queryFn: getNativeAudioInputState,
   });
   const nativePermissionQuery = useQuery({
+    enabled: normalTauriAudio,
     queryKey: ["native-audio-input-permission"],
     queryFn: getNativeAudioInputPermissionStatus,
   });
@@ -798,7 +803,6 @@ export function SettingsView() {
   const lastNativeCaptureError = readRememberedTunerNativeCaptureError();
   const lastPlaybackBackend = readRememberedPlaybackBackend();
   const lastNativePlaybackError = readRememberedNativePlaybackError();
-  const latestNativeFallbackCause = readRememberedNativeFallbackCause();
   const latestWebPlaybackError = readRememberedWebPlaybackError();
   const savedThemeOverrideCount = themeOverrideCount(themeOverrides);
   const beatAvailabilityResolved = beatBackendsQuery.data?.backends !== undefined;
@@ -1256,7 +1260,7 @@ export function SettingsView() {
 
           <TunerPreferenceControls
             inputDeviceId={defaultTunerInputDeviceId}
-            nativeCaptureDisabled={webAudioForced}
+            nativeCaptureDisabled={!normalTauriAudio}
             onInputDeviceChange={setDefaultTunerInputDeviceId}
             onReferenceHzChange={setDefaultTunerReferenceHz}
             onVisualModeChange={setDefaultTunerVisualMode}
@@ -1468,7 +1472,7 @@ export function SettingsView() {
                 </div>
                 <div>
                   <dt>Capture Selection Policy</dt>
-                  <dd>{webAudioForced ? "Forced Web Audio" : isAndroidRuntime() || nativeAudioQuery.data?.platform === "android" ? "Native required" : "Native preferred"}</dd>
+                  <dd>{webAudioForced ? "Web Audio (forced)" : normalTauriAudio ? "Native required" : "Web Audio"}</dd>
                 </div>
                 <div>
                   <dt>Current Microphone Permission</dt>
@@ -1500,7 +1504,7 @@ export function SettingsView() {
                 </div>
                 <div>
                   <dt>Playback Selection Policy</dt>
-                  <dd>{webAudioForced ? "Web Audio forced" : "Native preferred"}</dd>
+                  <dd>{webAudioForced ? "Web Audio (forced)" : normalTauriAudio ? "Native required" : "Web Audio"}</dd>
                 </div>
               </dl>
             </section>
@@ -1595,10 +1599,6 @@ export function SettingsView() {
                 <div>
                   <dt>Latest Native Playback Failure</dt>
                   <dd>{lastNativePlaybackError ?? "None"}</dd>
-                </div>
-                <div>
-                  <dt>Latest Native Fallback Cause</dt>
-                  <dd>{latestNativeFallbackCause ?? "None"}</dd>
                 </div>
                 <div>
                   <dt>Latest Web Media Failure</dt>

--- a/apps/desktop/src/features/tools/ToolsView.tsx
+++ b/apps/desktop/src/features/tools/ToolsView.tsx
@@ -13,7 +13,7 @@ import {
   type NativeAudioCapabilities,
   type NativeAudioInputFrame,
   type NativeAudioInputState,
-  type NativeAudioSessionControl,
+  type NativeAudioCaptureControl,
 } from "../../lib/nativeAudio";
 import { useStableCallback } from "../../lib/useStableCallback";
 import {
@@ -144,7 +144,7 @@ function ChromaticTunerPage() {
   const [activeCaptureBackend, setActiveCaptureBackend] = useState<CaptureBackend | null>(null);
   const [nativeAudioCapabilities, setNativeAudioCapabilities] =
     useState<NativeAudioCapabilities | null>(null);
-  const webAudioForced = isWebAudioBackendForced();
+  const webAudioForced = isTauriRuntime() && isWebAudioBackendForced();
   const androidRuntime = isAndroidRuntime() || nativeAudioCapabilities?.platform === "android";
   const [reading, setReading] = useState<TunerPitchReading | null>(null);
   const [deviceRefreshToken, setDeviceRefreshToken] = useState(0);
@@ -156,7 +156,7 @@ function ChromaticTunerPage() {
   const mediaSourceRef = useRef<MediaStreamAudioSourceNode | null>(null);
   const nativeCaptureActiveRef = useRef(false);
   const nativeCaptureGenerationRef = useRef<number | null>(null);
-  const nativeCaptureControlRef = useRef<NativeAudioSessionControl | null>(null);
+  const nativeCaptureControlRef = useRef<Omit<NativeAudioCaptureControl, "operationId"> | null>(null);
   const nativeCaptureOperationRef = useRef(0);
   const nativeInputUnlistenRef = useRef<(() => void) | null>(null);
   const nativeStateUnlistenRef = useRef<(() => void) | null>(null);
@@ -184,7 +184,7 @@ function ChromaticTunerPage() {
     let active = true;
 
     async function refreshNativeAudioCapabilities() {
-      if (webAudioForced) {
+      if (webAudioForced || !isTauriRuntime()) {
         setNativeAudioCapabilities(null);
         if (statusRef.current === "unsupported" && canUseTunerCapture(null)) {
           setStatus("idle");
@@ -232,11 +232,12 @@ function ChromaticTunerPage() {
       nativeCaptureActiveRef.current = false;
       const control = nativeCaptureControlRef.current;
       nativeCaptureControlRef.current = null;
-      void stopNativeAudioInput({
-        leaseId: control?.leaseId ?? "tuner-capture",
-        generation: control?.generation,
-        operationId: `tuner-capture-${++nativeCaptureOperationRef.current}`,
-      }).catch(() => undefined);
+      if (control) {
+        void stopNativeAudioInput({
+          ...control,
+          operationId: `tuner-capture-${++nativeCaptureOperationRef.current}`,
+        }).catch(() => undefined);
+      }
     }
 
     try {
@@ -306,7 +307,7 @@ function ChromaticTunerPage() {
   });
 
   const resolveNativeAudioCapabilities = useStableCallback(async function resolveNativeAudioCapabilities() {
-    if (webAudioForced) {
+    if (webAudioForced || !isTauriRuntime()) {
       setNativeAudioCapabilities(null);
       return null;
     }
@@ -397,9 +398,19 @@ function ChromaticTunerPage() {
       leaseId: "tuner-capture",
       operationId: `tuner-capture-${++nativeCaptureOperationRef.current}`,
     });
+    if (
+      !inputState.active ||
+      !inputState.leaseId ||
+      typeof inputState.generation !== "number" ||
+      inputState.generation <= 0 ||
+      typeof inputState.nativeTimeUs !== "number" ||
+      inputState.captureGeneration <= 0
+    ) {
+      throw new Error("Native microphone ownership metadata is unavailable.");
+    }
     nativeCaptureGenerationRef.current = inputState.captureGeneration;
     nativeCaptureControlRef.current = {
-      leaseId: inputState.leaseId ?? "tuner-capture",
+      leaseId: inputState.leaseId,
       generation: inputState.generation,
     };
     nativeCaptureActiveRef.current = inputState.active;
@@ -497,10 +508,8 @@ function ChromaticTunerPage() {
     const selectedDeviceId = nextDeviceId ?? inputDeviceIdRef.current;
     const selectedNativeDevice = isNativeAudioInputDeviceId(selectedDeviceId);
     const nativeCapabilities = await resolveNativeAudioCapabilities();
-    const androidNativeRequired =
-      isAndroidRuntime() || nativeCapabilities?.platform === "android";
     const tauriNativeRequired = isTauriRuntime() && !webAudioForced;
-    const nativeRequired = tauriNativeRequired || androidNativeRequired;
+    const nativeRequired = tauriNativeRequired;
 
     if (nativeRequired && !nativeCapabilities?.micCaptureSupported) {
       const message = "Native microphone capture is unavailable. Check microphone access and retry.";
@@ -516,7 +525,7 @@ function ChromaticTunerPage() {
           selectedDeviceId,
           requestId,
           nativeCapabilities.backend,
-          androidNativeRequired,
+          nativeCapabilities.platform === "android",
         );
         return;
       } catch (error) {
@@ -526,18 +535,12 @@ function ChromaticTunerPage() {
           return;
         }
         releaseCapture();
-        if (tauriNativeRequired || androidNativeRequired) {
+        if (tauriNativeRequired) {
           setStatus("error");
           setErrorMessage(message);
           return;
         }
       }
-    } else if (!webAudioForced && androidNativeRequired) {
-      const message = "Native Android microphone capture is unavailable.";
-      rememberTunerNativeCaptureError(message);
-      setStatus("error");
-      setErrorMessage(message);
-      return;
     } else if (!webAudioForced && selectedNativeDevice) {
       rememberTunerNativeCaptureError(
         "Selected microphone requires native input capture, but native capture is unavailable.",
@@ -584,7 +587,7 @@ function ChromaticTunerPage() {
   ) {
     inputDeviceIdRef.current = value;
     setDefaultTunerInputDeviceId(value);
-    if (statusRef.current === "listening") {
+    if (statusRef.current === "listening" || statusRef.current === "error") {
       void startTuner(value);
     }
   });
@@ -654,7 +657,7 @@ function ChromaticTunerPage() {
           className="tuner-preferences--with-mode"
           clearDevicesWhenSystemDefaultOnly={isTauriRuntime() || androidRuntime}
           inputDeviceId={defaultTunerInputDeviceId}
-          nativeCaptureDisabled={webAudioForced}
+          nativeCaptureDisabled={webAudioForced || !isTauriRuntime()}
           onInputDeviceChange={handleInputDeviceChange}
           onReferenceHzChange={handleReferenceHzChange}
           onVisualModeChange={handleVisualModeChange}

--- a/apps/desktop/src/features/tools/metronome.tsx
+++ b/apps/desktop/src/features/tools/metronome.tsx
@@ -16,6 +16,7 @@ import {
   getWebAudioContextConstructor,
 } from "../../lib/webAudio";
 import { usePlayback, type PlaybackSnapshot } from "../projects/playback-context";
+import { playbackRateForSession } from "../projects/playbackUtils";
 import { MetronomeContext, type MetronomeLaunchOptions } from "./metronome-context";
 import { DEFAULT_METRONOME_SOUND, scheduleMetronomeClick } from "./metronomeSound";
 import {
@@ -35,6 +36,11 @@ import {
 const SCHEDULE_AHEAD_SECONDS = 0.12;
 const SCHEDULER_INTERVAL_MS = 25;
 const START_DELAY_SECONDS = 0.035;
+
+function playbackRateForSnapshot(snapshot: PlaybackSnapshot) {
+  const playbackRate = playbackRateForSession(snapshot.session);
+  return Number.isFinite(playbackRate) && playbackRate > 0 ? playbackRate : 1;
+}
 
 type NativeMetronomeCommand = {
   enabled: boolean;
@@ -220,13 +226,15 @@ export function MetronomeProvider({ children }: { children: ReactNode }) {
       return;
     }
     const playbackTimeSeconds = Math.max(0, snapshot.playbackTimeSeconds);
+    const playbackRate = playbackRateForSnapshot(snapshot);
     let beatIndex = nextTimedBeatIndex({
       lastPlaybackTimeSeconds: lastSyncedPlaybackTimeRef.current,
       lastScheduledBeatIndex: lastSyncedScheduledBeatRef.current,
       playbackTimeSeconds,
       timingGrid,
     });
-    const scheduleUntilPlaybackSeconds = playbackTimeSeconds + SCHEDULE_AHEAD_SECONDS;
+    const scheduleUntilPlaybackSeconds =
+      playbackTimeSeconds + SCHEDULE_AHEAD_SECONDS * playbackRate;
 
     while (
       beatIndex < timingGrid.beats.length &&
@@ -234,7 +242,8 @@ export function MetronomeProvider({ children }: { children: ReactNode }) {
     ) {
       const beat = timingGrid.beats[beatIndex];
       const startTimeSeconds =
-        audioContext.currentTime + Math.max(0, beat.seconds - playbackTimeSeconds);
+        audioContext.currentTime +
+        Math.max(0, beat.seconds - playbackTimeSeconds) / playbackRate;
       scheduleBeat(audioContext, beat.index, startTimeSeconds, beat);
       lastSyncedScheduledBeatRef.current = beatIndex;
       beatIndex += 1;
@@ -253,18 +262,21 @@ export function MetronomeProvider({ children }: { children: ReactNode }) {
     }
     const beatSeconds = secondsPerBeat(bpmRef.current);
     const playbackTimeSeconds = Math.max(0, snapshot.playbackTimeSeconds);
+    const playbackRate = playbackRateForSnapshot(snapshot);
     let beatIndex = nextSyncedBeatIndex({
       bpm: bpmRef.current,
       lastPlaybackTimeSeconds: lastSyncedPlaybackTimeRef.current,
       lastScheduledBeatIndex: lastSyncedScheduledBeatRef.current,
       playbackTimeSeconds,
     });
-    const scheduleUntilPlaybackSeconds = playbackTimeSeconds + SCHEDULE_AHEAD_SECONDS;
+    const scheduleUntilPlaybackSeconds =
+      playbackTimeSeconds + SCHEDULE_AHEAD_SECONDS * playbackRate;
 
     while (beatIndex * beatSeconds <= scheduleUntilPlaybackSeconds) {
       const beatPlaybackTimeSeconds = beatIndex * beatSeconds;
       const startTimeSeconds =
-        audioContext.currentTime + Math.max(0, beatPlaybackTimeSeconds - playbackTimeSeconds);
+        audioContext.currentTime +
+        Math.max(0, beatPlaybackTimeSeconds - playbackTimeSeconds) / playbackRate;
       scheduleBeat(audioContext, beatIndex, startTimeSeconds);
       lastSyncedScheduledBeatRef.current = beatIndex;
       beatIndex += 1;
@@ -294,18 +306,31 @@ export function MetronomeProvider({ children }: { children: ReactNode }) {
       if (!command.enabled && !current) {
         return null;
       }
-      const next = await setNativeStandaloneMetronome({
+      if (current && !current.leaseId) {
+        throw new Error("Native metronome ownership metadata is unavailable.");
+      }
+      const configuration = {
         enabled: command.enabled,
         bpm: bpmRef.current,
         beatsPerBar: beatsPerBarRef.current,
         accentFirstBeat: accentFirstBeatRef.current,
         gain: volumeRef.current,
         followPlayback: followPlaybackRef.current,
-        leaseId: current?.leaseId ?? "standalone-metronome",
         operationId: `standalone-metronome-${++nativeStandaloneOperationRef.current}`,
-        generation: current?.generation,
-        timelineRevision: current?.revision,
-      });
+      };
+      const next = await setNativeStandaloneMetronome(
+        current?.leaseId
+          ? {
+              ...configuration,
+              leaseId: current.leaseId,
+              generation: current.generation,
+              timelineRevision: current.revision,
+            }
+          : { ...configuration, leaseId: "standalone-metronome" },
+      );
+      if (!next.leaseId || next.generation <= 0 || next.revision <= 0) {
+        throw new Error("Native metronome ownership metadata is unavailable.");
+      }
       if (command.lifecycle === nativeStandaloneLifecycleRef.current) {
         nativeStandaloneRef.current = next;
       }
@@ -392,7 +417,9 @@ export function MetronomeProvider({ children }: { children: ReactNode }) {
     if (!enabled) {
       return;
     }
-    await startMetronome();
+    if (!isTauriRuntime() || isWebAudioBackendForced()) {
+      await startMetronome();
+    }
   });
 
   const launchMetronome = useStableCallback(async function launchMetronome(
@@ -574,7 +601,12 @@ export function MetronomeProvider({ children }: { children: ReactNode }) {
   }, [nativeSession?.generation, nativeSession?.timelineRevision]);
 
   useEffect(() => {
-    if (!isRunning || !isTauriRuntime() || isWebAudioBackendForced()) return;
+    if (
+      !isRunning ||
+      !nativeStandaloneRef.current ||
+      !isTauriRuntime() ||
+      isWebAudioBackendForced()
+    ) return;
     const epoch = nativeStandaloneCommandEpochRef.current;
     const lifecycle = nativeStandaloneLifecycleRef.current;
     void enqueueNativeMetronomeCommand({ enabled: true, epoch, lifecycle }).catch(() => {

--- a/apps/desktop/src/lib/nativeAudio.test.ts
+++ b/apps/desktop/src/lib/nativeAudio.test.ts
@@ -38,6 +38,7 @@ import {
   listenNativeAudioInputState,
   listenNativeAudioErrors,
   listenNativeAudioPositions,
+  listenNativeAudioState,
   listenNativeAudioSessions,
   listenNativeAudioTerminal,
   pauseNativeAudio,
@@ -48,7 +49,6 @@ import {
   resetNativeAudioDiagnostics,
   scheduleNativeAudioCues,
   seekNativeAudio,
-  setNativeAudioClick,
   setNativeAudioLanes,
   setNativeAudioMonitor,
   setNativeStandaloneMetronome,
@@ -65,8 +65,7 @@ const capabilities: NativeAudioCapabilities = {
   micMonitoringSupported: false,
   systemInputVolumeSupported: true,
   emitsEvents: ["audio://state", "audio://input-frame", "audio://devices-changed"],
-  fallbackRequired: true,
-  fallbackReason: "Native audio playback is not wired yet; use existing WebView playback.",
+  availabilityReason: "native_audio_unavailable",
 };
 
 const devices: NativeAudioDevices = {
@@ -82,9 +81,13 @@ const snapshot: NativeAudioSnapshot = {
   durationSeconds: 180,
   playbackRate: 1,
   nativePlaybackSupported: false,
-  fallbackReason: "Native audio playback is not wired yet; use existing WebView playback.",
+  availabilityReason: "native_audio_unavailable",
   lanes: [],
   bufferHealth: [],
+  leaseId: "project-playback",
+  generation: 4,
+  timelineRevision: 2,
+  nativeTimeUs: 100,
 };
 
 const inputState: NativeAudioInputState = {
@@ -98,6 +101,9 @@ const inputState: NativeAudioInputState = {
   capturePath: "desktop-cpal",
   permissionState: "unavailable",
   error: null,
+  leaseId: "tuner-capture",
+  generation: 3,
+  nativeTimeUs: 100,
 };
 
 describe("native audio adapter", () => {
@@ -179,6 +185,7 @@ describe("native audio adapter", () => {
           ringCapacitySamples: 1024,
           scratchCapacitySamples: 512,
           rssKibAtBegin: null,
+          firstOutputStreamErrorKind: "xrun" as const,
           safeCodes: [],
         },
       ],
@@ -206,6 +213,8 @@ describe("native audio adapter", () => {
 
   it("sends camelCase session and transport payloads", async () => {
     const sessionRequest = {
+      leaseId: "project-playback",
+      operationId: "prepare-1",
       sessionId: "session-1",
       durationSeconds: 180,
       playbackRate: 1,
@@ -222,54 +231,48 @@ describe("native audio adapter", () => {
       ],
     };
     const laneUpdate = { lanes: sessionRequest.lanes };
+    const control = {
+      leaseId: "project-playback",
+      operationId: "mutate-1",
+      generation: 4,
+      timelineRevision: 2,
+    };
     mockInvoke.mockResolvedValue(snapshot);
 
     await prepareNativeAudioSession(sessionRequest);
-    await playNativeAudio({ startTimeSeconds: 4, scheduledStartTimeSeconds: 10 });
-    await seekNativeAudio({ timeSeconds: 24 });
-    await setNativeAudioLanes(laneUpdate);
-    await setNativeAudioClick({
-      enabled: true,
-      bpm: 120,
-      beatsPerBar: 4,
-      accentFirstBeat: true,
-      gain: 0.75,
-      followTransport: true,
-    });
+    await playNativeAudio({ ...control, startTimeSeconds: 4, scheduledStartTimeSeconds: 10 });
+    await seekNativeAudio({ ...control, operationId: "seek-1", timeSeconds: 24 });
+    await setNativeAudioLanes(laneUpdate, { ...control, operationId: "lanes-1" });
 
     expect(mockInvoke).toHaveBeenNthCalledWith(1, "audio_prepare_session", {
       payload: sessionRequest,
     });
     expect(mockInvoke).toHaveBeenNthCalledWith(2, "audio_play", {
-      payload: { startTimeSeconds: 4, scheduledStartTimeSeconds: 10 },
+      payload: { ...control, startTimeSeconds: 4, scheduledStartTimeSeconds: 10 },
     });
     expect(mockInvoke).toHaveBeenNthCalledWith(3, "audio_seek", {
-      payload: { timeSeconds: 24 },
+      payload: { ...control, operationId: "seek-1", timeSeconds: 24 },
     });
     expect(mockInvoke).toHaveBeenNthCalledWith(4, "audio_set_lanes", {
       payload: laneUpdate,
-    });
-    expect(mockInvoke).toHaveBeenNthCalledWith(5, "audio_set_click", {
-      payload: {
-        enabled: true,
-        bpm: 120,
-        beatsPerBar: 4,
-        accentFirstBeat: true,
-        gain: 0.75,
-        followTransport: true,
-      },
+      control: { ...control, operationId: "lanes-1" },
     });
   });
 
-  it("wraps snapshot and stop-state commands without payloads", async () => {
+  it("wraps snapshot and stop-state commands with ownership metadata", async () => {
     mockInvoke.mockResolvedValue(snapshot);
+    const control = {
+      leaseId: "project-playback", operationId: "pause-1", generation: 4, timelineRevision: 2,
+    };
 
-    await pauseNativeAudio();
-    await stopNativeAudio();
+    await pauseNativeAudio(control);
+    await stopNativeAudio({ ...control, operationId: "stop-1" });
     await getNativeAudioSnapshot();
 
-    expect(mockInvoke).toHaveBeenNthCalledWith(1, "audio_pause");
-    expect(mockInvoke).toHaveBeenNthCalledWith(2, "audio_stop");
+    expect(mockInvoke).toHaveBeenNthCalledWith(1, "audio_pause", { payload: control });
+    expect(mockInvoke).toHaveBeenNthCalledWith(2, "audio_stop", {
+      payload: { ...control, operationId: "stop-1" },
+    });
     expect(mockInvoke).toHaveBeenNthCalledWith(3, "audio_get_snapshot");
   });
 
@@ -296,7 +299,9 @@ describe("native audio adapter", () => {
       operationId: "metro-1",
       cues: [{ cueIndex: 2, positionSeconds: 1.5, kind: "metronome", accent: true, gain: 0.4 }],
     });
-    await cancelNativeAudioCues({ leaseId: "practice", timelineRevision: 3 }, "metronome");
+    await cancelNativeAudioCues({
+      leaseId: "practice", generation: 7, timelineRevision: 3, operationId: "cancel-1",
+    }, "metronome");
 
     expect(mockInvoke.mock.calls).toEqual([
       ["audio_get_session_snapshot"],
@@ -305,7 +310,9 @@ describe("native audio adapter", () => {
         cues: [{ cueIndex: 2, positionSeconds: 1.5, kind: "metronome", accent: true, gain: 0.4 }],
       } }],
       ["audio_cancel_cues", {
-        payload: { leaseId: "practice", timelineRevision: 3 }, kind: "metronome",
+        payload: {
+          leaseId: "practice", generation: 7, timelineRevision: 3, operationId: "cancel-1",
+        }, kind: "metronome",
       }],
     ]);
   });
@@ -379,21 +386,34 @@ describe("native audio adapter", () => {
 
     await getNativeAudioInputState();
     await startNativeAudioInput({
+      leaseId: "tuner-capture",
+      operationId: "start-1",
       deviceId: "built-in",
       monitorEnabled: true,
       monitorGain: 0.5,
     });
-    await setNativeAudioMonitor({ enabled: false, gain: 0 });
-    await stopNativeAudioInput();
+    await setNativeAudioMonitor({
+      enabled: false, gain: 0, leaseId: "tuner-capture", operationId: "monitor-1", generation: 3,
+    });
+    await stopNativeAudioInput({
+      leaseId: "tuner-capture", operationId: "stop-1", generation: 3,
+    });
 
     expect(mockInvoke).toHaveBeenNthCalledWith(1, "audio_get_input_state");
     expect(mockInvoke).toHaveBeenNthCalledWith(2, "audio_start_input", {
-      payload: { deviceId: "built-in", monitorEnabled: true, monitorGain: 0.5 },
+      payload: {
+        deviceId: "built-in", monitorEnabled: true, monitorGain: 0.5,
+        leaseId: "tuner-capture", operationId: "start-1",
+      },
     });
     expect(mockInvoke).toHaveBeenNthCalledWith(3, "audio_set_monitor", {
-      payload: { enabled: false, gain: 0 },
+      payload: {
+        enabled: false, gain: 0, leaseId: "tuner-capture", operationId: "monitor-1", generation: 3,
+      },
     });
-    expect(mockInvoke).toHaveBeenNthCalledWith(4, "audio_stop_input");
+    expect(mockInvoke).toHaveBeenNthCalledWith(4, "audio_stop_input", {
+      payload: { leaseId: "tuner-capture", operationId: "stop-1", generation: 3 },
+    });
   });
 
   it("keeps permission status and request separate from capture start", async () => {
@@ -470,9 +490,16 @@ describe("native audio adapter", () => {
     expect(unlisten).toHaveBeenCalled();
   });
 
-  it("wraps code-only native error events", async () => {
+  it("decodes correlated native error events", async () => {
     const unlisten = vi.fn();
-    const error = { sessionId: "session-1", code: "stream_invalidated" as const };
+    const error = {
+      sessionId: "session-1",
+      code: "stream_invalidated" as const,
+      generation: 4,
+      timelineRevision: 9,
+      nativeTimeUs: 101,
+      positionSeconds: 12.5,
+    };
     mockListen.mockImplementation(async (_eventName, callback) => {
       callback({ event: "audio://error", id: 1, payload: error });
       return unlisten;
@@ -485,6 +512,27 @@ describe("native audio adapter", () => {
     expect(handler).toHaveBeenCalledWith(error);
     stopListening();
     expect(unlisten).toHaveBeenCalled();
+  });
+
+  it("decodes correlated native state events", async () => {
+    const state = {
+      sessionId: "session-1",
+      state: "paused" as const,
+      positionSeconds: 12.5,
+      generation: 4,
+      timelineRevision: 9,
+      nativeTimeUs: 102,
+    };
+    mockListen.mockImplementation(async (_eventName, callback) => {
+      callback({ event: "audio://state", id: 1, payload: state });
+      return vi.fn();
+    });
+    const handler = vi.fn();
+
+    await listenNativeAudioState(handler);
+
+    expect(mockListen).toHaveBeenCalledWith("audio://state", expect.any(Function));
+    expect(handler).toHaveBeenCalledWith(state);
   });
 
   it("decodes safe camelCase session, cue, and terminal events", async () => {

--- a/apps/desktop/src/lib/nativeAudio.ts
+++ b/apps/desktop/src/lib/nativeAudio.ts
@@ -16,11 +16,18 @@ export type NativeAudioEventName =
   | "audio://cue"
   | "audio://terminal";
 
-export type NativeAudioSessionControl = {
-  leaseId?: string | null;
-  operationId?: string | null;
-  generation?: number | null;
-  timelineRevision?: number | null;
+export type NativeAudioAcquisitionControl = {
+  leaseId: string;
+  operationId: string;
+};
+
+export type NativeAudioOutputControl = NativeAudioAcquisitionControl & {
+  generation: number;
+  timelineRevision: number;
+};
+
+export type NativeAudioCaptureControl = NativeAudioAcquisitionControl & {
+  generation: number;
 };
 
 export type NativeAudioSessionSnapshot = {
@@ -63,6 +70,9 @@ export type NativeAudioTerminalEvent = {
   resource: "output" | "capture";
   source: "output_runtime" | "capture_runtime" | "project_playback" | "tuner_capture";
   generation: number;
+  timelineRevision: number;
+  captureGeneration: number | null;
+  positionSeconds: number;
   code: string;
   nativeTimeUs: number;
 };
@@ -75,8 +85,7 @@ export type NativeAudioCapabilities = {
   micMonitoringSupported: boolean;
   systemInputVolumeSupported: boolean;
   emitsEvents: NativeAudioEventName[];
-  fallbackRequired: boolean;
-  fallbackReason: string | null;
+  availabilityReason: string | null;
 };
 
 export type NativeAudioDiagnosticsAvailability = {
@@ -86,6 +95,8 @@ export type NativeAudioDiagnosticsAvailability = {
 export type NativeAudioDiagnosticOperationKind =
   | "prepare"
   | "play"
+  | "pause"
+  | "stop"
   | "seek"
   | "tempo"
   | "lane_update"
@@ -99,6 +110,23 @@ export type NativeAudioDiagnosticSafeCode =
   | "device_changed"
   | "device_not_available"
   | "stream_invalidated";
+
+export type NativeAudioDiagnosticOutputStreamErrorKind =
+  | "device_busy"
+  | "device_changed"
+  | "device_not_available"
+  | "host_unavailable"
+  | "invalid_input"
+  | "permission_denied"
+  | "realtime_denied"
+  | "resource_exhausted"
+  | "stream_invalidated"
+  | "unsupported_config"
+  | "unsupported_operation"
+  | "xrun"
+  | "backend_error"
+  | "other"
+  | "unknown";
 
 export type NativeAudioDiagnosticCounters = {
   operationCount: number;
@@ -143,6 +171,7 @@ export type NativeAudioDiagnosticOperation = {
   ringCapacitySamples: number | null;
   scratchCapacitySamples: number | null;
   rssKibAtBegin: number | null;
+  firstOutputStreamErrorKind: NativeAudioDiagnosticOutputStreamErrorKind | null;
   safeCodes: NativeAudioDiagnosticSafeCodeCount[];
 };
 
@@ -185,7 +214,7 @@ export type NativeAudioLaneUpdate = {
   playbackRate?: number | null;
 };
 
-export type NativeAudioSessionRequest = NativeAudioSessionControl & {
+export type NativeAudioSessionRequest = NativeAudioAcquisitionControl & {
   sessionId: string;
   durationSeconds?: number | null;
   playbackRate?: number | null;
@@ -195,15 +224,16 @@ export type NativeAudioSessionRequest = NativeAudioSessionControl & {
 
 export type NativeAudioSession = {
   id: string;
+  leaseId: string;
   nativePlaybackSupported: boolean;
-  fallbackReason: string | null;
+  availabilityReason: string | null;
   laneCount: number;
-  generation?: number | null;
-  timelineRevision?: number | null;
-  nativeTimeUs?: number | null;
+  generation: number;
+  timelineRevision: number;
+  nativeTimeUs: number;
 };
 
-export type NativeAudioPlayRequest = NativeAudioSessionControl & {
+export type NativeAudioPlayRequest = NativeAudioOutputControl & {
   startTimeSeconds?: number | null;
   scheduledStartTimeSeconds?: number | null;
   startAtNativeUs?: number | null;
@@ -213,7 +243,7 @@ export type NativeAudioPlayRequest = NativeAudioSessionControl & {
 
 export const nativePlayCueProvider = { current: null as ((positionSeconds: number) => Array<NativeAudioCue & { kind: "metronome" }>) | null };
 
-export type NativeAudioSeekRequest = NativeAudioSessionControl & {
+export type NativeAudioSeekRequest = NativeAudioOutputControl & {
   timeSeconds: number;
 };
 
@@ -244,25 +274,23 @@ export type NativeAudioSnapshot = {
   durationSeconds: number;
   playbackRate: number;
   nativePlaybackSupported: boolean;
-  fallbackReason: string | null;
+  availabilityReason: string | null;
   lanes: NativeAudioLane[];
   bufferHealth: NativeAudioBufferHealth[];
-  leaseId?: string | null;
-  generation?: number | null;
-  timelineRevision?: number | null;
-  nativeTimeUs?: number | null;
+  leaseId: string | null;
+  generation: number;
+  timelineRevision: number;
+  nativeTimeUs: number;
 };
 
-export type NativeAudioClickRequest = {
-  enabled: boolean;
-  bpm?: number | null;
-  beatsPerBar?: number | null;
-  accentFirstBeat?: boolean | null;
-  gain?: number | null;
-  followTransport?: boolean | null;
-};
+export type NativeStandaloneMetronomeRequest =
+  | (NativeAudioAcquisitionControl & {
+      generation?: never;
+      timelineRevision?: never;
+    } & NativeStandaloneMetronomeConfiguration)
+  | (NativeAudioOutputControl & NativeStandaloneMetronomeConfiguration);
 
-export type NativeStandaloneMetronomeRequest = NativeAudioSessionControl & {
+type NativeStandaloneMetronomeConfiguration = {
   enabled: boolean;
   bpm: number;
   beatsPerBar: number;
@@ -289,10 +317,26 @@ export type NativeAudioPositionEvent = {
   positionSeconds: number;
   durationSeconds: number;
   state: "stopped" | "playing" | "paused";
+  generation: number;
+  timelineRevision: number;
+  nativeTimeUs: number;
+};
+
+export type NativeAudioStateEvent = {
+  sessionId: string | null;
+  state: "stopped" | "playing" | "paused";
+  positionSeconds: number;
+  generation: number;
+  timelineRevision: number;
+  nativeTimeUs: number;
 };
 
 export type NativeAudioErrorEvent = {
   sessionId: string | null;
+  generation: number;
+  timelineRevision: number;
+  nativeTimeUs: number;
+  positionSeconds: number;
   code:
     | "device_changed"
     | "device_not_available"
@@ -301,13 +345,13 @@ export type NativeAudioErrorEvent = {
     | "decoder_worker_failure";
 };
 
-export type NativeAudioInputRequest = NativeAudioSessionControl & {
+export type NativeAudioInputRequest = NativeAudioAcquisitionControl & {
   deviceId?: string | null;
   monitorEnabled?: boolean | null;
   monitorGain?: number | null;
 };
 
-export type NativeAudioMonitorRequest = {
+export type NativeAudioMonitorRequest = NativeAudioCaptureControl & {
   enabled: boolean;
   gain?: number | null;
 };
@@ -330,9 +374,9 @@ export type NativeAudioInputState = {
     | "privacy-blocked"
     | "unavailable";
   error: NativeAudioInputError | null;
-  leaseId?: string | null;
-  generation?: number | null;
-  nativeTimeUs?: number | null;
+  leaseId: string | null;
+  generation: number | null;
+  nativeTimeUs: number;
 };
 
 export type NativeAudioInputError = {
@@ -406,17 +450,15 @@ export function prepareNativeAudioSession(payload: NativeAudioSessionRequest) {
   return invoke<NativeAudioSession>("audio_prepare_session", { payload });
 }
 
-export function playNativeAudio(payload: NativeAudioPlayRequest = {}) {
+export function playNativeAudio(payload: NativeAudioPlayRequest) {
   return invoke<NativeAudioSnapshot>("audio_play", { payload });
 }
 
-export function pauseNativeAudio(payload?: NativeAudioSessionControl) {
-  if (!payload) return invoke<NativeAudioSnapshot>("audio_pause");
+export function pauseNativeAudio(payload: NativeAudioOutputControl) {
   return invoke<NativeAudioSnapshot>("audio_pause", { payload });
 }
 
-export function stopNativeAudio(payload?: NativeAudioSessionControl) {
-  if (!payload) return invoke<NativeAudioSnapshot>("audio_stop");
+export function stopNativeAudio(payload: NativeAudioOutputControl) {
   return invoke<NativeAudioSnapshot>("audio_stop", { payload });
 }
 
@@ -426,13 +468,9 @@ export function seekNativeAudio(payload: NativeAudioSeekRequest) {
 
 export function setNativeAudioLanes(
   payload: NativeAudioLaneUpdate,
-  control?: NativeAudioSessionControl,
+  control: NativeAudioOutputControl,
 ) {
-  return invoke<NativeAudioSnapshot>("audio_set_lanes", control ? { payload, control } : { payload });
-}
-
-export function setNativeAudioClick(payload: NativeAudioClickRequest) {
-  return invoke<NativeAudioSnapshot>("audio_set_click", { payload });
+  return invoke<NativeAudioSnapshot>("audio_set_lanes", { payload, control });
 }
 
 export function setNativeStandaloneMetronome(payload: NativeStandaloneMetronomeRequest) {
@@ -448,19 +486,16 @@ export function getNativeAudioSessionSnapshot() {
 }
 
 export function scheduleNativeAudioCues(
-  payload: NativeAudioSessionControl & { cues: NativeAudioCue[] },
+  payload: NativeAudioOutputControl & { cues: NativeAudioCue[] },
 ) {
   return invoke<NativeAudioSessionSnapshot>("audio_schedule_cues", { payload });
 }
 
 export function cancelNativeAudioCues(
-  payload?: NativeAudioSessionControl,
+  payload: NativeAudioOutputControl,
   kind?: "marker" | "metronome",
 ) {
-  return invoke<NativeAudioSessionSnapshot>(
-    "audio_cancel_cues",
-    payload || kind ? { payload, kind } : undefined,
-  );
+  return invoke<NativeAudioSessionSnapshot>("audio_cancel_cues", { payload, kind });
 }
 
 export function getNativeAudioInputState() {
@@ -475,12 +510,11 @@ export function requestNativeAudioInputPermission() {
   return invoke<NativeAudioInputPermissionStatus>("audio_request_input_permission");
 }
 
-export function startNativeAudioInput(payload: NativeAudioInputRequest = {}) {
+export function startNativeAudioInput(payload: NativeAudioInputRequest) {
   return invoke<NativeAudioInputState>("audio_start_input", { payload });
 }
 
-export function stopNativeAudioInput(payload?: NativeAudioSessionControl) {
-  if (!payload) return invoke<NativeAudioInputState>("audio_stop_input");
+export function stopNativeAudioInput(payload: NativeAudioCaptureControl) {
   return invoke<NativeAudioInputState>("audio_stop_input", { payload });
 }
 
@@ -508,6 +542,12 @@ export function listenNativeAudioPositions(
   handler: (position: NativeAudioPositionEvent) => void,
 ) {
   return listen<NativeAudioPositionEvent>("audio://position", (event) => {
+    handler(event.payload);
+  });
+}
+
+export function listenNativeAudioState(handler: (state: NativeAudioStateEvent) => void) {
+  return listen<NativeAudioStateEvent>("audio://state", (event) => {
     handler(event.payload);
   });
 }

--- a/apps/desktop/src/lib/playbackDiagnostics.test.ts
+++ b/apps/desktop/src/lib/playbackDiagnostics.test.ts
@@ -82,7 +82,7 @@ describe("playback diagnostics", () => {
     });
   });
 
-  it("does not claim Web fallback before confirmation and clears it on error", () => {
+  it("does not claim Web playback before confirmation and clears it on error", () => {
     updateNativePlaybackDiagnostics({
       sessionId: "session_private",
       lanes: [
@@ -97,7 +97,7 @@ describe("playback diagnostics", () => {
       ],
       bufferHealth: [],
     });
-    markPlaybackStarting("web-fallback");
+    markPlaybackStarting("web");
     expect(readPlaybackLiveDiagnostics()).toMatchObject({
       currentState: "starting",
       currentPath: "none",
@@ -105,10 +105,10 @@ describe("playback diagnostics", () => {
       nativeBufferHealth: [],
     });
 
-    markPlaybackConfirmed({ backend: "web", detail: null, mode: "fallback" });
+    markPlaybackConfirmed({ backend: "web", detail: null, mode: "browser" });
     expect(readPlaybackLiveDiagnostics()).toMatchObject({
       currentState: "playing",
-      currentPath: "web-fallback",
+      currentPath: "web",
     });
 
     markPlaybackError("Playback stopped. Web Audio could not continue.");

--- a/apps/desktop/src/lib/playbackDiagnostics.ts
+++ b/apps/desktop/src/lib/playbackDiagnostics.ts
@@ -5,7 +5,6 @@ import type {
 } from "./nativeAudio";
 
 const NATIVE_PLAYBACK_ERROR_KEY = "tuneforge.playback-native-error";
-const NATIVE_FALLBACK_CAUSE_KEY = "tuneforge.playback-native-fallback-cause";
 const PLAYBACK_BACKEND_KEY = "tuneforge.playback-backend";
 const WEB_PLAYBACK_ERROR_KEY = "tuneforge.playback-web-error";
 
@@ -17,7 +16,7 @@ export type PlaybackBackend =
   | {
       backend: "web";
       detail: string | null;
-      mode: "fallback" | "forced";
+      mode: "browser" | "forced";
     };
 
 export type PlaybackCurrentState =
@@ -30,7 +29,7 @@ export type PlaybackCurrentState =
 export type PlaybackCurrentPath =
   | "none"
   | "native"
-  | "web-fallback"
+  | "web"
   | "web-forced";
 
 export type PlaybackLiveDiagnostics = {
@@ -84,18 +83,13 @@ export function resetLivePlaybackDiagnostics() {
 }
 
 export function markPlaybackStarting(
-  path: "native" | "web-fallback" | "web-forced",
+  path: "native" | "web" | "web-forced",
 ) {
-  const statusMessage =
-    path === "web-fallback"
-      ? "Native playback unavailable. Starting Web Audio fallback…"
-      : "Starting playback…";
+  const statusMessage = "Starting playback…";
   updateLiveDiagnostics({
     currentState: "starting",
     currentPath: "none",
-    ...(path === "web-fallback"
-      ? { nativeSessionLaneCount: null, nativeBufferHealth: [] }
-      : {}),
+    ...(path === "web" ? { nativeSessionLaneCount: null, nativeBufferHealth: [] } : {}),
     statusMessage,
   });
 }
@@ -106,9 +100,8 @@ export function markPlaybackConfirmed(backend: PlaybackBackend) {
       ? "native"
       : backend.mode === "forced"
         ? "web-forced"
-        : "web-fallback";
-  const statusMessage =
-    currentPath === "web-fallback" ? "Playing with Web Audio fallback." : null;
+        : "web";
+  const statusMessage = null;
   const nativeBackend =
     backend.backend === "native" ? backend.detail : liveDiagnostics.nativeBackend;
   if (
@@ -137,10 +130,7 @@ export function markPlaybackConfirmed(backend: PlaybackBackend) {
 export function markPlaybackPaused() {
   updateLiveDiagnostics({
     currentState: "paused",
-    statusMessage:
-      liveDiagnostics.currentPath === "web-fallback"
-        ? "Paused on Web Audio fallback."
-        : null,
+    statusMessage: null,
   });
 }
 
@@ -232,7 +222,7 @@ export function readRememberedPlaybackBackend(): PlaybackBackend | null {
     if (
       rawBackend.backend === "web" &&
       rawBackend.mode !== "forced" &&
-      rawBackend.mode !== "fallback"
+      rawBackend.mode !== "browser"
     ) {
       return null;
     }
@@ -277,25 +267,6 @@ export function clearRememberedNativePlaybackError() {
   }
   window.localStorage.removeItem(NATIVE_PLAYBACK_ERROR_KEY);
   notifyDiagnosticsChanged();
-}
-
-export function rememberNativeFallbackCause(cause: string) {
-  if (typeof window === "undefined") {
-    return;
-  }
-  window.localStorage.setItem(
-    NATIVE_FALLBACK_CAUSE_KEY,
-    redactPlaybackDiagnosticText(cause),
-  );
-  notifyDiagnosticsChanged();
-}
-
-export function readRememberedNativeFallbackCause() {
-  if (typeof window === "undefined") {
-    return null;
-  }
-  const value = window.localStorage.getItem(NATIVE_FALLBACK_CAUSE_KEY);
-  return value ? redactPlaybackDiagnosticText(value) : null;
 }
 
 export function rememberWebPlaybackError(error: string) {

--- a/apps/desktop/src/test/appTestHarness.tsx
+++ b/apps/desktop/src/test/appTestHarness.tsx
@@ -144,6 +144,9 @@ const {
     positionSeconds: number;
     durationSeconds: number;
     state: "stopped" | "playing" | "paused";
+    generation?: number;
+    timelineRevision?: number;
+    nativeTimeUs?: number;
   };
   type NativeAudioErrorPayload = {
     sessionId: string | null;
@@ -153,6 +156,10 @@ const {
       | "stream_invalidated"
       | "output_stream_failure"
       | "decoder_worker_failure";
+    generation?: number;
+    timelineRevision?: number;
+    nativeTimeUs?: number;
+    positionSeconds?: number;
   };
   type NativeAudioRuntimeEvent = {
     event: "audio://position" | "audio://ended" | "audio://error" | "audio://input-state" |
@@ -231,8 +238,9 @@ const {
       capturePath: "none" | "desktop-cpal" | "android-aaudio";
       permissionState: string;
       error: { code: string; message: string; guidance: string | null } | null;
-      leaseId?: string | null;
-      generation?: number | null;
+      leaseId: string | null;
+      generation: number | null;
+      nativeTimeUs: number;
     };
     nativeAudioInputPermission: {
       state: string;
@@ -240,8 +248,8 @@ const {
     };
     nativeAudioSnapshot: Record<string, unknown>;
     nativeAudioStartError: string | null;
-    nativeAudioPlayFallbackReason: string | null;
-    nativeAudioStopFallbackReason: string | null;
+    nativeAudioPlayError: string | null;
+    nativeAudioStopError: string | null;
     powerInhibitionStatus: {
       phase: string;
       backend: string | null;
@@ -887,8 +895,7 @@ const {
         micMonitoringSupported: false,
         systemInputVolumeSupported: true,
         emitsEvents: ["audio://input-frame", "audio://devices-changed"],
-        fallbackRequired: true,
-        fallbackReason: "Native audio playback is not wired yet; use existing WebView playback.",
+        availabilityReason: "native_audio_unavailable",
       },
       nativeAudioInputDevices: {
         supported: true,
@@ -906,6 +913,9 @@ const {
         capturePath: "none",
         permissionState: "unavailable",
         error: null,
+        leaseId: null,
+        generation: 0,
+        nativeTimeUs: 1,
       },
       nativeAudioInputPermission: { state: "unavailable", error: null },
       nativeAudioSnapshot: {
@@ -915,7 +925,7 @@ const {
         durationSeconds: 0,
         playbackRate: 1,
         nativePlaybackSupported: false,
-        fallbackReason: "Native audio playback is not wired yet; use existing WebView playback.",
+        availabilityReason: "native_audio_unavailable",
         lanes: [],
         bufferHealth: [],
         leaseId: "project-playback",
@@ -924,8 +934,8 @@ const {
         nativeTimeUs: 1,
       },
       nativeAudioStartError: null,
-      nativeAudioPlayFallbackReason: null,
-      nativeAudioStopFallbackReason: null,
+      nativeAudioPlayError: null,
+      nativeAudioStopError: null,
       powerInhibitionStatus: {
         phase: "inactive",
         backend: null,
@@ -983,8 +993,8 @@ const {
     inputPermission?: Partial<typeof state.nativeAudioInputPermission>;
     snapshot?: Record<string, unknown>;
     startError?: string | null;
-    playFallbackReason?: string | null;
-    stopFallbackReason?: string | null;
+    playError?: string | null;
+    stopError?: string | null;
   }) {
     state.nativeAudioCapabilities = {
       ...state.nativeAudioCapabilities,
@@ -1012,11 +1022,11 @@ const {
     if ("startError" in nextState) {
       state.nativeAudioStartError = nextState.startError ?? null;
     }
-    if ("playFallbackReason" in nextState) {
-      state.nativeAudioPlayFallbackReason = nextState.playFallbackReason ?? null;
+    if ("playError" in nextState) {
+      state.nativeAudioPlayError = nextState.playError ?? null;
     }
-    if ("stopFallbackReason" in nextState) {
-      state.nativeAudioStopFallbackReason = nextState.stopFallbackReason ?? null;
+    if ("stopError" in nextState) {
+      state.nativeAudioStopError = nextState.stopError ?? null;
     }
   }
 
@@ -1051,6 +1061,58 @@ const {
       };
     });
   }
+  function nativeControlText(
+    payload: Record<string, unknown>,
+    field: "leaseId" | "operationId",
+  ) {
+    const value = payload[field];
+    if (typeof value !== "string" || value.trim().length === 0) {
+      throw new Error(`Invalid native audio control: ${field} is required.`);
+    }
+    return value;
+  }
+  function validateNativeAcquisitionControl(value: unknown) {
+    if (!value || typeof value !== "object" || Array.isArray(value)) {
+      throw new Error("Invalid native audio acquisition control.");
+    }
+    const payload = value as Record<string, unknown>;
+    nativeControlText(payload, "leaseId");
+    nativeControlText(payload, "operationId");
+    if ("generation" in payload || "timelineRevision" in payload) {
+      throw new Error("Invalid native audio acquisition control metadata.");
+    }
+    return payload;
+  }
+  function validateNativeOutputControl(value: unknown) {
+    if (!value || typeof value !== "object" || Array.isArray(value)) {
+      throw new Error("Invalid native audio output control.");
+    }
+    const payload = value as Record<string, unknown>;
+    nativeControlText(payload, "leaseId");
+    nativeControlText(payload, "operationId");
+    if (!Number.isInteger(payload.generation) || Number(payload.generation) <= 0) {
+      throw new Error("Invalid native audio output generation.");
+    }
+    if (!Number.isInteger(payload.timelineRevision) || Number(payload.timelineRevision) <= 0) {
+      throw new Error("Invalid native audio timeline revision.");
+    }
+    return payload;
+  }
+  function validateNativeCaptureControl(value: unknown) {
+    if (!value || typeof value !== "object" || Array.isArray(value)) {
+      throw new Error("Invalid native audio capture control.");
+    }
+    const payload = value as Record<string, unknown>;
+    nativeControlText(payload, "leaseId");
+    nativeControlText(payload, "operationId");
+    if (!Number.isInteger(payload.generation) || Number(payload.generation) <= 0) {
+      throw new Error("Invalid native audio capture generation.");
+    }
+    if ("timelineRevision" in payload) {
+      throw new Error("Invalid native audio capture control metadata.");
+    }
+    return payload;
+  }
   function emitMockNativeAudioInputFrame(frame: NativeAudioInputFrame) {
     nativeInputFrameListeners.forEach((listener, id) => {
       listener({
@@ -1064,7 +1126,12 @@ const {
     emitMockNativeRuntimeEvent("audio://input-state", state.nativeAudioInputState);
   }
   function emitMockNativeAudioPosition(position: NativeAudioPositionPayload) {
-    emitMockNativeRuntimeEvent("audio://position", position);
+    emitMockNativeRuntimeEvent("audio://position", {
+      generation: state.nativeAudioSnapshot.generation,
+      timelineRevision: state.nativeAudioSnapshot.timelineRevision,
+      nativeTimeUs: state.nativeAudioSnapshot.nativeTimeUs,
+      ...position,
+    });
   }
   function emitMockNativeAudioCue(payload: Record<string, unknown>) {
     emitMockNativeRuntimeEvent("audio://cue", payload);
@@ -1073,10 +1140,22 @@ const {
     emitMockNativeRuntimeEvent("audio://session", payload);
   }
   function emitMockNativeAudioTerminal(payload: Record<string, unknown>) {
-    emitMockNativeRuntimeEvent("audio://terminal", payload);
+    emitMockNativeRuntimeEvent("audio://terminal", {
+      resource: "output",
+      timelineRevision: state.nativeAudioSnapshot.timelineRevision,
+      captureGeneration: null,
+      positionSeconds: state.nativeAudioSnapshot.positionSeconds,
+      ...payload,
+    });
   }
   function emitMockNativeAudioError(error: NativeAudioErrorPayload) {
-    emitMockNativeRuntimeEvent("audio://error", error);
+    emitMockNativeRuntimeEvent("audio://error", {
+      generation: state.nativeAudioSnapshot.generation,
+      timelineRevision: state.nativeAudioSnapshot.timelineRevision,
+      nativeTimeUs: state.nativeAudioSnapshot.nativeTimeUs,
+      positionSeconds: state.nativeAudioSnapshot.positionSeconds,
+      ...error,
+    });
   }
   function emitMockSystemMediaControl(payload: SystemMediaControlPayload) {
     systemMediaControlListeners.forEach((listener, id) => {
@@ -1285,7 +1364,9 @@ const {
     }
 
     if (command === "audio_prepare_session") {
-      const payload = (args?.payload ?? {}) as {
+      const payload = validateNativeAcquisitionControl(args?.payload) as {
+        leaseId: string;
+        operationId: string;
         sessionId?: string;
         durationSeconds?: number | null;
         playbackRate?: number | null;
@@ -1299,10 +1380,10 @@ const {
         }>;
       };
       const nativePlaybackSupported = state.nativeAudioCapabilities.nativePlaybackSupported === true;
-      const fallbackReason =
+      const availabilityReason =
         nativePlaybackSupported
           ? null
-          : String(state.nativeAudioCapabilities.fallbackReason ?? "Native audio playback is unavailable.");
+          : String(state.nativeAudioCapabilities.availabilityReason ?? "native_audio_unavailable");
       const lanes = effectiveNativeAudioLanes(payload.lanes ?? []);
       state.nativeAudioSnapshot = {
         ...state.nativeAudioSnapshot,
@@ -1312,8 +1393,9 @@ const {
         durationSeconds: payload.durationSeconds ?? 0,
         playbackRate: payload.playbackRate ?? 1,
         nativePlaybackSupported,
-        fallbackReason,
+        availabilityReason,
         lanes,
+        leaseId: payload.leaseId,
         bufferHealth: (payload.lanes ?? []).map((lane) => ({
           laneId: lane.id,
           artifactId: lane.artifactId ?? null,
@@ -1327,8 +1409,9 @@ const {
       };
       return {
         id: payload.sessionId ?? "session",
+        leaseId: payload.leaseId,
         nativePlaybackSupported,
-        fallbackReason,
+        availabilityReason,
         laneCount: lanes.length,
         generation: state.nativeAudioSnapshot.generation,
         timelineRevision: state.nativeAudioSnapshot.timelineRevision,
@@ -1337,16 +1420,11 @@ const {
     }
 
     if (command === "audio_play") {
-      const payload = (args?.payload ?? {}) as { startTimeSeconds?: number | null };
-      if (state.nativeAudioPlayFallbackReason) {
-        state.nativeAudioSnapshot = {
-          ...state.nativeAudioSnapshot,
-          state: "paused",
-          nativePlaybackSupported: false,
-          fallbackReason: state.nativeAudioPlayFallbackReason,
-          positionSeconds: payload.startTimeSeconds ?? Number(state.nativeAudioSnapshot.positionSeconds ?? 0),
-        };
-        return clone(state.nativeAudioSnapshot);
+      const payload = validateNativeOutputControl(args?.payload) as {
+        startTimeSeconds?: number | null;
+      };
+      if (state.nativeAudioPlayError) {
+        throw new Error(state.nativeAudioPlayError);
       }
       state.nativeAudioSnapshot = {
         ...state.nativeAudioSnapshot,
@@ -1357,6 +1435,7 @@ const {
     }
 
     if (command === "audio_pause") {
+      validateNativeOutputControl(args?.payload);
       state.nativeAudioSnapshot = {
         ...state.nativeAudioSnapshot,
         state: "paused",
@@ -1365,22 +1444,20 @@ const {
     }
 
     if (command === "audio_stop") {
+      validateNativeOutputControl(args?.payload);
       state.nativeAudioSnapshot = {
         ...state.nativeAudioSnapshot,
         state: "stopped",
         positionSeconds: 0,
-        ...(state.nativeAudioStopFallbackReason
-          ? {
-              nativePlaybackSupported: false,
-              fallbackReason: state.nativeAudioStopFallbackReason,
-            }
-          : {}),
       };
+      if (state.nativeAudioStopError) {
+        throw new Error(state.nativeAudioStopError);
+      }
       return clone(state.nativeAudioSnapshot);
     }
 
     if (command === "audio_seek") {
-      const payload = (args?.payload ?? {}) as { timeSeconds?: number };
+      const payload = validateNativeOutputControl(args?.payload) as { timeSeconds?: number };
       state.nativeAudioSnapshot = {
         ...state.nativeAudioSnapshot,
         positionSeconds: payload.timeSeconds ?? 0,
@@ -1389,6 +1466,7 @@ const {
     }
 
     if (command === "audio_set_lanes") {
+      validateNativeOutputControl(args?.control);
       const payload = (args?.payload ?? {}) as {
         playbackRate?: number | null;
         lanes?: Array<{
@@ -1419,12 +1497,29 @@ const {
       return clone(state.nativeAudioSnapshot);
     }
 
-    if (command === "audio_set_click" || command === "audio_get_snapshot") {
+    if (command === "audio_get_snapshot") {
       return clone(state.nativeAudioSnapshot);
     }
 
     if (command === "audio_set_standalone_metronome") {
-      const payload = (args?.payload ?? {}) as Record<string, unknown>;
+      const rawPayload = args?.payload;
+      const payload = (
+        rawPayload && typeof rawPayload === "object" && "generation" in rawPayload
+          ? validateNativeOutputControl(rawPayload)
+          : validateNativeAcquisitionControl(rawPayload)
+      );
+      const generation = "generation" in payload
+        ? Number(payload.generation)
+        : Number(state.nativeAudioSnapshot.generation) + 1;
+      const revision = "timelineRevision" in payload
+        ? Number(payload.timelineRevision) + 1
+        : Number(state.nativeAudioSnapshot.timelineRevision) + 1;
+      state.nativeAudioSnapshot = {
+        ...state.nativeAudioSnapshot,
+        leaseId: payload.leaseId,
+        generation,
+        timelineRevision: revision,
+      };
       return {
         enabled: payload.enabled === true,
         bpm: Number(payload.bpm ?? 120),
@@ -1432,13 +1527,16 @@ const {
         accentFirstBeat: payload.accentFirstBeat !== false,
         gain: Number(payload.gain ?? 0.8),
         followPlayback: payload.followPlayback !== false,
-        leaseId: String(payload.leaseId ?? "standalone-metronome"),
-        generation: Number(payload.generation ?? 1),
-        revision: Number(payload.timelineRevision ?? 0) + 1,
+        leaseId: String(payload.leaseId),
+        generation,
+        revision,
         nativeTimeUs: 1,
       };
     }
 
+    if (command === "audio_schedule_cues" || command === "audio_cancel_cues") {
+      validateNativeOutputControl(args?.payload);
+    }
     if (command === "audio_get_session_snapshot" || command === "audio_schedule_cues" || command === "audio_cancel_cues") {
       return {
         resource: "output",
@@ -1449,19 +1547,28 @@ const {
         generation: state.nativeAudioSnapshot.generation,
         timelineRevision: state.nativeAudioSnapshot.timelineRevision,
         nativeTimeUs: state.nativeAudioSnapshot.nativeTimeUs,
+        positionSeconds: state.nativeAudioSnapshot.positionSeconds,
+        playbackRate: state.nativeAudioSnapshot.playbackRate,
+        availabilityReason: state.nativeAudioSnapshot.availabilityReason,
+        terminalDiagnostic: null,
       };
     }
 
     if (command === "audio_start_input") {
+      const control = validateNativeAcquisitionControl(args?.payload);
       if (state.nativeAudioStartError) {
         throw new Error(state.nativeAudioStartError);
       }
-      const payload = (args?.payload ?? {}) as {
+      const payload = control as {
         deviceId?: string | null;
         monitorEnabled?: boolean | null;
         monitorGain?: number | null;
         leaseId?: string | null;
       };
+      const previousGeneration = state.nativeAudioInputState.generation;
+      if (typeof previousGeneration !== "number") {
+        throw new Error("Invalid mock native capture generation state.");
+      }
       state.nativeAudioInputState = {
         active: true,
         deviceId: payload.deviceId ?? null,
@@ -1475,13 +1582,15 @@ const {
         permissionState:
           state.nativeAudioCapabilities.platform === "android" ? "granted" : "unavailable",
         error: null,
-        leaseId: String(payload.leaseId ?? "tuner-capture"),
-        generation: Number(state.nativeAudioInputState.generation ?? 0) + 1,
+        leaseId: String(payload.leaseId),
+        generation: previousGeneration + 1,
+        nativeTimeUs: 1,
       };
       return clone(state.nativeAudioInputState);
     }
 
     if (command === "audio_stop_input") {
+      validateNativeCaptureControl(args?.payload);
       state.nativeAudioInputState = {
         ...state.nativeAudioInputState,
         active: false,
@@ -1490,6 +1599,16 @@ const {
         captureGeneration: state.nativeAudioInputState.captureGeneration + 1,
         capturePath: "none",
         error: null,
+      };
+      return clone(state.nativeAudioInputState);
+    }
+
+    if (command === "audio_set_monitor") {
+      const payload = validateNativeCaptureControl(args?.payload);
+      state.nativeAudioInputState = {
+        ...state.nativeAudioInputState,
+        monitorEnabled: payload.monitorEnabled === true,
+        monitorGain: Number(payload.monitorGain ?? 0),
       };
       return clone(state.nativeAudioInputState);
     }

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -217,7 +217,9 @@ Validation failures return `INVALID_REQUEST` with serialized validation details.
 ## Packaging Constraints
 
 - FFmpeg is a host dependency and is not bundled.
-- Desktop tuner microphone capture and project playback use `cpal` locally and fall back to Web Audio when native audio is unavailable.
+- Normal Tauri project playback, metronome output, and tuner microphone capture use the native
+  audio control plane. Native failure remains terminal until a later explicit action; it does not
+  fall back to Web Audio. Browser, non-Tauri, and forced-Web Tauri builds use Web Audio.
 - Native desktop tempo playback uses `signalsmith-stretch` for pitch preservation.
 - Native desktop playback decodes local files through a WAV fast path or Symphonia. FFmpeg remains a host dependency for transform/export work.
 - Native audio development notes live in [NATIVE_AUDIO.md](NATIVE_AUDIO.md).

--- a/docs/MOBILE.md
+++ b/docs/MOBILE.md
@@ -189,13 +189,23 @@ passwords, expected certificate fingerprint, signer count, and manifest version,
 writes `apps/desktop/src-tauri/target/release/bundle/apk/TuneForge_<version>_android_aarch64_publishable.apk`.
 Packaging never installs, launches, uploads, tags, or publishes the app.
 
-Project playback prefers the native `android-aaudio` path. Web Audio is an automatic disclosed
-fallback after native failure or a build-time development override; it is not a mobile setting.
-Playback state, clocks, and Settings diagnostics change only after the active native session or Web
-media confirms the transition.
+Normal Android Tauri requires native `android-aaudio` playback. Native capability, decode, startup,
+or runtime failure stays terminal for native playback: TuneForge freezes the last authoritative
+position, cancels pending count-in and cues, clears busy state, and shows the transport error. It
+never starts Web Audio or retries itself. A later explicit Play creates one fresh native attempt.
 
-On Android, Web Audio reads project artifacts through a private seekable server bound to an
-ephemeral `127.0.0.1` port. Routes contain only opaque artifact IDs, revalidate the current
+Browser/non-Tauri Android uses Web Audio. A Tauri build compiled with
+`VITE_TUNEFORGE_FORCE_WEB_AUDIO=1` also uses Web Audio only; it is a build-time development override,
+not a mobile setting, and makes no native audio calls. Playback state and clocks change only after
+the active native session or Web media confirms the transition.
+
+Settings diagnostics identify the active policy as `Native required`, `Web Audio (forced)`, or
+`Web Audio`. A valid `device_changed` report is advisory while the stream remains usable; it does
+not stop playback or trigger retry. Diagnostics do not present a `Native preferred` or
+`Web Audio (fallback)` path.
+
+On Android forced-Web playback, Web Audio reads project artifacts through a private seekable server
+bound to an ephemeral `127.0.0.1` port. Routes contain only opaque artifact IDs, revalidate the current
 app-owned project file for every request, and support bounded streaming plus single byte ranges.
 The URL includes an unguessable per-process capability segment. Origin-less Android media requests
 are accepted, while requests that name a foreign browser origin are rejected. The server starts only
@@ -204,10 +214,11 @@ or backend transport.
 
 ## Android Tuner Capture
 
-The packaged Android tuner requires native CPAL/AAudio microphone capture. A native capability,
-permission, startup, or stream failure produces a truthful recoverable tuner error and never falls
-through to Web Audio. `VITE_TUNEFORGE_FORCE_WEB_AUDIO=1` remains an explicit development-only
-all-Web override shared with playback.
+Normal Android Tauri tuner capture requires native CPAL/AAudio. A native capability, permission,
+startup, device, or stream failure produces a truthful recoverable tuner error and never falls
+through to Web Audio or retries automatically. Only explicit Retry or input selection creates a
+fresh capture attempt. `VITE_TUNEFORGE_FORCE_WEB_AUDIO=1` remains an explicit all-Web build override
+shared with playback and the metronome.
 
 The tuner requests `RECORD_AUDIO` at start and distinguishes prompt, prompting, granted, denied,
 blocked, microphone-privacy blocked, and unavailable states. A blocked state points to Android
@@ -218,9 +229,10 @@ the microphone automatically.
 
 Android input routing is `System Default` only, and microphone monitoring remains unavailable. Live
 state is generation-scoped so late samples from a stopped or replaced stream cannot update pitch or
-input level. Settings keeps native capability, selection policy, permission, current path/state, last
-confirmed path, and latest safe historical failure as separate facts. Active capture is never
-restored after reload.
+input level. Capture runs independently from the shared output runtime: tuner start/stop never stops
+playback or the standalone metronome. Settings keeps native capability, selection policy, permission,
+current path/state, last confirmed path, and latest safe historical failure as separate facts. Active
+capture is never restored after reload.
 
 Android power protection follows confirmed work automatically; no manual toggle exists. See
 [POWER_PROTECTION.md](./POWER_PROTECTION.md) for the shared owner, backend, diagnostic, and

--- a/docs/NATIVE_AUDIO.md
+++ b/docs/NATIVE_AUDIO.md
@@ -1,47 +1,57 @@
 # Native Audio
 
-TuneForge prefers native audio for project playback and keeps Web Audio as a disclosed fallback or
-development override. Native audio is added feature by feature behind the Tauri native audio
-boundary.
+TuneForge uses native audio in a normal Tauri runtime. Web Audio remains the complete audio path
+for browsers and non-Tauri runtimes, and for a Tauri build compiled with the forced-Web override.
 
 ## Current Scope
 
 - Tuner microphone capture uses native `cpal` on supported desktop builds and CPAL/AAudio on
   Android.
-- Tuner device listing uses native input enumeration first, then cached/browser labels as fallback.
-- Source, practice-mix, and stem playback prefer native `cpal` on macOS/Linux and CPAL/AAudio on
+- Source, practice-mix, and stem playback use native `cpal` on macOS/Linux and CPAL/AAudio on
   Android when every active
   artifact has a local path. WAV uses a fast streaming reader; other common formats decode through
   Symphonia for playback only.
+- One native output runtime mixes project lanes, count-in cues, and the standalone metronome. A
+  separate native capture runtime can run tuner input at the same time; starting or stopping either
+  resource does not replace the other.
 - Native playback supports shared transport play/pause/seek, position events, mute/solo lane gains,
   project count-ins, and generated metronome click lanes for follow-playback mode. Project count-ins
   use a 760 Hz triangle click with a 2 ms attack, 45 ms duration, and exponential decay on both
   native and Web Audio paths; timing-grid gaps are filtered against source BPM and scaled to the
   displayed playback tempo.
+- The standalone metronome free-runs at its configured BPM when no project is playing. Follow is on
+  by default: during playback it follows the analysed beat grid when available, otherwise the
+  playback timeline. Pause, stop, or natural end re-anchor it to free-run. With Follow off it stays
+  free-running alongside playback.
 - Native tempo changes use `signalsmith-stretch` for pitch-preserving playback.
-- If native setup, decode, seek, or output startup fails, playback falls back to Web Audio at the
-  same transport position.
+- A normal Tauri native failure is terminal for that resource. Playback holds its last authoritative
+  position, cancels pending cues, and shows the transport error; tuner capture clears live input.
+  Neither path starts Web Audio or retries automatically. A later explicit Play, metronome Start,
+  tuner Retry, or input selection starts one fresh native attempt. On Linux, a recoverable CPAL
+  output xrun remains on the current stream and is recorded in diagnostics; a later unrecoverable
+  output error still follows the terminal path.
 - Linux native capture and playback currently use `cpal`'s ALSA host. On PipeWire/PulseAudio
   desktops this usually routes through the host ALSA compatibility layer, but device labels may
   still look like ALSA PCM names.
 - Android native playback and tuner capture report the `android-aaudio` backend and require Android
   API 26 or newer. Tuner monitoring remains unsupported.
-- Android Web Audio fallback and forced-Web-Audio playback use a private seekable loopback
+- Android forced-Web-Audio playback uses a private seekable loopback
   transport so Chromium can request complete byte ranges without exposing arbitrary file paths.
 - Synced Android source, practice-mix, and stem artifacts accept PCM16 WAV, FLAC, MP3, and AAC-LC
   M4A. Receive validation checks the declared suffix, container, codec, and a bounded first decoded
   packet before commit without decoding the full file. Playback and the private range transport use
   the preserved bytes; TuneForge does not create a receiver-side transcode or playback proxy.
 
-## Backend Selection
+## Backend Selection And Failure Handling
 
-The frontend prefers native audio when a feature is supported and falls back to Web Audio when
-native support is unavailable or startup fails.
+Normal Tauri requires native playback, metronome, and tuner capture. Capability or runtime failure
+remains a safe native failure; it never transfers to Web Audio. Native control responses and events
+are generation- and revision-correlated, so stale output positions, cues, capture frames, and terminal
+reports do not replace newer state.
 
-Packaged Android tuner capture is an exception: it requires the native AAudio path and never silently
-falls back to `getUserMedia` after a capability, permission, startup, or stream failure. The global
-`VITE_TUNEFORGE_FORCE_WEB_AUDIO=1` development override remains an explicit all-Web mode for both
-tuner capture and playback.
+Browser and non-Tauri runtimes use Web Audio only. A Tauri build with
+`VITE_TUNEFORGE_FORCE_WEB_AUDIO=1` also uses Web Audio only and makes no native audio calls. The flag
+is a compile-time override, not a setting or a runtime switch; rebuild and relaunch to change mode.
 
 Playback owns media-key controls, while playback and tuner capture participate in TuneForge's
 shared power-protection model. See [POWER_PROTECTION.md](./POWER_PROTECTION.md) for the
@@ -57,28 +67,23 @@ cross-platform owner, backend, diagnostic, and validation rules.
   newer session, position, or lane state. Pause and Stop remain prompt cancellation boundaries and
   are not held behind an unresolved Play response.
 - Web Audio/HTML media playback owns the transport only after a `playing` event or confirmed media
-  progress,
-  including `VITE_TUNEFORGE_FORCE_WEB_AUDIO=1` and native fallback. It uses the browser Screen Wake
-  Lock while playing. Browser Screen Wake Lock protects the visible screen only; it does not claim
-  native background protection.
+  progress. This applies to browser, non-Tauri, and forced-Web Tauri builds. It uses the browser
+  Screen Wake Lock while playing. Browser Screen Wake Lock protects the visible screen only; it does
+  not claim native background protection.
 - Native tuner capture acquires the same OS power-protection manager only after the CPAL/AAudio
   stream starts. Worker exit releases its scoped owner on stop, interruption, replacement, Android
   suspension, or teardown even when WebView effects cannot run.
-- Confirmed Web Audio tuner capture owns the same shared browser Screen Wake Lock and a native
-  `tuner-capture` reason in packaged Tauri builds. Track termination, stop, error, replacement, and
-  unmount clear both. Pending permission and startup never acquire protection. Playback and tuner
-  browser owners share one sentinel, so either owner can stop without releasing the other.
-- Native fallback is an explicit ownership transfer. TuneForge clears system media state and native
-  power protection, starts the Web Audio path at the fallback position, then re-registers system
-  media state for the Web Audio owner and acquires the browser wake lock. Diagnostics keep the
-  native fallback reason.
-- Native output events carry only a session ID and one safe code: `device_changed`,
-  `device_not_available`, `stream_invalidated`, `output_stream_failure`, or
-  `decoder_worker_failure`. A device change is informational and leaves playback alone.
-  Device loss and stream invalidation retire native playback and hand off once to Web Audio at the
-  synchronously captured, clamped position. Pause, stop, project changes, and unmount cancel a
-  pending handoff. TuneForge never retries native playback automatically; the next explicit Play
-  makes one new native attempt.
+- Confirmed Web Audio tuner capture owns the shared browser Screen Wake Lock. Track termination,
+  stop, error, replacement, and unmount clear it. Pending permission and startup never acquire
+  protection. Playback and tuner browser owners share one sentinel, so either owner can stop without
+  releasing the other.
+- Native lifecycle events carry safe codes plus resource, ownership generation, revision where
+  applicable, and native timing. They never include paths, device IDs, endpoints, or audio content.
+  Output codes include `device_changed`, `device_not_available`, `stream_invalidated`,
+  `output_stream_failure`, and `decoder_worker_failure`. `device_changed` is advisory while the
+  stream remains valid. Device loss, invalidation, missed release acknowledgement, or unrecoverable
+  runtime failure terminalizes only the affected native resource. Pause, stop, seek, project
+  changes, and unmount do not retry native audio.
 - Failed native prepare/play attempts before audio starts never activate native transport ownership.
 
 ## Linux Build Prerequisites
@@ -111,9 +116,9 @@ If the backend is already running separately:
 VITE_TUNEFORGE_FORCE_WEB_AUDIO=1 pnpm dev:desktop
 ```
 
-This is a global native audio override, not a per-feature setting. It affects tuner capture and
-project playback so Web Audio remains the comparison path for both. It does not disable native
-capability detection, and it is not a persisted current-playback state.
+This is a global native audio override, not a per-feature setting. It affects tuner capture,
+project playback, count-in, and standalone metronome. It is a build-time setting, so it must be set
+before the desktop frontend is built or started. It is not persisted current-playback state.
 
 ## Diagnostics
 
@@ -124,12 +129,11 @@ Settings -> Local Data -> Show diagnostics reports:
 - input capture availability
 - capture selection policy, current Android permission, current state, and current confirmed path
 - last confirmed tuner capture path and latest safe historical failure
-- audio override and playback selection policy
-- native playback capability, even while Web Audio is forced
+- audio override, playback selection policy, and capture selection policy
+- native playback capability in normal Tauri only
 - current playback state and current confirmed path
 - last confirmed playback path
 - latest native playback failure
-- latest native fallback cause
 - latest Web media failure
 - active native session lane count
 - native playback buffer health per lane, including fill level, underrun count, worker errors, and
@@ -140,13 +144,17 @@ Settings -> Local Data -> Show diagnostics reports:
   screen coverage, plus latest safe power-protection error and last confirmed native backend
 
 Current state is live and starts as `Not playing` / `None` after reload. Only last-confirmed path and
-redacted failures are restored from local storage. A native failure does not claim Web fallback
-until Web playback is confirmed, and `android-null` is always reported as unavailable. Diagnostic
-reasons omit local paths, URLs, artifact IDs, and session IDs. Active power state is never restored
-from local storage; only a safe historical backend and error may survive reload.
+redacted failures are restored from local storage. `android-null` is always reported as unavailable.
+Diagnostic reasons omit local paths, URLs, artifact IDs, and session IDs. Active power state is never
+restored from local storage; only a safe historical backend and error may survive reload.
 
-When `VITE_TUNEFORGE_FORCE_WEB_AUDIO=1` is active, diagnostics report the build-time override and
-`Web Audio forced` policy while continuing to report native capability independently.
+Selection-policy labels are exact: normal Tauri shows `Native required`; a forced-Web Tauri build
+shows `Web Audio (forced)` and the build-time override; browser and non-Tauri show `Web Audio`.
+Diagnostics never show `Native preferred` or `Web Audio (fallback)`.
+
+Native capability queries and listeners run only in normal Tauri. When
+`VITE_TUNEFORGE_FORCE_WEB_AUDIO=1` is active, diagnostics report `Web Audio (forced)` and the
+build-time override; native capability remains Unknown/unqueried and no native audio call runs.
 
 ### Retained Native Audio Diagnostics
 
@@ -219,9 +227,11 @@ BlackHole capture are release checks, not default `pnpm test` coverage.
 | Tempo control | tempo change applies and stays stable | tempo change applies and stays stable | tempo change applies and stays stable |
 | Metronome follow | follows active track tempo while BPM changes | follows active track tempo while BPM changes | follows active track tempo while BPM changes |
 | Media keys / headset controls | system media controls play/pause/stop/seek native transport only | MPRIS controls play/pause/stop/seek native transport only | system media controls play/pause/stop/seek browser transport only |
-| Wake prevention | native display idle inhibition while playing; released on pause/stop/end/fallback | portal or logind inhibition while playing; released on pause/stop/end/fallback | Screen Wake Lock while playing; released on pause/stop/end |
-| Native runtime fallback ownership | system state/inhibition clear before Web Audio starts at fallback position, then system controls route to Web Audio | same | not applicable; web owns controls from start |
-| Fallback + no output device | falls back (or errors and recovers) without crash when no native output exists | same | same |
+| Wake prevention | native display idle inhibition while playing; released on pause/stop/end/failure | portal or logind inhibition while playing; released on pause/stop/end/failure | Screen Wake Lock while playing; released on pause/stop/end |
+| Native terminal output | holds last authoritative position, cancels pending cues, and waits for explicit Play | same | not applicable; Web Audio owns playback from start |
+| No output device | shows native error without crash, Web start, or automatic retry; explicit Play makes one fresh attempt | same | Web Audio error behavior applies |
+| Tuner plus output | tuner capture can run with playback and metronome; stopping one leaves others active | same | Web capture can run with Web playback and metronome |
+| Standalone metronome | free-run, followed playback, and Follow off stay distinct across pause, seek, stop, and replay | same | same |
 
 For manual Linux, macOS, Android, and browser power validation, use the owner-specific evidence and
 release checks in [POWER_PROTECTION.md](./POWER_PROTECTION.md#validation).

--- a/docs/POWER_PROTECTION.md
+++ b/docs/POWER_PROTECTION.md
@@ -19,14 +19,14 @@ TuneForge tracks power protection through counted owners:
 - `sync-transfer`: active sync transfer.
 
 Pending user intent, permission prompts, native prepare work, and failed starts do not acquire
-protection. Stop, interruption, suspension, natural end, fallback, transfer completion,
-cancellation, failure, and app shutdown release only the corresponding owner. Shared protection
-releases after the final owner exits.
+protection. Stop, interruption, suspension, natural end, transfer completion, cancellation, failure,
+and app shutdown release only the corresponding owner. Shared protection releases after the final
+owner exits.
 
-Native fallback is an explicit ownership transfer. TuneForge clears native playback ownership from
-system media state and power protection before starting Web Audio at the fallback position, then
-reacquires the browser wake lock after Web playback is confirmed. Other active owners continue to
-hold shared protection.
+Normal Tauri native failure releases only that resource's confirmed owner; it does not transfer power
+protection or playback to Web Audio. A later explicit native action may acquire a fresh owner after
+the new runtime confirms start. Browser, non-Tauri, and forced-Web Tauri builds use their Web Audio
+owners directly.
 
 ## Platform Matrix
 
@@ -108,7 +108,7 @@ all of these are true:
 - `WHY` matches TuneForge active work;
 - `MODE=block`;
 - TuneForge diagnostics report `systemd-logind` and the expected owner state;
-- the inhibitor releases after pause, stop, fallback, natural end, failure, or app exit.
+- the inhibitor releases after pause, stop, natural end, failure, or app exit.
 
 Do not add host helpers, broader DBus access, telemetry, or new services only to change the host
 diagnostic `COMM` column.

--- a/scripts/capture-release-media.mjs
+++ b/scripts/capture-release-media.mjs
@@ -19,6 +19,78 @@ const releaseMediaNativeAudioMetadata = Object.freeze({
   timelineRevision: 1,
   nativeTimeUs: 1,
 });
+const releaseMediaNativeAudioCapabilities = Object.freeze({
+  platform: "release-media",
+  backend: "release-media-fixture",
+  nativePlaybackSupported: true,
+  micCaptureSupported: true,
+  micMonitoringSupported: false,
+  systemInputVolumeSupported: false,
+  emitsEvents: ["audio://position", "audio://ended", "audio://error", "audio://input-frame"],
+  availabilityReason: null,
+});
+const releaseMediaNativeAudioCaptureMetadata = Object.freeze({
+  leaseId: "tuner-capture",
+  generation: 1,
+  captureGeneration: 1,
+  nativeTimeUs: 1,
+  capturePath: "desktop-cpal",
+  permissionState: "granted",
+  error: null,
+});
+
+function createReleaseMediaTunerFixture(metadata) {
+  let active = false;
+  let captureGeneration = Math.max(0, metadata.captureGeneration - 1);
+  let monitorEnabled = false;
+  let monitorGain = 0;
+  let sessionGeneration = Math.max(0, metadata.generation - 1);
+
+  function state(overrides = {}) {
+    return {
+      active,
+      deviceId: active ? "release-media-default-input" : null,
+      inputLevel: active ? 0.28 : 0,
+      monitorEnabled,
+      monitorGain,
+      sampleRate: active ? 48_000 : null,
+      captureGeneration,
+      capturePath: active ? metadata.capturePath : "none",
+      permissionState: metadata.permissionState,
+      error: metadata.error,
+      leaseId: active ? metadata.leaseId : null,
+      generation: sessionGeneration,
+      nativeTimeUs: metadata.nativeTimeUs,
+      ...overrides,
+    };
+  }
+
+  return {
+    acceptsFrame: (frame) => active && frame.captureGeneration === captureGeneration,
+    captureGeneration: () => captureGeneration,
+    setMonitor: (enabled, gain) => {
+      monitorEnabled = enabled;
+      monitorGain = gain;
+      return state();
+    },
+    start: () => {
+      if (!active) {
+        active = true;
+        sessionGeneration += 1;
+        captureGeneration += 1;
+      }
+      return state();
+    },
+    state,
+    stop: () => {
+      if (active) {
+        active = false;
+        captureGeneration += 1;
+      }
+      return state();
+    },
+  };
+}
 const childTailLines = 40;
 const releaseMediaCaptureCatalog = [
   {
@@ -552,13 +624,25 @@ async function installPageStabilizers(
   const mobileFixture = entry?.runtime === "mobile"
     ? mobilePlaybackFixture(mobileFixtureOptions)
     : null;
-  await page.addInitScript(({ animatePlayback, mobileFixture, nativeAudioMetadata, theme }) => {
+  await page.addInitScript(({
+    animatePlayback,
+    mobileFixture,
+    nativeAudioCapabilities,
+    nativeAudioCaptureMetadata,
+    nativeAudioMetadata,
+    theme,
+    tunerFixtureFactorySource,
+  }) => {
     const fixedNow = Date.parse("2026-04-18T13:16:00.000Z");
     let callbackId = 1;
     const callbacks = new Map();
     const eventListeners = new Map();
     const powerInhibitionReasons = new Set();
     let tunerFrameTimer = null;
+    const createTunerFixture = Function(`return (${tunerFixtureFactorySource});`)();
+    const tunerFixture = createTunerFixture(
+      nativeAudioCaptureMetadata,
+    );
     let playbackPositionTimer = null;
     let playbackSnapshot = {
       sessionId: null,
@@ -567,7 +651,7 @@ async function installPageStabilizers(
       durationSeconds: 182,
       playbackRate: 1,
       nativePlaybackSupported: true,
-      fallbackReason: null,
+      availabilityReason: null,
       ...nativeAudioMetadata,
       lanes: [],
       bufferHealth: [],
@@ -617,6 +701,7 @@ async function installPageStabilizers(
         sampleRate,
         samples,
         timestampMs: fixedNow + index * 24,
+        captureGeneration: tunerFixture.captureGeneration(),
       };
     }
 
@@ -639,6 +724,9 @@ async function installPageStabilizers(
     }
 
     function startTunerFrames() {
+      if (!tunerFrameTimer) {
+        tunerFixture.start();
+      }
       if (tunerFrameTimer) {
         window.clearInterval(tunerFrameTimer);
       }
@@ -656,6 +744,11 @@ async function installPageStabilizers(
         window.clearInterval(tunerFrameTimer);
         tunerFrameTimer = null;
       }
+      tunerFixture.stop();
+    }
+
+    function tunerInputState(overrides = {}) {
+      return tunerFixture.state(overrides);
     }
 
     function playbackLanesFromRequests(lanes) {
@@ -698,6 +791,9 @@ async function installPageStabilizers(
         positionSeconds: playbackSnapshot.positionSeconds,
         durationSeconds: playbackSnapshot.durationSeconds,
         state: playbackSnapshot.state,
+        generation: playbackSnapshot.generation,
+        timelineRevision: playbackSnapshot.timelineRevision,
+        nativeTimeUs: playbackSnapshot.nativeTimeUs,
       });
     }
 
@@ -827,17 +923,7 @@ async function installPageStabilizers(
         };
       }
       if (command === "audio_get_capabilities") {
-        return {
-          platform: "release-media",
-          backend: "release-media-fixture",
-          nativePlaybackSupported: true,
-          micCaptureSupported: true,
-          micMonitoringSupported: false,
-          systemInputVolumeSupported: false,
-          emitsEvents: ["audio://position", "audio://ended", "audio://error", "audio://input-frame"],
-          fallbackRequired: false,
-          fallbackReason: null,
-        };
+        return { ...nativeAudioCapabilities };
       }
       if (command === "audio_list_input_devices") {
         return {
@@ -859,13 +945,14 @@ async function installPageStabilizers(
           durationSeconds: payload.durationSeconds ?? 182,
           playbackRate: payload.playbackRate ?? 1,
           nativePlaybackSupported: true,
-          fallbackReason: null,
+          availabilityReason: null,
           lanes,
         });
         return {
           id: playbackSnapshot.sessionId,
+          leaseId: playbackSnapshot.leaseId,
           nativePlaybackSupported: true,
-          fallbackReason: null,
+          availabilityReason: null,
           laneCount: lanes.length,
           generation: playbackSnapshot.generation,
           timelineRevision: playbackSnapshot.timelineRevision,
@@ -883,7 +970,7 @@ async function installPageStabilizers(
           state: "playing",
           positionSeconds: startTimeSeconds,
           nativePlaybackSupported: true,
-          fallbackReason: null,
+          availabilityReason: null,
         });
         startPlaybackPosition();
         return snapshot;
@@ -913,50 +1000,25 @@ async function installPageStabilizers(
           lanes: playbackLanesFromRequests(payload.lanes ?? []),
         });
       }
-      if (command === "audio_set_click" || command === "audio_get_snapshot") {
+      if (command === "audio_get_snapshot") {
         return updatePlaybackSnapshot();
       }
       if (command === "audio_get_input_state") {
-        return {
-          active: Boolean(tunerFrameTimer),
-          deviceId: tunerFrameTimer ? "release-media-default-input" : null,
-          inputLevel: tunerFrameTimer ? 0.28 : 0,
-          monitorEnabled: false,
-          monitorGain: 0,
-          sampleRate: tunerFrameTimer ? 48_000 : null,
-        };
+        return tunerInputState();
       }
       if (command === "audio_start_input") {
         startTunerFrames();
-        return {
-          active: true,
-          deviceId: "release-media-default-input",
-          inputLevel: 0.28,
-          monitorEnabled: false,
-          monitorGain: 0,
-          sampleRate: 48_000,
-        };
+        return tunerInputState();
       }
       if (command === "audio_stop_input") {
         stopTunerFrames();
-        return {
-          active: false,
-          deviceId: null,
-          inputLevel: 0,
-          monitorEnabled: false,
-          monitorGain: 0,
-          sampleRate: null,
-        };
+        return tunerInputState();
       }
       if (command === "audio_set_monitor") {
-        return {
-          active: Boolean(tunerFrameTimer),
-          deviceId: tunerFrameTimer ? "release-media-default-input" : null,
-          inputLevel: tunerFrameTimer ? 0.28 : 0,
-          monitorEnabled: Boolean(args?.payload?.enabled),
-          monitorGain: Number(args?.payload?.gain ?? 0),
-          sampleRate: tunerFrameTimer ? 48_000 : null,
-        };
+        return tunerFixture.setMonitor(
+          Boolean(args?.payload?.enabled),
+          Number(args?.payload?.gain ?? 0),
+        );
       }
       if (command === "get_system_default_input_volume" || command === "set_system_default_input_volume") {
         return {
@@ -1069,8 +1131,11 @@ async function installPageStabilizers(
   }, {
     animatePlayback: motionPolicy.animatePlayback,
     mobileFixture,
+    nativeAudioCapabilities: releaseMediaNativeAudioCapabilities,
+    nativeAudioCaptureMetadata: releaseMediaNativeAudioCaptureMetadata,
     nativeAudioMetadata: releaseMediaNativeAudioMetadata,
     theme: options.theme,
+    tunerFixtureFactorySource: createReleaseMediaTunerFixture.toString(),
   });
 }
 
@@ -2412,12 +2477,15 @@ export {
   captureMotionPolicy,
   chords,
   chordBackends,
+  createReleaseMediaTunerFixture,
   expectedCatalogEntries,
   manifestItemForCatalogEntry,
   measureMobilePlaybackFollowLayouts,
   overflowToScrollDelta,
   parseOptions,
   releaseMediaCaptureCatalog,
+  releaseMediaNativeAudioCapabilities,
+  releaseMediaNativeAudioCaptureMetadata,
   releaseMediaNativeAudioMetadata,
   validateReleaseMediaCatalog,
 };

--- a/scripts/capture-release-media.test.mjs
+++ b/scripts/capture-release-media.test.mjs
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
+import { readFileSync } from "node:fs";
 import test from "node:test";
 import {
   buildManifest,
@@ -7,11 +8,14 @@ import {
   captureMotionPolicy,
   chords,
   chordBackends,
+  createReleaseMediaTunerFixture,
   expectedCatalogEntries,
   manifestItemForCatalogEntry,
   overflowToScrollDelta,
   parseOptions,
   releaseMediaCaptureCatalog,
+  releaseMediaNativeAudioCapabilities,
+  releaseMediaNativeAudioCaptureMetadata,
   releaseMediaNativeAudioMetadata,
   validateReleaseMediaCatalog,
 } from "./capture-release-media.mjs";
@@ -24,6 +28,88 @@ test("native playback fixture exposes stable safe session metadata", () => {
     nativeTimeUs: 1,
   });
   assert.equal(Object.isFrozen(releaseMediaNativeAudioMetadata), true);
+});
+
+test("native release-media fixtures match required audio contracts", () => {
+  assert.deepEqual(releaseMediaNativeAudioCapabilities, {
+    platform: "release-media",
+    backend: "release-media-fixture",
+    nativePlaybackSupported: true,
+    micCaptureSupported: true,
+    micMonitoringSupported: false,
+    systemInputVolumeSupported: false,
+    emitsEvents: ["audio://position", "audio://ended", "audio://error", "audio://input-frame"],
+    availabilityReason: null,
+  });
+  assert.deepEqual(releaseMediaNativeAudioCaptureMetadata, {
+    leaseId: "tuner-capture",
+    generation: 1,
+    captureGeneration: 1,
+    nativeTimeUs: 1,
+    capturePath: "desktop-cpal",
+    permissionState: "granted",
+    error: null,
+  });
+  assert.equal(Object.hasOwn(releaseMediaNativeAudioCapabilities, "fallbackReason"), false);
+  assert.equal(Object.hasOwn(releaseMediaNativeAudioCaptureMetadata, "fallbackReason"), false);
+  assert.equal(Object.isFrozen(releaseMediaNativeAudioCapabilities), true);
+  assert.equal(Object.isFrozen(releaseMediaNativeAudioCaptureMetadata), true);
+});
+
+test("tuner fixture separates session ownership from capture runtime generations", () => {
+  const tuner = createReleaseMediaTunerFixture(releaseMediaNativeAudioCaptureMetadata);
+  const firstStart = tuner.start();
+  const firstFrame = { captureGeneration: firstStart.captureGeneration };
+
+  assert.deepEqual(firstStart, {
+    active: true,
+    deviceId: "release-media-default-input",
+    inputLevel: 0.28,
+    monitorEnabled: false,
+    monitorGain: 0,
+    sampleRate: 48_000,
+    captureGeneration: 1,
+    capturePath: "desktop-cpal",
+    permissionState: "granted",
+    error: null,
+    leaseId: "tuner-capture",
+    generation: 1,
+    nativeTimeUs: 1,
+  });
+  assert.equal(tuner.acceptsFrame(firstFrame), true);
+
+  assert.deepEqual(tuner.stop(), {
+    ...firstStart,
+    active: false,
+    deviceId: null,
+    inputLevel: 0,
+    sampleRate: null,
+    captureGeneration: 2,
+    capturePath: "none",
+    leaseId: null,
+  });
+  assert.equal(tuner.acceptsFrame(firstFrame), false);
+
+  const secondStart = tuner.start();
+  assert.equal(secondStart.leaseId, "tuner-capture");
+  assert.equal(secondStart.generation, 2);
+  assert.equal(secondStart.captureGeneration, 3);
+  assert.equal(tuner.acceptsFrame(firstFrame), false);
+  assert.equal(tuner.acceptsFrame({ captureGeneration: secondStart.captureGeneration }), true);
+});
+
+test("release-media Tauri mock emits correlated contracts without fallback fields", () => {
+  const mockSource = readFileSync(new URL("./capture-release-media.mjs", import.meta.url), "utf8");
+
+  assert.doesNotMatch(mockSource, /\bfallbackReason\b/);
+  assert.doesNotMatch(mockSource, /\bfallbackRequired\b/);
+  assert.doesNotMatch(mockSource, /\baudio_set_click\b/);
+  assert.doesNotMatch(mockSource, /__tuneforgeReleaseMediaTunerFixture/);
+  assert.equal((mockSource.match(/page\.addInitScript/g) ?? []).length, 1);
+  assert.match(mockSource, /captureGeneration: tunerFixture\.captureGeneration\(\)/);
+  assert.match(mockSource, /generation: playbackSnapshot\.generation/);
+  assert.match(mockSource, /timelineRevision: playbackSnapshot\.timelineRevision/);
+  assert.match(mockSource, /nativeTimeUs: playbackSnapshot\.nativeTimeUs/);
 });
 
 test("settings fixture exposes the available default advanced chord backend", () => {


### PR DESCRIPTION
## Summary

- Require native audio in normal Tauri and stop safely after terminal failures.
- Require correlated ownership metadata and remove legacy fallback/default control paths.
- Preserve browser, non-Tauri, and explicitly forced Web Audio behavior.
- Closes #513

## Testing

- `rtk cargo test native_audio::` (127 passed)
- `rtk cargo check`
- `rtk cargo fmt --all -- --check`
- `rtk pnpm --filter @tuneforge/desktop lint`
- `rtk pnpm --dir apps/desktop run typecheck`
- `rtk pnpm --filter @tuneforge/desktop test -- --run` (843 passed)
- `rtk pnpm --filter @tuneforge/site test` (6 passed)
- `rtk git diff --check`
- Physical teardown, permissions, hotplug, audible timing, and OS scheduling remain for final manual stack validation.
