### PR TITLE
chore: prepare v1.5.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,21 +5,25 @@ download, installation, verification, signature, and publication instructions.
 
 ## [Unreleased]
 
+## [1.5.0] - 2026-09-08
+
 ### Added
 
 - Moved project count-ins and playback-following metronome cues onto the native audio timeline,
   with timing-grid-aware spacing and the same short triangle click on native and Web Audio paths.
-- Moved project count-ins and metronome timing onto one native output runtime, including standalone
-  free-run and playback-following modes, while keeping tuner capture independently concurrent.
+- Moved the standalone metronome onto the shared native output runtime while keeping tuner capture
+  independently concurrent.
 
 ### Changed
 
-- Made native audio required in normal Tauri sessions while preserving browser and explicitly
-  forced Web Audio modes.
+- Made native audio required in normal Tauri sessions: startup and runtime failures now stop with
+  an actionable diagnostic and require explicit recovery, while browser and explicitly forced Web
+  Audio modes remain supported.
 
 ### Fixed
 
 - Reduced Android sync reconciliation memory use for libraries with many pending projects.
+- Prevented Sync Evidence exports from hanging on macOS and Linux when a native save path is used.
 - Preserved project playback position across native output changes, rejected stale transport
   completions, cancelled pending native and Web starts, kept native loop restarts reliable, and
   kept playback-following native and Web metronome timing aligned through tempo changes.
@@ -179,7 +183,8 @@ download, installation, verification, signature, and publication instructions.
 
 - Development used `0.1.0` metadata; `v1.0.0` was the first tagged release.
 
-[Unreleased]: https://github.com/grazzolini/tuneforge/compare/v1.4.0...main
+[Unreleased]: https://github.com/grazzolini/tuneforge/compare/v1.5.0...main
+[1.5.0]: https://github.com/grazzolini/tuneforge/compare/v1.4.0...v1.5.0
 [1.4.0]: https://github.com/grazzolini/tuneforge/compare/v1.3.0...v1.4.0
 [1.3.0]: https://github.com/grazzolini/tuneforge/compare/v1.2.0...v1.3.0
 [1.2.0]: https://github.com/grazzolini/tuneforge/compare/v1.1.0...v1.2.0

--- a/apps/backend/pyproject.toml
+++ b/apps/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tuneforge-backend"
-version = "1.4.0"
+version = "1.5.0"
 description = "Local API and processing backend for TuneForge."
 readme = "README.md"
 requires-python = ">=3.14,<3.15"

--- a/apps/backend/uv.lock
+++ b/apps/backend/uv.lock
@@ -1412,7 +1412,7 @@ wheels = [
 
 [[package]]
 name = "tuneforge-backend"
-version = "1.4.0"
+version = "1.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tuneforge/desktop",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -7120,7 +7120,7 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tuneforge"
-version = "1.4.0"
+version = "1.5.0"
 dependencies = [
  "android_system_properties",
  "base64 0.23.1",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tuneforge"
-version = "1.4.0"
+version = "1.5.0"
 description = "TuneForge desktop shell"
 edition = "2021"
 license = "MIT"

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "TuneForge",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "identifier": "com.tuneforge.desktop",
   "build": {
     "beforeDevCommand": "pnpm --filter @tuneforge/desktop dev",

--- a/apps/desktop/src/App.project-export.test.tsx
+++ b/apps/desktop/src/App.project-export.test.tsx
@@ -60,8 +60,8 @@ function health(defaultExportFormat: string): HealthResponse {
   return {
     name: "TuneForge",
     version: "backend-test-ref",
-    backend_version: { package_version: "1.4.0", git_ref: "backend-test-ref" },
-    frontend_version: { package_version: "1.4.0", git_ref: "frontend-test-ref" },
+    backend_version: { package_version: "1.5.0", git_ref: "backend-test-ref" },
+    frontend_version: { package_version: "1.5.0", git_ref: "frontend-test-ref" },
     status: "ok",
     api_base_url: "http://127.0.0.1:8765/api/v1",
     data_root: "/tmp/tuneforge",

--- a/apps/desktop/src/test/appTestHarness.tsx
+++ b/apps/desktop/src/test/appTestHarness.tsx
@@ -1620,11 +1620,11 @@ const {
     name: "TuneForge",
     version: "backend-test-ref",
     backend_version: {
-      package_version: "1.4.0",
+      package_version: "1.5.0",
       git_ref: "backend-test-ref",
     },
     frontend_version: {
-      package_version: "1.4.0",
+      package_version: "1.5.0",
       git_ref: "frontend-test-ref",
     },
     status: "ok",

--- a/packages/shared-types/package.json
+++ b/packages/shared-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tuneforge/shared-types",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "private": true,
   "type": "module",
   "exports": {

--- a/packaging/flatpak/com.tuneforge.desktop.metainfo.xml
+++ b/packaging/flatpak/com.tuneforge.desktop.metainfo.xml
@@ -27,6 +27,7 @@
   </categories>
   <content_rating type="oars-1.1" />
   <releases>
+    <release version="1.5.0" date="2026-09-08" />
     <release version="1.4.0" date="2026-09-01" />
     <release version="1.3.0" date="2026-08-28" />
     <release version="1.2.0" date="2026-08-24" />

--- a/scripts/capture-release-media.mjs
+++ b/scripts/capture-release-media.mjs
@@ -2009,11 +2009,11 @@ function healthResponse() {
     name: "TuneForge",
     version: "release-media-fixture",
     backend_version: {
-      package_version: "1.4.0",
+      package_version: "1.5.0",
       git_ref: "release-media-fixture",
     },
     frontend_version: {
-      package_version: "1.4.0",
+      package_version: "1.5.0",
       git_ref: "release-media-fixture",
     },
     status: "ok",

--- a/scripts/flatpak-pnpm.test.mjs
+++ b/scripts/flatpak-pnpm.test.mjs
@@ -21,6 +21,7 @@ const flatpakManifest = readFileSync(
   "utf8",
 );
 const pnpmSeeder = readFileSync(new URL("../packaging/flatpak/seed-pnpm-store.mjs", import.meta.url), "utf8");
+const pnpmPath = process.env.npm_execpath ?? "pnpm";
 
 function run(command, args, cwd) {
   const result = spawnSync(command, args, { cwd, encoding: "utf8" });
@@ -193,7 +194,7 @@ test("pnpm store seeding preserves durable warm caches and rejects corrupt store
       tarballRoot: sources,
       storeDir,
       cacheDir,
-      pnpmPath: "pnpm",
+      pnpmPath,
     });
   } finally {
     process.chdir(previousCwd);
@@ -232,7 +233,7 @@ test("pnpm store seeding preserves durable warm caches and rejects corrupt store
       tarballRoot: warmSources,
       storeDir,
       cacheDir,
-      pnpmPath: "pnpm",
+      pnpmPath,
     });
   } finally {
     process.chdir(previousCwd);
@@ -258,7 +259,7 @@ test("pnpm store seeding preserves durable warm caches and rejects corrupt store
         tarballRoot: missingSources,
         storeDir: missingBlobStore,
         cacheDir,
-        pnpmPath: "pnpm",
+        pnpmPath,
       }),
     );
   } finally {


### PR DESCRIPTION
## Summary

- Prepare TuneForge v1.5.0 release metadata for 2026-09-08 and promote the curated changelog.
- Keep Flatpak pnpm fixture validation on the repository-pinned launcher when the global launcher differs.

## Motivation

Refs #514

## Changes

- Set backend, desktop, Tauri, and shared package versions to 1.5.0; refresh only root lockfile versions.
- Add the Flatpak AppStream release record and update synthetic release-version fixtures.
- Record native-required desktop audio behavior and failures, sync export repair, and Android sync fixes.
- Reuse the pnpm lifecycle launcher for Flatpak cold, warm, and missing-store fixture paths.

## Testing

- `pnpm release:check-version` — passed for 1.5.0.
- `pnpm lint` — passed, including Ruff and mypy over 87 backend source files.
- `pnpm typecheck` — passed.
- `cargo check --manifest-path apps/desktop/src-tauri/Cargo.toml` — passed.
- `pnpm --filter @tuneforge/desktop test --run` — 893 passed across 49 files.
- `cargo test --manifest-path apps/desktop/src-tauri/Cargo.toml` — 421 passed.
- `pnpm --filter @tuneforge/site test` — 6 passed.
- `node --test scripts/capture-release-media.test.mjs` — 18 passed.
- `node scripts/capture-release-media.mjs --run` — captured all 9 catalog entries; inspected every screenshot, video frame set, poster, and manifest entry.
- `pnpm test` — build info 1/1 and Flatpak 57/57 passed through the normal pnpm lifecycle. The run was intentionally stopped at desktop-test startup after targeted launcher verification, so this is not a full-root pass.
- `uv run --directory apps/backend --python 3.14 pytest` — the full local gate is not green: one run completed with 823 passed and 1 import-flow failure; a separate root-run backend phase segfaulted in Numba/Librosa. A clean-main focused default-JIT analysis test passed 1/1, and a clean-main full suite was stopped at 96% without displayed failures. No backend regression is attributed to this metadata patch. Rerun the exact command above for full verification.
- `git diff --check` — passed.

Release package and license inventory gates were not run because this draft does not create tagged release builds.
