### PR TITLE
feat: add owned FFmpeg conversion for macOS and Android

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,3 +80,6 @@ data/
 *.keystore
 *.cer
 *.crt
+# Verified local FFmpeg source/build cache and generated platform payloads.
+packaging/ffmpeg/cache/
+packaging/ffmpeg/generated/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,12 +25,18 @@ These are non-negotiable. If a task seems to require breaking one, stop and ask.
 
 1. **Local-only stays local.** The backend binds `127.0.0.1`. Do not introduce network exposure, public binds, reverse-proxy assumptions, multi-user concepts, auth/session systems, telemetry, analytics, or external API calls (other than the Demucs model download that already exists).
 2. **No cloud, no accounts.** The app must keep working with no internet after first run.
-3. **Don't bundle FFmpeg.** It is a host-installed dependency by design. See [THIRD_PARTY_NOTICES.md](./THIRD_PARTY_NOTICES.md) for the licensing reason.
+3. **Bundle only audited LGPL FFmpeg builds.** Packaged macOS arm64 and Android arm64-v8a use
+   the repository-pinned owned runtime; development uses host tools, and Flatpak uses only its
+   runtime/extension. Keep source, notices, provenance, linkage checks, and replacement steps with
+   every distribution. See [THIRD_PARTY_NOTICES.md](./THIRD_PARTY_NOTICES.md).
 4. **Respect the layering.** `routes/` → `services/` → `engines/`. Routes are thin; business logic lives in services; raw audio/ML work lives in engines. Don't bypass layers.
 5. **Don't commit generated files by hand.** Run the generator (see "Generated artifacts" below).
 6. **Don't disable lint/type/test rules to make CI pass.** Fix the underlying issue.
 7. **Don't bypass safety flags.** No `--no-verify`, no `git push --force` on shared branches, no destructive shell shortcuts.
-8. **MIT-compatible deps only.** Avoid GPL/AGPL/SSPL runtime dependencies. Note any new dep's license in [THIRD_PARTY_NOTICES.md](./THIRD_PARTY_NOTICES.md).
+8. **MIT-compatible deps only, except the audited owned FFmpeg runtime.** Avoid GPL/AGPL/SSPL
+   runtime dependencies. The pinned dynamically linked FFmpeg/LAME distribution is the explicit
+   LGPL exception; future unrelated LGPL additions still require separate approval. Note any new
+   dependency's license in [THIRD_PARTY_NOTICES.md](./THIRD_PARTY_NOTICES.md).
 
 ## Repository Layout
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ download, installation, verification, signature, and publication instructions.
 
 ## [Unreleased]
 
+### Added
+
+- Added owned, offline LGPL FFmpeg conversion for macOS arm64 and Android arm64, API 26+, with
+  durable WAV, FLAC, MP3, and M4A import, preview, retune, transpose, and Android export support.
+
+### Changed
+
+- Android Settings and Export now expose the same four durable audio formats while keeping export
+  limited to existing saved artifacts and leaving playback tempo/tuning out of export.
+
 ## [1.5.0] - 2026-09-08
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -174,9 +174,9 @@ ci: pin commitlint action to v6.2.1
 
 Use the same action version across branch and pull request checks.
 
-docs: clarify ffmpeg prerequisite
+docs: clarify ffmpeg runtime ownership
 
-Explain that FFmpeg is host-installed instead of bundled with Tuneforge.
+Explain the development, packaged macOS and Android, and Flatpak FFmpeg sources.
 ```
 
 Rules:

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Local-first does not mean first use is always offline: setup or first use can do
 
 ## Status
 
-The desktop workflow is the supported full TuneForge experience. The dev flow (`pnpm dev`) is the fastest way to iterate. Local macOS app/DMG and Linux Flatpak packaging are available, but generated builds are unsigned and not notarized. Development/source runs and macOS packages require `ffmpeg`/`ffprobe` on the host `PATH`; Flatpak uses `/app/bin/ffmpeg` and `/app/bin/ffprobe` wrappers backed by the Flatpak runtime sandbox.
+The desktop workflow is the supported full TuneForge experience. The dev flow (`pnpm dev`) is the fastest way to iterate. Local macOS app/DMG and Linux Flatpak packaging are available, but generated builds are unsigned and not notarized. Development/source runs use host `ffmpeg`/`ffprobe`; macOS arm64 packages own an audited LGPL runtime; Flatpak uses `/app/bin/ffmpeg` and `/app/bin/ffprobe` wrappers backed by the sandbox runtime.
 
 Current release limits:
 
@@ -63,7 +63,7 @@ Security reports follow the process in [SECURITY.md](./SECURITY.md). "There is n
 - `pnpm` (version pinned in [package.json](./package.json))
 - [`uv`](https://docs.astral.sh/uv/)
 - Python 3.14.7
-- `ffmpeg` and `ffprobe` available on `PATH` for development/source runs and macOS packages (install via `brew install ffmpeg`, `apt install ffmpeg`, etc.)
+- `ffmpeg` and `ffprobe` available on `PATH` for development/source runs (install via `brew install ffmpeg`, `apt install ffmpeg`, etc.)
 - macOS system mic volume control uses the built-in CoreAudio API.
 - Linux system mic volume control uses `wpctl` or `pactl` for the active PipeWire/PulseAudio session.
 - Linux native tempo playback builds require Clang/libclang for `bindgen` (`sudo pacman -S clang`
@@ -131,9 +131,10 @@ The built-in chord and beat backends remain available as fallbacks when advanced
 missing, unsupported, or disabled. Mobile paths do not run the desktop Python/FastAPI stack and must
 keep clear disabled/fallback states instead of requiring ONNX Runtime or beat-this.
 
-Release diagnostics distinguish host tools from local model/cache dependencies. If an import or
-metadata error names `ffmpeg` or `ffprobe`, install FFmpeg on the host or set
-`TUNEFORGE_FFMPEG_PATH` / `TUNEFORGE_FFPROBE_PATH`; TuneForge does not bundle those binaries.
+Release diagnostics distinguish host tools from local model/cache dependencies. For development,
+install FFmpeg on the host or set `TUNEFORGE_FFMPEG_PATH` / `TUNEFORGE_FFPROBE_PATH`. Packaged
+macOS builds use their owned runtime and fail clearly when that verified payload is missing or
+invalid.
 Diagnostics that name Demucs, Whisper, crema, or beat-this refer to local runtime dependencies or
 model/checkpoint caches, which are prepared by setup/model prewarm or by packages built with
 `--model-bundle`.
@@ -278,7 +279,7 @@ install flow. Pass `--cpu`, `--nvidia`, or `--legacy-nvidia` to limit a Flatpak 
 selections always include the CPU app, while no profile flags build all profiles. Source distribution is the source
 checkout/archive; the package commands do not create a separate source tarball.
 
-macOS packages require host `ffmpeg` / `ffprobe`; Flatpak routes backend lookups to sandbox wrappers at `/app/bin/ffmpeg` and `/app/bin/ffprobe`. TuneForge does not bundle FFmpeg. See [Packaging](./docs/PACKAGING.md) for output paths, package flags, local repo install commands, data-directory behavior, and size expectations.
+macOS arm64 packages include the audited LGPL FFmpeg runtime; Flatpak routes backend lookups to sandbox wrappers at `/app/bin/ffmpeg` and `/app/bin/ffprobe` and includes no owned Linux codec payload. See [Packaging](./docs/PACKAGING.md) for source verification, replacement instructions, output paths, package flags, local repo install commands, data-directory behavior, and size expectations.
 
 ## CI
 

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -9,7 +9,7 @@ This document is an engineering notice and distribution checklist, not legal adv
 This file is the source of truth for dependency and model-weight distribution policy:
 
 - Default release package commands (`pnpm package:mac`, `pnpm package:linux:flatpak`) do not pass `--model-bundle`. They include Advanced Chords, Advanced Beat Analysis, and LV Chordia. LV Chordia's five dependency-owned checkpoints are included; external Demucs, Whisper, and beat-this weights are not.
-- FFmpeg and ffprobe are not bundled by Tuneforge. macOS and source runs use host-installed binaries on `PATH` or explicit `TUNEFORGE_FFMPEG_PATH` / `TUNEFORGE_FFPROBE_PATH` overrides. Flatpak builds use `/app/bin/ffmpeg` and `/app/bin/ffprobe` wrappers backed by the Flatpak runtime or extensions.
+- Packaged macOS arm64 and Android arm64 include the LGPL FFmpeg/LAME distribution pinned by [`packaging/ffmpeg/sources.lock.json`](./packaging/ffmpeg/sources.lock.json). Development/source runs keep host lookup and explicit overrides. Flatpak includes no owned FFmpeg payload and uses runtime/extension wrappers.
 - Demucs, Whisper, and beat-this weights are local cache assets by default. Setup/model-prewarm can prepare them ahead of time, and the app may download them on first use if they are missing. Fully offline use requires the relevant caches/assets to already exist.
 - `--model-bundle` is an explicit local/dev packaging option, not part of default release packaging. It stages Demucs and Whisper weights and, when selected, the beat-this `small0` checkpoint; redistribution needs separate review before publishable artifacts use it.
 - Default Advanced Chords packages use ONNX Runtime and always include the exact pinned 2.2 MB converted model and runtime state so startup can seed the verified TuneForge data cache. The Crema Python package, TensorFlow, and Keras are not included.
@@ -120,9 +120,17 @@ This file is the source of truth for dependency and model-weight distribution po
 
 ### FFmpeg / ffprobe
 
-- **License:** LGPL-2.1+ or GPL-2.0+ depending on the build
+- **Version:** See [`packaging/ffmpeg/sources.lock.json`](./packaging/ffmpeg/sources.lock.json).
+- **License:** LGPL-2.1-or-later for TuneForge's owned configuration
 - **Source:** <https://ffmpeg.org/>
-- **Notes:** **Tuneforge does not bundle FFmpeg.** macOS and source runs use a user-installed build (for example via Homebrew, apt, or winget) discoverable on `PATH` or through explicit binary path settings. Flatpak packages use sandbox wrapper paths backed by the Flatpak runtime or extensions. Users are responsible for the licensing terms of the FFmpeg build they install or provide.
+- **Notes:** Packaged macOS arm64 and Android arm64 use the repository recipe and source lock in `packaging/ffmpeg/`. The build disables GPL, nonfree, version3, network, device, and unused libraries/features. macOS also includes `ffmpeg` and `ffprobe`; Android links the five selected libav libraries through a narrow C bridge. The detached source signature is verified against the signing key pinned by the source lock. Each build emits a hash-bound corresponding-source companion containing the full upstream archives, signature/key, patch, recipe, lock, validator, and notices. Development/source runs keep host lookup. Flatpak uses only sandbox runtime/extension wrappers.
+
+### LAME
+
+- **Version:** See [`packaging/ffmpeg/sources.lock.json`](./packaging/ffmpeg/sources.lock.json).
+- **License:** LGPL-2.0-or-later
+- **Source:** <https://sourceforge.net/projects/lame/>
+- **Notes:** Dynamically linked only for the owned MP3 encoder. Upstream publishes the release archive over HTTPS but no detached signature or checksum sidecar; TuneForge pins and verifies the reviewed archive SHA-256 in `packaging/ffmpeg/sources.lock.json`. The package includes LAME's COPYING and LICENSE texts.
 
 ### PulseAudio pactl
 
@@ -178,7 +186,7 @@ This file is the source of truth for dependency and model-weight distribution po
 
 - **License:** MPL-2.0
 - **Source:** <https://github.com/pdeljanov/Symphonia>
-- **Notes:** Used only by the native macOS, Linux, and Android playback engine for streaming demux/decode of local playback files. FFmpeg remains the desktop host dependency for transform/export work and is not bundled on Android.
+- **Notes:** Used by the native macOS, Linux, and Android playback engine and by Android durable-artifact validation. FFmpeg conversion remains separate from realtime playback.
 
 ### ndk-context
 

--- a/apps/backend/app/engines/transform.py
+++ b/apps/backend/app/engines/transform.py
@@ -60,6 +60,8 @@ def run_ffmpeg_transform(
         "-y",
         "-i",
         str(source_path),
+        "-map",
+        "0:a:0",
         "-vn",
         "-af",
         filter_graph,

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -345,7 +345,7 @@ dependencies = [
  "quote",
  "regex",
  "rustc-hash 1.1.0",
- "shlex 1.3.0",
+ "shlex",
  "syn 2.0.119",
 ]
 
@@ -365,7 +365,7 @@ dependencies = [
  "quote",
  "regex",
  "rustc-hash 2.1.3",
- "shlex 1.3.0",
+ "shlex",
  "syn 2.0.119",
 ]
 
@@ -589,12 +589,12 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.4.4"
+version = "1.2.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ad534f4357a5264cce5019c989cf66a4f0dc4e0d1b1d15f8aacec0ff7360273"
+checksum = "7a0dd1ca384932ff3641c8718a02769f1698e7563dc6974ffd03346116310423"
 dependencies = [
  "find-msvc-tools",
- "shlex 2.0.1",
+ "shlex",
 ]
 
 [[package]]
@@ -5688,12 +5688,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
-name = "shlex"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
-
-[[package]]
 name = "signal-hook-registry"
 version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7125,6 +7119,7 @@ dependencies = [
  "android_system_properties",
  "base64 0.23.1",
  "block2",
+ "cc",
  "chrono",
  "cpal",
  "dbus",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -9,6 +9,7 @@ license = "MIT"
 crate-type = ["staticlib", "cdylib", "rlib"]
 
 [build-dependencies]
+cc = "=1.2.57"
 tauri-build = { version = "2.6.3", features = [] }
 
 [features]

--- a/apps/desktop/src-tauri/build.rs
+++ b/apps/desktop/src-tauri/build.rs
@@ -3,7 +3,45 @@ fn main() {
     if let Some(git_ref) = git_ref() {
         println!("cargo:rustc-env=TUNEFORGE_GIT_REF={git_ref}");
     }
+    build_android_ffmpeg_bridge();
     tauri_build::build()
+}
+
+fn build_android_ffmpeg_bridge() {
+    if std::env::var("CARGO_CFG_TARGET_OS").as_deref() != Ok("android") {
+        return;
+    }
+    let root = std::env::var("TUNEFORGE_ANDROID_FFMPEG_ROOT")
+        .expect("TUNEFORGE_ANDROID_FFMPEG_ROOT is required for Android builds");
+    let root = std::path::PathBuf::from(root);
+    let include = root.join("include");
+    let library = root.join("lib");
+    if !include.is_dir() || !library.is_dir() {
+        panic!(
+            "verified Android FFmpeg headers/libraries missing at {}",
+            root.display()
+        );
+    }
+    cc::Build::new()
+        .file("src/mobile_ffmpeg/bridge.c")
+        .include(&include)
+        .flag_if_supported("-std=c11")
+        .warnings(true)
+        .compile("tuneforge_ffmpeg_bridge");
+    println!("cargo:rustc-link-search=native={}", library.display());
+    for library in [
+        "avfilter",
+        "avformat",
+        "avcodec",
+        "swresample",
+        "avutil",
+        "mp3lame",
+    ] {
+        println!("cargo:rustc-link-lib=dylib={library}");
+    }
+    println!("cargo:rerun-if-env-changed=TUNEFORGE_ANDROID_FFMPEG_ROOT");
+    println!("cargo:rerun-if-changed=src/mobile_ffmpeg/bridge.c");
+    println!("cargo:rerun-if-changed=src/mobile_ffmpeg/bridge.h");
 }
 
 fn git_ref() -> Option<String> {

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -21,6 +21,8 @@ use serde::{Deserialize, Serialize};
 
 mod file_dialog_scope;
 mod mobile_backend;
+#[cfg(target_os = "android")]
+mod mobile_ffmpeg;
 mod mobile_media_transport;
 mod native_audio;
 pub mod power_inhibition;
@@ -296,14 +298,15 @@ fn build_python_path(backend_root: &Path) -> Result<String, Box<dyn std::error::
 }
 
 #[cfg(not(target_os = "android"))]
-fn build_backend_library_path(python_root: &Path) -> Result<OsString, env::JoinPathsError> {
+fn build_backend_library_path(
+    python_root: &Path,
+    mut prefixes: Vec<PathBuf>,
+) -> Result<OsString, env::JoinPathsError> {
     let current_paths: Vec<PathBuf> = env::var_os("LD_LIBRARY_PATH")
         .map(|path| env::split_paths(&path).collect())
         .unwrap_or_default();
-    env::join_paths(append_unique_paths(
-        vec![python_root.join("lib")],
-        current_paths,
-    ))
+    prefixes.push(python_root.join("lib"));
+    env::join_paths(append_unique_paths(prefixes, current_paths))
 }
 
 #[cfg(not(target_os = "android"))]
@@ -354,17 +357,15 @@ fn append_unique_paths(
 }
 
 #[cfg(not(target_os = "android"))]
-fn build_backend_search_path() -> Result<OsString, env::JoinPathsError> {
-    let current_paths = env::var_os("PATH")
+fn build_backend_search_path(mut prefixes: Vec<PathBuf>) -> Result<OsString, env::JoinPathsError> {
+    let current_paths: Vec<PathBuf> = env::var_os("PATH")
         .map(|path| env::split_paths(&path).collect())
         .unwrap_or_default();
-    env::join_paths(append_unique_paths(
-        current_paths,
-        host_tool_fallback_dirs(),
-    ))
+    prefixes.extend(current_paths);
+    env::join_paths(append_unique_paths(prefixes, host_tool_fallback_dirs()))
 }
 
-#[cfg(all(not(target_os = "android"), unix))]
+#[cfg(all(not(target_os = "android"), any(not(target_os = "macos"), test), unix))]
 fn is_executable_file(path: &Path) -> bool {
     use std::os::unix::fs::PermissionsExt;
 
@@ -373,12 +374,16 @@ fn is_executable_file(path: &Path) -> bool {
         .unwrap_or(false)
 }
 
-#[cfg(all(not(target_os = "android"), not(unix)))]
+#[cfg(all(
+    not(target_os = "android"),
+    any(not(target_os = "macos"), test),
+    not(unix)
+))]
 fn is_executable_file(path: &Path) -> bool {
     path.is_file()
 }
 
-#[cfg(not(target_os = "android"))]
+#[cfg(all(not(target_os = "android"), any(not(target_os = "macos"), test)))]
 fn find_executable_in_path(binary_name: &str, search_path: &OsString) -> Option<PathBuf> {
     env::split_paths(search_path)
         .map(|directory| directory.join(binary_name))
@@ -399,10 +404,39 @@ fn spawn_packaged_backend(app: &AppHandle) -> Result<BackendRuntime, Box<dyn std
     let port = allocate_port()?;
     let base_url = format!("http://127.0.0.1:{port}");
     let python_path = build_python_path(&bundled_backend_root)?;
-    let backend_library_path = build_backend_library_path(&bundled_python_root)?;
-    let backend_search_path = build_backend_search_path()?;
-    let ffmpeg_path = find_executable_in_path("ffmpeg", &backend_search_path);
-    let ffprobe_path = find_executable_in_path("ffprobe", &backend_search_path);
+    let owned_ffmpeg_root = bundled_backend_root.join("ffmpeg");
+    let owned_ffmpeg_bin = owned_ffmpeg_root.join("bin");
+    let owned_ffmpeg_lib = owned_ffmpeg_root.join("lib");
+    #[cfg(target_os = "macos")]
+    if !owned_ffmpeg_bin.join("ffmpeg").is_file()
+        || !owned_ffmpeg_bin.join("ffprobe").is_file()
+        || !owned_ffmpeg_lib.is_dir()
+    {
+        return Err(format!(
+            "Owned FFmpeg runtime is incomplete at {}",
+            owned_ffmpeg_root.display()
+        )
+        .into());
+    }
+    let mut library_roots = Vec::new();
+    let mut search_roots = Vec::new();
+    #[cfg(target_os = "macos")]
+    {
+        library_roots.insert(0, owned_ffmpeg_lib.clone());
+        search_roots.push(owned_ffmpeg_bin.clone());
+    }
+    let backend_library_path = build_backend_library_path(&bundled_python_root, library_roots)?;
+    let backend_search_path = build_backend_search_path(search_roots)?;
+    #[cfg(target_os = "macos")]
+    let (ffmpeg_path, ffprobe_path) = (
+        Some(owned_ffmpeg_bin.join("ffmpeg")),
+        Some(owned_ffmpeg_bin.join("ffprobe")),
+    );
+    #[cfg(not(target_os = "macos"))]
+    let (ffmpeg_path, ffprobe_path) = (
+        find_executable_in_path("ffmpeg", &backend_search_path),
+        find_executable_in_path("ffprobe", &backend_search_path),
+    );
     let model_bundle_dir = bundled_backend_root.join("models").join("bundle");
 
     let mut command = Command::new(&python);
@@ -418,6 +452,7 @@ fn spawn_packaged_backend(app: &AppHandle) -> Result<BackendRuntime, Box<dyn std
         .arg(port.to_string())
         .current_dir(&backend_source_root)
         .env("LD_LIBRARY_PATH", &backend_library_path)
+        .env("DYLD_LIBRARY_PATH", &backend_library_path)
         .env("PATH", &backend_search_path)
         .env("PYTHONHOME", &bundled_python_root)
         .env("PYTHONPATH", python_path)
@@ -869,7 +904,8 @@ mod tests {
     #[test]
     fn backend_library_path_starts_with_bundled_python_lib() {
         let python_root = PathBuf::from("/app/lib/tuneforge/backend/python");
-        let library_path = build_backend_library_path(&python_root).expect("build library path");
+        let library_path =
+            build_backend_library_path(&python_root, Vec::new()).expect("build library path");
         let paths = env::split_paths(&library_path).collect::<Vec<_>>();
 
         assert_eq!(paths.first(), Some(&python_root.join("lib")));

--- a/apps/desktop/src-tauri/src/mobile_backend/android.rs
+++ b/apps/desktop/src-tauri/src/mobile_backend/android.rs
@@ -1,6 +1,7 @@
 use super::*;
+use crate::mobile_ffmpeg::{render_audio, AudioOutputFormat};
 use crate::native_audio::decode::{
-    read_mobile_audio, read_resampled_mono_audio, write_mono_pcm_wav,
+    probe_mobile_durable_audio, read_mobile_audio, read_resampled_mono_audio, write_mono_pcm_wav,
 };
 use android_system_properties::AndroidSystemProperties;
 use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};

--- a/apps/desktop/src-tauri/src/mobile_backend/audio.rs
+++ b/apps/desktop/src-tauri/src/mobile_backend/audio.rs
@@ -9,6 +9,8 @@ struct MobileAudioFeatures {
     sample_rate: i64,
     channels: i64,
     pitch_classes: [f64; 12],
+    estimated_reference_hz: Option<f64>,
+    tuning_offset_cents: Option<f64>,
 }
 
 fn read_audio_features(path: &Path) -> Result<MobileAudioFeatures, String> {
@@ -30,12 +32,85 @@ fn read_audio_features(path: &Path) -> Result<MobileAudioFeatures, String> {
         .map(|sample| *sample as f64)
         .collect::<Vec<_>>();
 
+    let tuning_offset_cents = estimate_tuning_offset_cents(&samples, audio.sample_rate as f64);
     Ok(MobileAudioFeatures {
         duration_seconds: audio.samples.len() as f64 / audio.sample_rate as f64,
         sample_rate: audio.sample_rate as i64,
         channels: audio.channels as i64,
         pitch_classes: pitch_class_energy(&samples, audio.sample_rate as f64),
+        estimated_reference_hz: tuning_offset_cents
+            .map(|cents| 440.0 * 2.0_f64.powf(cents / 1200.0)),
+        tuning_offset_cents,
     })
+}
+
+fn estimate_tuning_offset_cents(samples: &[f64], sample_rate: f64) -> Option<f64> {
+    const WINDOW_SAMPLES: usize = 4096;
+    const WINDOW_COUNT: usize = 3;
+    const MIN_RMS: f64 = 1.0e-5;
+    const MIN_MIDI: i32 = 36;
+    const MAX_MIDI: i32 = 84;
+    const STEP_CENTS: i32 = 2;
+
+    if !sample_rate.is_finite() || sample_rate <= 0.0 || samples.len() < WINDOW_SAMPLES {
+        return None;
+    }
+    let mean_square =
+        samples.iter().map(|sample| sample * sample).sum::<f64>() / samples.len() as f64;
+    if !mean_square.is_finite() || mean_square.sqrt() < MIN_RMS {
+        return None;
+    }
+
+    let last_start = samples.len() - WINDOW_SAMPLES;
+    let starts = (0..WINDOW_COUNT)
+        .map(|index| index * last_start / (WINDOW_COUNT - 1))
+        .collect::<Vec<_>>();
+    let offsets = (-50..=50).step_by(STEP_CENTS as usize).collect::<Vec<_>>();
+    let mut scores = vec![0.0; offsets.len()];
+    for (offset_index, offset_cents) in offsets.iter().enumerate() {
+        for midi_note in MIN_MIDI..=MAX_MIDI {
+            let frequency = 440.0
+                * 2.0_f64
+                    .powf((f64::from(midi_note) - 69.0 + f64::from(*offset_cents) / 100.0) / 12.0);
+            if frequency >= sample_rate * 0.48 {
+                continue;
+            }
+            let coefficient = 2.0 * (2.0 * std::f64::consts::PI * frequency / sample_rate).cos();
+            for start in &starts {
+                let mut q1 = 0.0;
+                let mut q2 = 0.0;
+                for (index, sample) in samples[*start..*start + WINDOW_SAMPLES].iter().enumerate() {
+                    let phase =
+                        2.0 * std::f64::consts::PI * index as f64 / (WINDOW_SAMPLES - 1) as f64;
+                    let windowed = sample * (0.5 - 0.5 * phase.cos());
+                    let q0 = coefficient * q1 - q2 + windowed;
+                    q2 = q1;
+                    q1 = q0;
+                }
+                scores[offset_index] += (q1 * q1 + q2 * q2 - coefficient * q1 * q2).max(0.0);
+            }
+        }
+    }
+
+    let best_index = scores
+        .iter()
+        .enumerate()
+        .max_by(|left, right| left.1.total_cmp(right.1))?
+        .0;
+    if scores[best_index] <= 0.0 {
+        return None;
+    }
+    let mut cents = f64::from(offsets[best_index]);
+    if best_index > 0 && best_index + 1 < scores.len() {
+        let left = scores[best_index - 1].ln_1p();
+        let center = scores[best_index].ln_1p();
+        let right = scores[best_index + 1].ln_1p();
+        let denominator = left - 2.0 * center + right;
+        if denominator.abs() > f64::EPSILON {
+            cents += 0.5 * (left - right) / denominator * f64::from(STEP_CENTS);
+        }
+    }
+    cents.is_finite().then_some(cents.clamp(-50.0, 50.0))
 }
 
 fn install_playback_proxy(
@@ -362,8 +437,8 @@ fn store_analysis_result(
         "source_artifact_id": source_artifact.id,
         "estimated_key": estimated_key,
         "key_confidence": key_confidence,
-        "estimated_reference_hz": Value::Null,
-        "tuning_offset_cents": Value::Null,
+        "estimated_reference_hz": features.estimated_reference_hz,
+        "tuning_offset_cents": features.tuning_offset_cents,
         "tempo_bpm": Value::Null,
         "timing": Value::Null,
         "analysis_version": analysis_version,
@@ -385,13 +460,15 @@ fn store_analysis_result(
     connection
         .execute(
             "INSERT INTO analysis_results (project_id, source_artifact_id, estimated_key, key_confidence, estimated_reference_hz, tuning_offset_cents, tempo_bpm, timing_json, analysis_version, created_at)
-             VALUES (?1, ?2, ?3, ?4, NULL, NULL, NULL, NULL, ?5, ?6)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, NULL, NULL, ?7, ?8)
              ON CONFLICT(project_id) DO UPDATE SET source_artifact_id = excluded.source_artifact_id, estimated_key = excluded.estimated_key, key_confidence = excluded.key_confidence, estimated_reference_hz = excluded.estimated_reference_hz, tuning_offset_cents = excluded.tuning_offset_cents, tempo_bpm = excluded.tempo_bpm, timing_json = excluded.timing_json, analysis_version = excluded.analysis_version, created_at = excluded.created_at",
             params![
                 project.id,
                 source_artifact.id,
                 estimated_key,
                 key_confidence,
+                features.estimated_reference_hz,
+                features.tuning_offset_cents,
                 analysis_version,
                 timestamp,
             ],
@@ -574,6 +651,377 @@ fn empty_chords(project_id: String) -> ChordResponse {
     }
 }
 
+#[cfg(target_os = "android")]
+#[derive(Deserialize)]
+#[serde(rename_all = "snake_case")]
+struct MobileRetunePayload {
+    target_reference_hz: Option<f64>,
+    target_cents_offset: Option<f64>,
+    #[serde(default = "default_true")]
+    preview_only: bool,
+    #[serde(default = "default_wav_format")]
+    output_format: String,
+}
+
+#[cfg(target_os = "android")]
+#[derive(Deserialize)]
+#[serde(rename_all = "snake_case")]
+struct MobileTransposePayload {
+    semitones: i32,
+    #[serde(default = "default_true")]
+    preview_only: bool,
+    #[serde(default = "default_wav_format")]
+    output_format: String,
+}
+
+#[cfg(target_os = "android")]
+fn retune_cents(
+    payload: &MobileRetunePayload,
+    source_reference_hz: Option<f64>,
+) -> Result<f64, String> {
+    match (payload.target_reference_hz, payload.target_cents_offset) {
+        (Some(target), None) if target.is_finite() && target > 0.0 => {
+            let source = source_reference_hz
+                .filter(|value| value.is_finite() && *value > 0.0)
+                .ok_or_else(|| {
+                    "Analyze source tuning before retuning to a reference frequency.".to_string()
+                })?;
+            Ok(1200.0 * (target / source).log2())
+        }
+        (None, Some(cents)) if cents.is_finite() => Ok(cents),
+        _ => Err(
+            "Android retune requires exactly one finite target reference or cents offset."
+                .to_string(),
+        ),
+    }
+}
+
+#[cfg(target_os = "android")]
+fn stored_source_reference_hz(
+    connection: &Connection,
+    project_id: &str,
+    source_artifact_id: &str,
+) -> Result<Option<f64>, String> {
+    connection
+        .query_row(
+            "SELECT estimated_reference_hz FROM analysis_results WHERE project_id = ?1 AND source_artifact_id = ?2",
+            params![project_id, source_artifact_id],
+            |row| row.get(0),
+        )
+        .optional()
+        .map(|value| value.flatten())
+        .map_err(|error| error.to_string())
+}
+
+fn cache_source_reference_tuning(
+    connection: &Connection,
+    project_id: &str,
+    source_artifact_id: &str,
+    reference_hz: f64,
+    tuning_offset_cents: f64,
+) -> Result<(), String> {
+    let existing_source = connection
+        .query_row(
+            "SELECT source_artifact_id FROM analysis_results WHERE project_id = ?1",
+            params![project_id],
+            |row| row.get::<_, Option<String>>(0),
+        )
+        .optional()
+        .map_err(|error| error.to_string())?;
+    match existing_source {
+        Some(Some(existing)) if existing == source_artifact_id => {
+            connection.execute(
+                "UPDATE analysis_results SET estimated_reference_hz = ?1, tuning_offset_cents = ?2 WHERE project_id = ?3 AND source_artifact_id = ?4",
+                params![reference_hz, tuning_offset_cents, project_id, source_artifact_id],
+            )
+            .map_err(|error| error.to_string())?;
+        }
+        None => {
+            connection.execute(
+                "INSERT INTO analysis_results (project_id, source_artifact_id, estimated_reference_hz, tuning_offset_cents, analysis_version, created_at) VALUES (?1, ?2, ?3, ?4, 'mobile-tuning-v1', ?5)",
+                params![project_id, source_artifact_id, reference_hz, tuning_offset_cents, now_iso()],
+            )
+            .map_err(|error| error.to_string())?;
+        }
+        _ => {}
+    }
+    Ok(())
+}
+
+#[cfg(target_os = "android")]
+fn resolve_source_reference_hz(
+    connection: &Connection,
+    project: &ProjectSchema,
+    source: &ArtifactSchema,
+) -> Result<f64, String> {
+    if let Some(reference) = stored_source_reference_hz(connection, &project.id, &source.id)?
+        .filter(|value| value.is_finite() && *value > 0.0)
+    {
+        return Ok(reference);
+    }
+    let features = read_audio_features(Path::new(&project.imported_path))?;
+    let reference = features.estimated_reference_hz.ok_or_else(|| {
+        "Source tuning could not be established from the selected audio.".to_string()
+    })?;
+    cache_source_reference_tuning(
+        connection,
+        &project.id,
+        &source.id,
+        reference,
+        features.tuning_offset_cents.unwrap_or(0.0),
+    )?;
+    Ok(reference)
+}
+
+#[cfg(target_os = "android")]
+fn update_transform_job(
+    connection: &Connection,
+    job_id: &str,
+    status: &str,
+    progress: i64,
+    result_artifact_id: Option<&str>,
+    error: Option<&str>,
+    started: Instant,
+) -> Result<bool, String> {
+    let timestamp = now_iso();
+    let completed = matches!(status, "completed" | "failed" | "cancelled");
+    connection
+        .execute(
+            "UPDATE jobs SET status = ?1, progress = ?2, result_artifact_ids_json = ?3, error_message = ?4, completed_at = CASE WHEN ?5 THEN ?6 ELSE completed_at END, duration_seconds = CASE WHEN ?5 THEN ?7 ELSE duration_seconds END, updated_at = ?6 WHERE id = ?8 AND (cancel_requested = 0 OR ?1 = 'cancelled')",
+            params![
+                status,
+                progress,
+                result_artifact_id.map_or_else(|| json!([]), |id| json!([id])).to_string(),
+                error,
+                completed,
+                timestamp,
+                started.elapsed().as_secs_f64(),
+                job_id,
+            ],
+        )
+        .map(|updated| updated == 1)
+        .map_err(|error| error.to_string())
+}
+
+#[cfg(target_os = "android")]
+fn transform_cancel_requested(connection: &Connection, job_id: &str) -> Result<bool, String> {
+    connection
+        .query_row(
+            "SELECT cancel_requested != 0 OR status = 'cancelled' FROM jobs WHERE id = ?1",
+            params![job_id],
+            |row| row.get(0),
+        )
+        .map_err(|error| error.to_string())
+}
+
+#[cfg(target_os = "android")]
+struct MobileTransformPlan {
+    job_type: &'static str,
+    output_format: String,
+    pitch_cents: f64,
+    preview_only: bool,
+    metadata: Value,
+}
+
+#[cfg(target_os = "android")]
+fn run_transform_job(
+    root: PathBuf,
+    project_id: String,
+    source_path: PathBuf,
+    source_artifact_id: String,
+    job_id: String,
+    plan: MobileTransformPlan,
+) -> Result<(), String> {
+    let connection = db_at_root(&root)?;
+    let started = Instant::now();
+    let project_root = project_root_path(&root, &project_id)?;
+    let output_dir = project_root.join(if plan.preview_only {
+        "previews"
+    } else {
+        "exports"
+    });
+    let output_path = output_dir.join(format!("{}.{}", job_id, plan.output_format));
+    let temporary_path = output_dir.join(format!(".{}.{}", job_id, plan.output_format));
+    let temporary_path = prepare_owned_project_file(&root, &project_root, &temporary_path)?;
+    let format = AudioOutputFormat::parse(&plan.output_format)?;
+    let render_result = render_audio(
+        &source_path,
+        &temporary_path,
+        format,
+        plan.pitch_cents,
+        &mut || transform_cancel_requested(&connection, &job_id).unwrap_or(true),
+        &mut |progress| {
+            let _ = connection.execute(
+                "UPDATE jobs SET progress = ?1, updated_at = ?2 WHERE id = ?3 AND status = 'running' AND cancel_requested = 0",
+                params![i64::from(progress.clamp(5, 90)), now_iso(), job_id],
+            );
+        },
+    )
+    .and_then(|rendered| {
+        probe_mobile_durable_audio(&temporary_path, &plan.output_format).map(|()| rendered)
+    });
+    let rendered = match render_result {
+        Ok(rendered) => rendered,
+        Err(message) => {
+            let _ = fs::remove_file(&temporary_path);
+            let cancelled = transform_cancel_requested(&connection, &job_id)?;
+            let status = if cancelled { "cancelled" } else { "failed" };
+            let error = (!cancelled).then_some(message.as_str());
+            let _ = update_transform_job(&connection, &job_id, status, 0, None, error, started)?;
+            return Ok(());
+        }
+    };
+    let temporary = capture_owned_project_file(&root, &project_root, &temporary_path)?;
+
+    let storage_guard = project_storage_mutation_guard();
+    connection
+        .execute_batch("BEGIN IMMEDIATE")
+        .map_err(|error| error.to_string())?;
+    let mut published = None;
+    let publish = (|| -> Result<String, String> {
+        if transform_cancel_requested(&connection, &job_id)? {
+            return Err("TRANSFORM_CANCELLED".to_string());
+        }
+        let current_source: String = connection
+            .query_row(
+                "SELECT path FROM artifacts WHERE id = ?1 AND project_id = ?2 AND type = 'source_audio'",
+                params![source_artifact_id, project_id],
+                |row| row.get(0),
+            )
+            .map_err(|_| "Transform source is no longer owned by this project.".to_string())?;
+        if current_source != source_path.to_string_lossy() {
+            return Err("Transform source changed before publication.".to_string());
+        }
+        published = Some(move_owned_project_file(&temporary, &output_path)?);
+        let artifact_id = new_artifact_id()?;
+        let timestamp = now_iso();
+        let mut artifact_metadata = plan.metadata.clone();
+        artifact_metadata["output_sample_rate"] = json!(rendered.sample_rate);
+        artifact_metadata["output_channels"] = json!(rendered.channels);
+        connection
+            .execute(
+                "INSERT INTO artifacts (id, project_id, type, format, path, content_sha256, size_bytes, generated_by, can_delete, can_regenerate, metadata_json, cache_key, created_at) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, 'ffmpeg', 1, ?8, ?9, NULL, ?10)",
+                params![
+                    artifact_id,
+                    project_id,
+                    if plan.preview_only { "preview_mix" } else { "export_mix" },
+                    plan.output_format,
+                    output_path.to_string_lossy(),
+                    file_sha256(&output_path)?,
+                    fs::metadata(&output_path).map_err(|error| error.to_string())?.len() as i64,
+                    plan.preview_only,
+                    artifact_metadata.to_string(),
+                    timestamp,
+                ],
+            )
+            .map_err(|error| error.to_string())?;
+        if !update_transform_job(
+            &connection,
+            &job_id,
+            "completed",
+            100,
+            Some(&artifact_id),
+            None,
+            started,
+        )? {
+            return Err("TRANSFORM_CANCELLED".to_string());
+        }
+        Ok(artifact_id)
+    })();
+    let committed = match publish {
+        Ok(_artifact_id) => {
+            if let Err(error) = connection.execute_batch("COMMIT") {
+                let _ = connection.execute_batch("ROLLBACK");
+                if let Some(file) = published.as_ref() {
+                    cleanup_owned_project_files(std::slice::from_ref(file));
+                }
+                return Err(error.to_string());
+            }
+            true
+        }
+        Err(message) => {
+            let _ = connection.execute_batch("ROLLBACK");
+            if let Some(file) = published.as_ref() {
+                cleanup_owned_project_files(std::slice::from_ref(file));
+            }
+            cleanup_owned_project_files(std::slice::from_ref(&temporary));
+            let cancelled = message == "TRANSFORM_CANCELLED";
+            let _ = update_transform_job(
+                &connection,
+                &job_id,
+                if cancelled { "cancelled" } else { "failed" },
+                0,
+                None,
+                (!cancelled).then_some(message.as_str()),
+                started,
+            )?;
+            false
+        }
+    };
+    drop(storage_guard);
+    if committed {
+        reconcile_project_storage_after_commit(&connection, &root, &project_id);
+    }
+    Ok(())
+}
+
+#[cfg(target_os = "android")]
+fn submit_transform(
+    app: AppHandle,
+    project_id: String,
+    plan: MobileTransformPlan,
+) -> Result<JobResponse, String> {
+    let connection = db(&app)?;
+    let root = app_data_root(&app)?;
+    let project = require_sync_editable_project(&connection, &project_id)?;
+    let source = get_source_artifact(&connection, &project_id)?;
+    let _ = AudioOutputFormat::parse(&plan.output_format)?;
+    if !plan.pitch_cents.is_finite() || plan.pitch_cents.abs() > 4800.0 {
+        return Err(
+            "Android audio transform requires a finite shift within four octaves.".to_string(),
+        );
+    }
+    if plan.job_type == "preview" && plan.pitch_cents == 0.0 {
+        return Err("Android preview requires at least one non-zero transform.".to_string());
+    }
+    let job = create_running_job(
+        &connection,
+        &project_id,
+        plan.job_type,
+        Some(source.id.clone()),
+    )?;
+    let project_root = project_root_path(&root, &project_id)?;
+    let staging_dir = project_root.join(if plan.preview_only {
+        "previews"
+    } else {
+        "exports"
+    });
+    let staging_path = staging_dir.join(format!(".{}.{}", job.id, plan.output_format));
+    register_job_staging_path(&connection, &job.id, &staging_path)?;
+    let job_for_worker = job.clone();
+    thread::spawn(move || {
+        let failure_root = root.clone();
+        let failure_job_id = job_for_worker.id.clone();
+        if let Err(message) = run_transform_job(
+            root,
+            project_id,
+            PathBuf::from(project.imported_path),
+            source.id,
+            job_for_worker.id,
+            plan,
+        ) {
+            if let Ok(connection) = db_at_root(&failure_root) {
+                let timestamp = now_iso();
+                let _ = connection.execute(
+                    "UPDATE jobs SET status = 'failed', progress = 0, error_message = ?1, completed_at = ?2, updated_at = ?2 WHERE id = ?3 AND status IN ('pending', 'running')",
+                    params![message, timestamp, failure_job_id],
+                );
+            }
+        }
+    });
+    Ok(JobResponse { job })
+}
+
 pub fn mobile_submit_analyze(app: AppHandle, project_id: String) -> Result<JobResponse, String> {
     let connection = db(&app)?;
     let root = app_data_root(&app)?;
@@ -641,17 +1089,62 @@ pub fn mobile_submit_preview(
     project_id: String,
     payload: Value,
 ) -> Result<JobResponse, String> {
-    let _ = payload;
-    let connection = db(&app)?;
-    let _ = require_sync_editable_project(&connection, &project_id)?;
-    Ok(JobResponse {
-        job: create_failed_job(
-            &connection,
-            &project_id,
-            "preview",
-            "Android MediaCodec preview export is not wired yet.",
-        )?,
-    })
+    #[cfg(target_os = "android")]
+    {
+        let output_format = match payload.get("output_format") {
+            None => "wav".to_string(),
+            Some(Value::String(format)) => format.clone(),
+            Some(_) => return Err("Android preview output_format must be a string.".to_string()),
+        };
+        let mut cents = 0.0;
+        if let Some(retune) = payload.get("retune") {
+            let retune: MobileRetunePayload = serde_json::from_value(retune.clone())
+                .map_err(|_| "Android preview received an invalid retune selection.".to_string())?;
+            let source_reference = if retune.target_reference_hz.is_some() {
+                let connection = db(&app)?;
+                let project = require_sync_editable_project(&connection, &project_id)?;
+                let source = get_source_artifact(&connection, &project_id)?;
+                Some(resolve_source_reference_hz(&connection, &project, &source)?)
+            } else {
+                None
+            };
+            cents += retune_cents(&retune, source_reference)?;
+        }
+        if let Some(transpose) = payload.get("transpose") {
+            cents += transpose
+                .get("semitones")
+                .and_then(Value::as_i64)
+                .ok_or_else(|| {
+                    "Android preview received invalid transpose semitones.".to_string()
+                })? as f64
+                * 100.0;
+        }
+        return submit_transform(
+            app,
+            project_id,
+            MobileTransformPlan {
+                job_type: "preview",
+                output_format,
+                pitch_cents: cents,
+                preview_only: true,
+                metadata: payload,
+            },
+        );
+    }
+    #[cfg(not(target_os = "android"))]
+    {
+        let _ = payload;
+        let connection = db(&app)?;
+        let _ = require_sync_editable_project(&connection, &project_id)?;
+        Ok(JobResponse {
+            job: create_failed_job(
+                &connection,
+                &project_id,
+                "preview",
+                "Android FFmpeg preview is unavailable in host tests.",
+            )?,
+        })
+    }
 }
 
 pub fn mobile_submit_stems(
@@ -677,17 +1170,44 @@ pub fn mobile_submit_retune(
     project_id: String,
     payload: Value,
 ) -> Result<JobResponse, String> {
-    let _ = payload;
-    let connection = db(&app)?;
-    let _ = require_sync_editable_project(&connection, &project_id)?;
-    Ok(JobResponse {
-        job: create_failed_job(
-            &connection,
-            &project_id,
-            "retune",
-            "Android MediaCodec retune export is not wired yet.",
-        )?,
-    })
+    #[cfg(target_os = "android")]
+    {
+        let parsed: MobileRetunePayload = serde_json::from_value(payload.clone())
+            .map_err(|_| "Android retune received an invalid request.".to_string())?;
+        let connection = db(&app)?;
+        let project = require_sync_editable_project(&connection, &project_id)?;
+        let source = get_source_artifact(&connection, &project_id)?;
+        let source_reference_hz = parsed
+            .target_reference_hz
+            .map(|_| resolve_source_reference_hz(&connection, &project, &source))
+            .transpose()?;
+        drop(connection);
+        return submit_transform(
+            app,
+            project_id,
+            MobileTransformPlan {
+                job_type: "retune",
+                output_format: parsed.output_format.clone(),
+                pitch_cents: retune_cents(&parsed, source_reference_hz)?,
+                preview_only: parsed.preview_only,
+                metadata: payload,
+            },
+        );
+    }
+    #[cfg(not(target_os = "android"))]
+    {
+        let _ = payload;
+        let connection = db(&app)?;
+        let _ = require_sync_editable_project(&connection, &project_id)?;
+        Ok(JobResponse {
+            job: create_failed_job(
+                &connection,
+                &project_id,
+                "retune",
+                "Android FFmpeg retune is unavailable in host tests.",
+            )?,
+        })
+    }
 }
 
 pub fn mobile_submit_transpose(
@@ -695,15 +1215,149 @@ pub fn mobile_submit_transpose(
     project_id: String,
     payload: Value,
 ) -> Result<JobResponse, String> {
-    let _ = payload;
-    let connection = db(&app)?;
-    let _ = require_sync_editable_project(&connection, &project_id)?;
-    Ok(JobResponse {
-        job: create_failed_job(
-            &connection,
-            &project_id,
-            "transpose",
-            "Android MediaCodec transpose export is not wired yet.",
-        )?,
-    })
+    #[cfg(target_os = "android")]
+    {
+        let parsed: MobileTransposePayload = serde_json::from_value(payload.clone())
+            .map_err(|_| "Android transpose received an invalid request.".to_string())?;
+        return submit_transform(
+            app,
+            project_id,
+            MobileTransformPlan {
+                job_type: "transpose",
+                output_format: parsed.output_format.clone(),
+                pitch_cents: f64::from(parsed.semitones) * 100.0,
+                preview_only: parsed.preview_only,
+                metadata: payload,
+            },
+        );
+    }
+    #[cfg(not(target_os = "android"))]
+    {
+        let _ = payload;
+        let connection = db(&app)?;
+        let _ = require_sync_editable_project(&connection, &project_id)?;
+        Ok(JobResponse {
+            job: create_failed_job(
+                &connection,
+                &project_id,
+                "transpose",
+                "Android FFmpeg transpose is unavailable in host tests.",
+            )?,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tuning_tests {
+    use super::{cache_source_reference_tuning, estimate_tuning_offset_cents};
+    use crate::mobile_backend::{db_at_root, new_id, now_iso};
+    use rusqlite::params;
+    use std::fs;
+
+    fn sine(frequency: f64, sample_rate: usize) -> Vec<f64> {
+        (0..sample_rate * 2)
+            .map(|index| {
+                (2.0 * std::f64::consts::PI * frequency * index as f64 / sample_rate as f64).sin()
+                    * 0.5
+            })
+            .collect()
+    }
+
+    fn tuned_chord_with_percussion(reference_hz: f64, sample_rate: usize) -> Vec<f64> {
+        let tuning = reference_hz / 440.0;
+        let frequencies = [261.625_565, 329.627_557, 391.995_436];
+        let mut noise = 0x1234_5678_u32;
+        (0..sample_rate * 2)
+            .map(|index| {
+                noise = noise.wrapping_mul(1_664_525).wrapping_add(1_013_904_223);
+                let harmonic = frequencies
+                    .iter()
+                    .map(|frequency| {
+                        (2.0 * std::f64::consts::PI * frequency * tuning * index as f64
+                            / sample_rate as f64)
+                            .sin()
+                    })
+                    .sum::<f64>()
+                    * 0.16;
+                let click_phase = index % (sample_rate / 4);
+                let click = if click_phase < 64 {
+                    (1.0 - click_phase as f64 / 64.0) * 0.15
+                } else {
+                    0.0
+                };
+                let noise_sample = (f64::from(noise >> 8) / f64::from(1_u32 << 24) - 0.5) * 0.01;
+                harmonic + click + noise_sample
+            })
+            .collect()
+    }
+
+    #[test]
+    fn estimates_flat_reference_tuning() {
+        let cents = estimate_tuning_offset_cents(&sine(432.0, 22_050), 22_050.0).unwrap();
+        assert!((cents + 31.77).abs() < 3.0, "estimated {cents} cents");
+    }
+
+    #[test]
+    fn estimates_standard_reference_tuning() {
+        let cents = estimate_tuning_offset_cents(&sine(440.0, 22_050), 22_050.0).unwrap();
+        assert!(cents.abs() < 3.0, "estimated {cents} cents");
+    }
+
+    #[test]
+    fn rejects_silence_as_a_tuning_reference() {
+        assert!(estimate_tuning_offset_cents(&vec![0.0; 22_050], 22_050.0).is_none());
+    }
+
+    #[test]
+    fn estimates_polyphonic_reference_under_percussion_and_noise() {
+        let audio = tuned_chord_with_percussion(432.0, 22_050);
+        let cents = estimate_tuning_offset_cents(&audio, 22_050.0).unwrap();
+        assert!((cents + 31.77).abs() < 4.0, "estimated {cents} cents");
+    }
+
+    #[test]
+    fn tuning_cache_preserves_existing_analysis_fields_and_snapshot() {
+        let root = std::env::temp_dir().join(format!("tuneforge-tuning-cache-{}", new_id("test")));
+        fs::create_dir_all(root.join("projects/project/analysis")).unwrap();
+        let analysis_path = root.join("projects/project/analysis/analysis.json");
+        fs::write(
+            &analysis_path,
+            br#"{"tempo_bpm":123,"estimated_key":"D major"}"#,
+        )
+        .unwrap();
+        let connection = db_at_root(&root).unwrap();
+        let timestamp = now_iso();
+        connection.execute(
+            "INSERT INTO projects (id, display_name, source_path, imported_path, sync_status, created_at, updated_at) VALUES ('project', 'Test', 'source.wav', 'source.wav', 'local', ?1, ?1)",
+            params![timestamp],
+        ).unwrap();
+        connection.execute(
+            "INSERT INTO artifacts (id, project_id, type, format, path, size_bytes, generated_by, can_delete, can_regenerate, metadata_json, created_at) VALUES ('source', 'project', 'source_audio', 'wav', 'source.wav', 1, 'import', 0, 0, '{}', ?1)",
+            params![timestamp],
+        ).unwrap();
+        connection.execute(
+            "INSERT INTO analysis_results (project_id, source_artifact_id, estimated_key, key_confidence, tempo_bpm, timing_json, analysis_version, created_at) VALUES ('project', 'source', 'D major', 0.8, 123.0, '{\"beats\":[1]}', 'desktop-v4', ?1)",
+            params![timestamp],
+        ).unwrap();
+
+        cache_source_reference_tuning(&connection, "project", "source", 432.0, -31.77).unwrap();
+        let row = connection.query_row(
+            "SELECT source_artifact_id, estimated_key, key_confidence, estimated_reference_hz, tuning_offset_cents, tempo_bpm, timing_json, analysis_version FROM analysis_results WHERE project_id = 'project'",
+            [],
+            |row| Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?, row.get::<_, f64>(2)?, row.get::<_, f64>(3)?, row.get::<_, f64>(4)?, row.get::<_, f64>(5)?, row.get::<_, String>(6)?, row.get::<_, String>(7)?)),
+        ).unwrap();
+        assert_eq!(row.0, "source");
+        assert_eq!(row.1, "D major");
+        assert_eq!(row.2, 0.8);
+        assert_eq!(row.3, 432.0);
+        assert_eq!(row.4, -31.77);
+        assert_eq!(row.5, 123.0);
+        assert_eq!(row.6, "{\"beats\":[1]}");
+        assert_eq!(row.7, "desktop-v4");
+        assert_eq!(
+            fs::read(&analysis_path).unwrap(),
+            br#"{"tempo_bpm":123,"estimated_key":"D major"}"#
+        );
+        let _ = fs::remove_dir_all(root);
+    }
 }

--- a/apps/desktop/src-tauri/src/mobile_backend/export.rs
+++ b/apps/desktop/src-tauri/src/mobile_backend/export.rs
@@ -1,3 +1,8 @@
+#[cfg(target_os = "android")]
+use super::storage_cleanup::{
+    capture_owned_project_file, cleanup_owned_project_files, prepare_owned_project_file,
+    OwnedProjectFile,
+};
 use super::*;
 use serde::Deserialize;
 use serde_json::{json, Value};
@@ -269,10 +274,11 @@ fn parse_request(payload: Value) -> Result<MobileExportRequest, String> {
     if request.artifact_ids.len() > 1 || request.generated_document_ids.len() > 1 {
         return Err("Android export supports only one deliverable at a time.".to_string());
     }
-    if request.output_format != "wav" {
-        return Err(
-            "Android audio export supports WAV only and does not re-encode files.".to_string(),
-        );
+    if !matches!(
+        request.output_format.as_str(),
+        "wav" | "flac" | "mp3" | "m4a"
+    ) {
+        return Err("Android audio export requires WAV, FLAC, MP3, or M4A.".to_string());
     }
     if request
         .generated_document_ids
@@ -358,16 +364,13 @@ fn snapshot_export(
                 "Only project tracks, practice mixes, and stems can be exported.".to_string(),
             );
         }
-        if !artifact.format.eq_ignore_ascii_case("wav") {
-            return Err("Android can export only a locally stored WAV file.".to_string());
-        }
         let path = canonical_project_file(root, project_id, &artifact.path)?;
         if fs::metadata(&path)
             .map_err(|_| "Selected project audio is missing or unreadable.".to_string())?
             .len()
             == 0
         {
-            return Err("TuneForge refused to export an empty WAV file.".to_string());
+            return Err("TuneForge refused to export an empty audio file.".to_string());
         }
         let context = if artifact.r#type == "source_audio" {
             "Source".to_string()
@@ -376,13 +379,20 @@ fn snapshot_export(
         } else {
             stem_export_context(connection, project_id, &artifact)?
         };
+        let (extension, filter_name, format) = match request.output_format.as_str() {
+            "wav" => ("wav", "WAV Audio", "wav"),
+            "flac" => ("flac", "FLAC Audio", "flac"),
+            "mp3" => ("mp3", "MP3 Audio", "mp3"),
+            "m4a" => ("m4a", "M4A Audio", "m4a"),
+            _ => unreachable!("validated output format"),
+        };
         return Ok(ExportSnapshot {
             source_artifact_id: Some(artifact.id),
             generated_document_id: None,
-            output_name: format!("{filename_base} - {context}.wav"),
-            extension: "wav",
-            filter_name: "WAV Audio",
-            format: "wav",
+            output_name: format!("{filename_base} - {context}.{extension}"),
+            extension,
+            filter_name,
+            format,
             content: ExportContent::File(path),
         });
     }
@@ -1091,12 +1101,18 @@ fn update_export_job(
     completed: bool,
 ) -> Result<(), String> {
     let timestamp = now_iso();
-    let payload = json!({
-        "stage": stage,
-        "stage_label": stage_label,
-        "runtime_detail": runtime_detail,
-        "export_result": result,
-    });
+    let payload_raw = connection
+        .query_row(
+            "SELECT payload_json FROM jobs WHERE id = ?1",
+            params![job_id],
+            |row| row.get::<_, String>(0),
+        )
+        .map_err(|error| error.to_string())?;
+    let mut payload = serde_json::from_str::<Value>(&payload_raw).unwrap_or_else(|_| json!({}));
+    payload["stage"] = json!(stage);
+    payload["stage_label"] = json!(stage_label);
+    payload["runtime_detail"] = json!(runtime_detail);
+    payload["export_result"] = result;
     connection
         .execute(
             "UPDATE jobs SET status = ?1, progress = ?2, payload_json = ?3, error_message = ?4, completed_at = CASE WHEN ?5 THEN ?6 ELSE completed_at END, updated_at = ?6 WHERE id = ?7 AND status IN ('pending', 'running') AND cancel_requested = 0",
@@ -1425,6 +1441,104 @@ fn run_export_worker(
     }
 }
 
+#[cfg(target_os = "android")]
+fn export_source_still_owned(
+    connection: &Connection,
+    root: &Path,
+    project_id: &str,
+    artifact_id: &str,
+    expected_path: &Path,
+) -> Result<bool, String> {
+    let stored_path = connection
+        .query_row(
+            "SELECT path FROM artifacts WHERE id = ?1 AND project_id = ?2",
+            params![artifact_id, project_id],
+            |row| row.get::<_, String>(0),
+        )
+        .optional()
+        .map_err(|error| error.to_string())?;
+    let Some(stored_path) = stored_path else {
+        return Ok(false);
+    };
+    canonical_project_file(root, project_id, &stored_path)
+        .map(|path| path == expected_path)
+        .or(Ok(false))
+}
+
+#[cfg(target_os = "android")]
+fn materialize_audio_export(
+    connection: &Connection,
+    root: &Path,
+    project_id: &str,
+    snapshot: &mut ExportSnapshot,
+    job_id: &str,
+) -> Result<Option<OwnedProjectFile>, String> {
+    let Some(source_artifact_id) = snapshot.source_artifact_id.clone() else {
+        return Ok(None);
+    };
+    let source_path = match &snapshot.content {
+        ExportContent::File(path) => path.clone(),
+        ExportContent::Memory(_) => return Err("Audio export source was not a file.".to_string()),
+    };
+    if !export_source_still_owned(
+        connection,
+        root,
+        project_id,
+        &source_artifact_id,
+        &source_path,
+    )? {
+        return Err("Export source changed before conversion.".to_string());
+    }
+    let project_root = project_root_path(root, project_id)?;
+    let temporary_path = project_root
+        .join("export-staging")
+        .join(format!(".{job_id}.{}", snapshot.extension));
+    let temporary_path = prepare_owned_project_file(root, &project_root, &temporary_path)?;
+    let format = AudioOutputFormat::parse(snapshot.format)?;
+    let result = render_audio(
+        &source_path,
+        &temporary_path,
+        format,
+        0.0,
+        &mut || export_cancel_requested(connection, job_id).unwrap_or(true),
+        &mut |progress| {
+            let mapped = 5 + i64::from(progress.clamp(0, 100)) / 4;
+            let _ = connection.execute(
+                "UPDATE jobs SET progress = ?1, updated_at = ?2 WHERE id = ?3 AND status = 'running' AND cancel_requested = 0",
+                params![mapped, now_iso(), job_id],
+            );
+        },
+    )
+    .and_then(|_| probe_mobile_durable_audio(&temporary_path, snapshot.format));
+    if let Err(message) = result {
+        let _ = fs::remove_file(&temporary_path);
+        if export_cancel_requested(connection, job_id)? {
+            return Err("EXPORT_CANCELLED".to_string());
+        }
+        return Err(message);
+    }
+    if export_cancel_requested(connection, job_id)?
+        || !export_source_still_owned(
+            connection,
+            root,
+            project_id,
+            &source_artifact_id,
+            &source_path,
+        )?
+    {
+        let _ = fs::remove_file(&temporary_path);
+        return if export_cancel_requested(connection, job_id)? {
+            Err("EXPORT_CANCELLED".to_string())
+        } else {
+            Err("Export source changed before delivery.".to_string())
+        };
+    }
+    let temporary = capture_owned_project_file(root, &project_root, &temporary_path)?;
+    snapshot.content = ExportContent::File(temporary.path.clone());
+    Ok(Some(temporary))
+}
+
+#[cfg(test)]
 fn submit_export_with_provider(
     connection: &Connection,
     root: &Path,
@@ -1444,11 +1558,32 @@ pub fn mobile_submit_export(
 ) -> Result<JobResponse, String> {
     let connection = db(&app)?;
     let root = app_data_root(&app)?;
-    let (snapshot, job) = prepare_export(&connection, &root, &project_id, payload)?;
+    let (mut snapshot, job) = prepare_export(&connection, &root, &project_id, payload)?;
+    if snapshot.source_artifact_id.is_some() {
+        let staging_path = project_root_path(&root, &project_id)?
+            .join("export-staging")
+            .join(format!(".{}.{}", job.id, snapshot.extension));
+        register_job_staging_path(&connection, &job.id, &staging_path)?;
+    }
     let job_id = job.id.clone();
     thread::spawn(move || {
         let provider = AndroidExportProvider { app: &app };
-        let _ = run_export_worker(&connection, &project_id, &snapshot, &job_id, &provider);
+        let materialized =
+            materialize_audio_export(&connection, &root, &project_id, &mut snapshot, &job_id);
+        match materialized {
+            Ok(temporary) => {
+                let _ = run_export_worker(&connection, &project_id, &snapshot, &job_id, &provider);
+                if let Some(temporary) = temporary.as_ref() {
+                    cleanup_owned_project_files(std::slice::from_ref(temporary));
+                }
+            }
+            Err(message) if message == "EXPORT_CANCELLED" => {
+                let _ = cancel_export_job(&connection, &job_id, &snapshot);
+            }
+            Err(message) => {
+                let _ = fail_export_job(&connection, &job_id, &snapshot, &message);
+            }
+        }
     });
     Ok(JobResponse { job })
 }
@@ -1637,7 +1772,7 @@ mod tests {
     }
 
     #[test]
-    fn request_rejects_destinations_multiple_items_and_non_wav_audio() {
+    fn request_rejects_destinations_and_multiple_items_but_accepts_all_audio_formats() {
         assert!(parse_request(json!({
             "artifact_ids": ["art"],
             "output_format": "wav",
@@ -1665,7 +1800,7 @@ mod tests {
             "artifact_ids": ["art"],
             "output_format": "m4a"
         }))
-        .is_err());
+        .is_ok());
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/mobile_backend/mod.rs
+++ b/apps/desktop/src-tauri/src/mobile_backend/mod.rs
@@ -58,10 +58,11 @@ use self::storage::{
     app_data_root, create_completed_job, create_failed_job, create_running_job, db, db_at_root,
     file_sha256, find_existing_project_source, get_project_manifest, get_project_schema,
     get_source_artifact, get_staged_artifact, migrate_mobile_db, new_id, project_cleanup_root_path,
-    project_root_path, relative_artifact_path, require_sync_editable_project, row_artifact,
-    row_delete_tombstone, row_entity_revision, row_job, row_project, safe_relative_path,
-    source_format, verify_staged_artifact, ARTIFACT_COLUMNS, JOB_COLUMNS, PROJECT_COLUMNS,
-    SYNC_DELETE_TOMBSTONE_COLUMNS, SYNC_ENTITY_REVISION_COLUMNS,
+    project_root_path, register_job_staging_path, relative_artifact_path,
+    require_sync_editable_project, row_artifact, row_delete_tombstone, row_entity_revision,
+    row_job, row_project, safe_relative_path, source_format, verify_staged_artifact,
+    ARTIFACT_COLUMNS, JOB_COLUMNS, PROJECT_COLUMNS, SYNC_DELETE_TOMBSTONE_COLUMNS,
+    SYNC_ENTITY_REVISION_COLUMNS,
 };
 
 #[cfg(all(test, not(target_os = "android")))]

--- a/apps/desktop/src-tauri/src/mobile_backend/schemas.rs
+++ b/apps/desktop/src-tauri/src/mobile_backend/schemas.rs
@@ -206,9 +206,15 @@ pub struct LyricsResponse {
 #[cfg_attr(not(target_os = "android"), allow(dead_code))]
 pub struct ProjectImportRequest {
     source_path: String,
-    #[serde(default = "default_true")]
-    copy_into_project: bool,
+    #[serde(default = "default_true", rename = "copy_into_project")]
+    _copy_into_project: bool,
     display_name: Option<String>,
+    #[serde(default = "default_wav_format")]
+    output_format: String,
+}
+
+fn default_wav_format() -> String {
+    "wav".to_string()
 }
 
 #[derive(Deserialize)]
@@ -735,6 +741,6 @@ mod tests {
         let request: ProjectImportRequest =
             serde_json::from_str(r#"{"source_path":"/music/song.wav"}"#).unwrap();
 
-        assert!(request.copy_into_project);
+        assert!(request._copy_into_project);
     }
 }

--- a/apps/desktop/src-tauri/src/mobile_backend/storage.rs
+++ b/apps/desktop/src-tauri/src/mobile_backend/storage.rs
@@ -365,15 +365,12 @@ pub(super) fn db_at_root(root: &Path) -> Result<Connection, String> {
     let connection =
         Connection::open(root.join("mobile.sqlite3")).map_err(|error| error.to_string())?;
     migrate_mobile_db(&connection)?;
-    mark_interrupted_exports_on_first_open(root, &connection)?;
+    mark_interrupted_jobs_on_first_open(root, &connection)?;
     ensure_local_identity(&connection)?;
     Ok(connection)
 }
 
-fn mark_interrupted_exports_on_first_open(
-    root: &Path,
-    connection: &Connection,
-) -> Result<(), String> {
+fn mark_interrupted_jobs_on_first_open(root: &Path, connection: &Connection) -> Result<(), String> {
     use std::sync::{Mutex, OnceLock};
 
     static OPENED_DATABASES: OnceLock<Mutex<HashSet<PathBuf>>> = OnceLock::new();
@@ -383,8 +380,33 @@ fn mark_interrupted_exports_on_first_open(
         .lock()
         .map_err(|_| "Mobile database open-state lock was poisoned.".to_string())?;
     if opened.insert(database_path) {
+        let mut statement = connection
+            .prepare(
+                "SELECT DISTINCT project_id FROM jobs WHERE project_id IS NOT NULL AND status IN ('pending', 'running') AND type IN ('export', 'preview', 'retune', 'transpose')",
+            )
+            .map_err(|error| error.to_string())?;
+        let project_ids = statement
+            .query_map([], |row| row.get::<_, String>(0))
+            .map_err(|error| error.to_string())?
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|error| error.to_string())?;
         super::export::fail_interrupted_exports(connection)?;
+        fail_interrupted_audio_transforms(connection)?;
+        for project_id in project_ids {
+            reconcile_project_storage_after_commit(connection, root, &project_id);
+        }
     }
+    Ok(())
+}
+
+fn fail_interrupted_audio_transforms(connection: &Connection) -> Result<(), String> {
+    let timestamp = now_iso();
+    connection
+        .execute(
+            "UPDATE jobs SET status = 'failed', progress = 0, error_message = 'Audio conversion was interrupted when TuneForge restarted. Retry the operation.', completed_at = ?1, updated_at = ?1 WHERE status IN ('pending', 'running') AND type IN ('preview', 'retune', 'transpose')",
+            params![timestamp],
+        )
+        .map_err(|error| error.to_string())?;
     Ok(())
 }
 
@@ -937,6 +959,30 @@ pub(super) fn create_running_job(
         )
         .map_err(|error| error.to_string())?;
     Ok(job)
+}
+
+pub(super) fn register_job_staging_path(
+    connection: &Connection,
+    job_id: &str,
+    staging_path: &Path,
+) -> Result<(), String> {
+    let _storage_guard = super::storage_cleanup::project_storage_mutation_guard();
+    let payload_raw = connection
+        .query_row(
+            "SELECT payload_json FROM jobs WHERE id = ?1 AND status IN ('pending', 'running')",
+            params![job_id],
+            |row| row.get::<_, String>(0),
+        )
+        .map_err(|error| error.to_string())?;
+    let mut payload = serde_json::from_str::<Value>(&payload_raw).unwrap_or_else(|_| json!({}));
+    payload["staging_path"] = json!(staging_path.to_string_lossy());
+    connection
+        .execute(
+            "UPDATE jobs SET payload_json = ?1, updated_at = ?2 WHERE id = ?3 AND status IN ('pending', 'running')",
+            params![payload.to_string(), now_iso(), job_id],
+        )
+        .map_err(|error| error.to_string())?;
+    Ok(())
 }
 
 pub(super) fn update_job_progress(
@@ -1717,7 +1763,8 @@ pub fn mobile_import_project(
     }
 
     let source_file_name = source_filename(&app, &payload.source_path);
-    let needs_copy = payload.copy_into_project || source_is_uri;
+    let output_extension = payload.output_format.clone();
+    let needs_copy = true;
     let temporary_import_path = if needs_copy {
         let temp_dir = root.join("sync").join("imports").join(new_id("import"));
         fs::create_dir_all(&temp_dir).map_err(|error| error.to_string())?;
@@ -1752,20 +1799,30 @@ pub fn mobile_import_project(
     let project_root = project_root_path(&root, &project_id)?;
     let source_dir = project_root.join("source");
     fs::create_dir_all(&source_dir).map_err(|error| error.to_string())?;
-    let imported_path = if let Some(temp_path) = temporary_import_path {
-        let target = source_dir.join(&source_file_name);
-        fs::rename(&temp_path, &target)
-            .or_else(|_| {
-                fs::copy(&temp_path, &target)?;
-                fs::remove_file(&temp_path)
-            })
-            .map_err(|error| error.to_string())?;
+    let conversion_source = temporary_import_path.as_ref().unwrap_or(&source);
+    let staged_import = source_dir.join(format!(".{}.{}", new_id("import"), output_extension));
+    let imported_path = source_dir.join(format!("imported.{output_extension}"));
+    let conversion_result =
+        convert_mobile_import(conversion_source, &staged_import, &output_extension).and_then(
+            |rendered| {
+                fs::rename(&staged_import, &imported_path)
+                    .map(|()| rendered)
+                    .map_err(|error| error.to_string())
+            },
+        );
+    if let Some(temp_path) = temporary_import_path {
         if let Some(parent) = temp_path.parent() {
             let _ = fs::remove_dir_all(parent);
         }
-        target
-    } else {
-        source.clone()
+    }
+    let rendered = match conversion_result {
+        Ok(rendered) => rendered,
+        Err(message) => {
+            let _ = fs::remove_file(&staged_import);
+            return Err(format!(
+                "Android could not create durable {output_extension} audio: {message}"
+            ));
+        }
     };
     let timestamp = now_iso();
     let display_name = payload
@@ -1779,9 +1836,9 @@ pub fn mobile_import_project(
         source_sha256: Some(source_sha256.clone()),
         source_path: payload.source_path.clone(),
         imported_path: imported_path.to_string_lossy().into_owned(),
-        duration_seconds: None,
-        sample_rate: None,
-        channels: None,
+        duration_seconds: Some(rendered.duration_seconds),
+        sample_rate: Some(i64::from(rendered.sample_rate)),
+        channels: Some(i64::from(rendered.channels)),
         sync_status: DEFAULT_SYNC_STATUS.to_string(),
         sync_status_reason: None,
         sync_editable: true,
@@ -1791,9 +1848,19 @@ pub fn mobile_import_project(
         created_at: timestamp.clone(),
         updated_at: timestamp.clone(),
     };
-    if upgrading_placeholder {
-        connection
-            .execute(
+    let size_bytes = fs::metadata(&imported_path)
+        .map_err(|error| error.to_string())?
+        .len() as i64;
+    let imported_sha256 = file_sha256(&imported_path)?;
+    let source_artifact_id = new_artifact_id()?;
+    let artifact_metadata = json!({ "source_path": payload.source_path });
+
+    connection
+        .execute_batch("BEGIN IMMEDIATE")
+        .map_err(|error| error.to_string())?;
+    let persist_result = (|| -> Result<(), String> {
+        if upgrading_placeholder {
+            connection.execute(
                 "UPDATE projects SET display_name = ?1, source_key_override = ?2, source_sha256 = ?3, source_path = ?4, imported_path = ?5, duration_seconds = ?6, sample_rate = ?7, channels = ?8, sync_status = 'local', sync_status_reason = NULL, sync_required_artifact_ids_json = ?9, sync_provider_device_ids_json = ?9, sync_conflict_count = 0, sync_status_updated_at = ?10, updated_at = ?10 WHERE id = ?11",
                 params![
                     project.display_name,
@@ -1810,9 +1877,8 @@ pub fn mobile_import_project(
                 ],
             )
             .map_err(|error| error.to_string())?;
-    } else {
-        connection
-            .execute(
+        } else {
+            connection.execute(
                 "INSERT INTO projects (id, display_name, source_key_override, source_sha256, source_path, imported_path, duration_seconds, sample_rate, channels, sync_status, sync_status_reason, sync_required_artifact_ids_json, sync_provider_device_ids_json, sync_conflict_count, sync_status_updated_at, created_at, updated_at)
                  VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17)",
                 params![
@@ -1836,35 +1902,86 @@ pub fn mobile_import_project(
                 ],
             )
             .map_err(|error| error.to_string())?;
-    }
+        }
 
-    let size_bytes = fs::metadata(&imported_path)
-        .map(|metadata| metadata.len() as i64)
-        .unwrap_or(0);
-    let source_artifact_id = new_artifact_id()?;
-    let artifact_metadata = json!({ "source_path": payload.source_path });
-
-    connection
-        .execute(
+        connection.execute(
             "INSERT INTO artifacts (id, project_id, type, format, path, content_sha256, size_bytes, generated_by, can_delete, can_regenerate, metadata_json, cache_key, created_at)
              VALUES (?1, ?2, 'source_audio', ?3, ?4, ?5, ?6, 'import', 0, 0, ?7, NULL, ?8)",
             params![
                 &source_artifact_id,
                 &project_id,
-                source_format(&imported_path),
+                &output_extension,
                 imported_path.to_string_lossy().into_owned(),
-                source_sha256,
+                imported_sha256,
                 size_bytes,
                 artifact_metadata.to_string(),
                 timestamp,
             ],
         )
         .map_err(|error| error.to_string())?;
+        Ok(())
+    })();
+    if let Err(message) = persist_result {
+        let _ = connection.execute_batch("ROLLBACK");
+        let _ = fs::remove_file(&imported_path);
+        return Err(message);
+    }
+    if let Err(error) = connection.execute_batch("COMMIT") {
+        let _ = connection.execute_batch("ROLLBACK");
+        let _ = fs::remove_file(&imported_path);
+        return Err(error.to_string());
+    }
 
     reconcile_project_storage_after_commit(&connection, &root, &project_id);
     spawn_playback_proxy_generation(root, project_root, imported_path, source_artifact_id);
 
     Ok(ProjectResponse { project })
+}
+
+struct ImportAudioProperties {
+    duration_seconds: f64,
+    sample_rate: u32,
+    channels: u32,
+}
+
+#[cfg(target_os = "android")]
+fn convert_mobile_import(
+    source: &Path,
+    destination: &Path,
+    format: &str,
+) -> Result<ImportAudioProperties, String> {
+    let output_format = AudioOutputFormat::parse(format)?;
+    let rendered = render_audio(
+        source,
+        destination,
+        output_format,
+        0.0,
+        &mut || false,
+        &mut |_| {},
+    )?;
+    probe_mobile_durable_audio(destination, format).map(|()| ImportAudioProperties {
+        duration_seconds: rendered.duration_seconds,
+        sample_rate: rendered.sample_rate,
+        channels: rendered.channels,
+    })
+}
+
+#[cfg(all(test, not(target_os = "android")))]
+fn convert_mobile_import(
+    source: &Path,
+    destination: &Path,
+    format: &str,
+) -> Result<ImportAudioProperties, String> {
+    if format != "wav" {
+        return Err("Owned Android FFmpeg conversion is unavailable in host tests.".to_string());
+    }
+    let decoded = read_mobile_audio(source)?;
+    fs::copy(source, destination).map_err(|error| error.to_string())?;
+    Ok(ImportAudioProperties {
+        duration_seconds: decoded.samples.len() as f64 / decoded.sample_rate as f64,
+        sample_rate: decoded.sample_rate,
+        channels: decoded.channels,
+    })
 }
 
 pub fn mobile_get_project(app: AppHandle, project_id: String) -> Result<ProjectResponse, String> {
@@ -2211,6 +2328,86 @@ mod mobile_media_tests {
 
     const ARTIFACT_ID: &str = "art_0123456789ab";
     const MANIFEST_ARTIFACT_ID: &str = "manifest/source v1";
+
+    #[test]
+    fn mobile_import_conversion_reports_audio_duration() {
+        let root = std::env::temp_dir().join(format!(
+            "tuneforge-mobile-import-duration-{}",
+            new_id("test")
+        ));
+        fs::create_dir_all(&root).unwrap();
+        let source = root.join("source.wav");
+        let destination = root.join("imported.wav");
+        let sample_rate = 48_000;
+        let duration_seconds = 24;
+        write_mono_pcm_wav(
+            &source,
+            &crate::native_audio::decode::DecodedAudio {
+                samples: vec![0.0; sample_rate as usize * duration_seconds],
+                sample_rate,
+                channels: 1,
+            },
+        )
+        .unwrap();
+
+        let properties = convert_mobile_import(&source, &destination, "wav").unwrap();
+
+        assert_eq!(properties.duration_seconds, duration_seconds as f64);
+        assert_eq!(properties.sample_rate, sample_rate);
+        assert_eq!(properties.channels, 1);
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn restart_recovery_fails_transform_jobs_and_reconciles_staging() {
+        let root = std::env::temp_dir().join(format!(
+            "tuneforge-mobile-transform-restart-{}",
+            new_id("test")
+        ));
+        fs::create_dir_all(&root).unwrap();
+        let connection = db_at_root(&root).unwrap();
+        let project_id = source_hash_to_project_id(&"f".repeat(64)).unwrap();
+        let project_root = project_root_path(&root, &project_id).unwrap();
+        let source = project_root.join("source/source.wav");
+        let staging = project_root.join("previews/.interrupted.wav");
+        fs::create_dir_all(source.parent().unwrap()).unwrap();
+        fs::create_dir_all(staging.parent().unwrap()).unwrap();
+        fs::write(&source, b"source").unwrap();
+        fs::write(&staging, b"partial").unwrap();
+        let timestamp = now_iso();
+        connection.execute(
+            "INSERT INTO projects (id, display_name, source_path, imported_path, sync_status, created_at, updated_at) VALUES (?1, 'Restart', ?2, ?2, 'local', ?3, ?3)",
+            params![project_id, source.to_string_lossy(), timestamp],
+        ).unwrap();
+        connection.execute(
+            "INSERT INTO artifacts (id, project_id, type, format, path, size_bytes, generated_by, can_delete, can_regenerate, metadata_json, created_at) VALUES ('source-restart', ?1, 'source_audio', 'wav', ?2, 6, 'import', 0, 0, '{}', ?3)",
+            params![project_id, source.to_string_lossy(), timestamp],
+        ).unwrap();
+        let job = create_running_job(
+            &connection,
+            &project_id,
+            "preview",
+            Some("source-restart".to_string()),
+        )
+        .unwrap();
+        register_job_staging_path(&connection, &job.id, &staging).unwrap();
+        reconcile_project_storage_after_commit(&connection, &root, &project_id);
+        assert!(staging.exists());
+
+        fail_interrupted_audio_transforms(&connection).unwrap();
+        reconcile_project_storage_after_commit(&connection, &root, &project_id);
+        let status: String = connection
+            .query_row(
+                "SELECT status FROM jobs WHERE id = ?1",
+                params![job.id],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(status, "failed");
+        assert!(!staging.exists());
+        assert!(source.exists());
+        let _ = fs::remove_dir_all(root);
+    }
 
     #[test]
     fn media_resolution_rejects_invalid_stale_unauthorized_and_changed_artifacts() {

--- a/apps/desktop/src-tauri/src/mobile_backend/storage_cleanup.rs
+++ b/apps/desktop/src-tauri/src/mobile_backend/storage_cleanup.rs
@@ -38,7 +38,7 @@ struct ProjectStoragePlan {
 pub(super) struct OwnedProjectFile {
     data_root: PathBuf,
     project_root: PathBuf,
-    path: PathBuf,
+    pub(super) path: PathBuf,
     identity: EntryIdentity,
 }
 
@@ -193,6 +193,10 @@ pub(super) fn reconcile_project_storage(
     project_id: &str,
 ) -> Result<(), String> {
     let plan = build_project_storage_plan(connection, root, project_id)?;
+    apply_project_storage_plan(plan)
+}
+
+fn apply_project_storage_plan(plan: ProjectStoragePlan) -> Result<(), String> {
     let Some(projects_identity) = validate_storage_roots(&plan)? else {
         return Ok(());
     };
@@ -294,6 +298,24 @@ fn build_project_storage_plan(
             "Mobile artifact storage metadata is unreadable; cleanup deferred.".to_string()
         })?;
         protect_metadata_paths(&mut protected_paths, &project_root, &metadata)?;
+    }
+
+    let mut jobs = connection
+        .prepare(
+            "SELECT payload_json FROM jobs WHERE project_id = ?1 AND status IN ('pending', 'running')",
+        )
+        .map_err(|error| error.to_string())?;
+    let job_rows = jobs
+        .query_map(params![project_id], |row| row.get::<_, String>(0))
+        .map_err(|error| error.to_string())?;
+    for row in job_rows {
+        let payload = serde_json::from_str::<Value>(&row.map_err(|error| error.to_string())?)
+            .map_err(|_| {
+                "Mobile job storage metadata is unreadable; cleanup deferred.".to_string()
+            })?;
+        if let Some(staging_path) = payload.get("staging_path").and_then(Value::as_str) {
+            protect_owned_path(&mut protected_paths, &project_root, Path::new(staging_path))?;
+        }
     }
 
     if !delete_project_root {
@@ -537,6 +559,8 @@ pub(super) fn lexical_absolute(path: &Path) -> Result<PathBuf, String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::mpsc;
+    use std::time::Duration;
 
     struct TestRoot {
         parent: PathBuf,
@@ -799,5 +823,157 @@ mod tests {
         connection.execute_batch("COMMIT").unwrap();
         reconcile_project_storage_after_commit(&connection, &temp.data, &delete_id);
         assert!(!delete_root.exists());
+    }
+
+    #[test]
+    fn reconciliation_preserves_only_staging_owned_by_an_active_job() {
+        let temp = TestRoot::new("active-job-staging");
+        let connection = db_at_root(&temp.data).unwrap();
+        let target_id = project_id('e');
+        let target_root = project_root_path(&temp.data, &target_id).unwrap();
+        let source = target_root.join("source/source.wav");
+        let staging = target_root.join("previews/.job_active.wav");
+        write(&source, b"source");
+        write(&staging, b"partial output");
+        insert_project(&connection, &target_id, &source);
+        insert_artifact(&connection, "source-active", &target_id, &source, json!({}));
+        let job = create_running_job(
+            &connection,
+            &target_id,
+            "preview",
+            Some("source-active".to_string()),
+        )
+        .unwrap();
+        register_job_staging_path(&connection, &job.id, &staging).unwrap();
+
+        reconcile_project_storage(&connection, &temp.data, &target_id).unwrap();
+        assert!(staging.exists());
+        connection
+            .execute(
+                "UPDATE jobs SET status = 'failed', completed_at = ?1 WHERE id = ?2",
+                params![now_iso(), job.id],
+            )
+            .unwrap();
+        reconcile_project_storage(&connection, &temp.data, &target_id).unwrap();
+        assert!(!staging.exists());
+        assert!(source.exists());
+    }
+
+    #[test]
+    fn staging_registration_cannot_cross_a_cleanup_plan_apply_window() {
+        let temp = TestRoot::new("staging-registration-race");
+        let connection = db_at_root(&temp.data).unwrap();
+        let target_id = project_id('f');
+        let target_root = project_root_path(&temp.data, &target_id).unwrap();
+        let source = target_root.join("source/source.wav");
+        let staging = target_root.join("export-staging/.job_race.m4a");
+        write(&source, b"source");
+        insert_project(&connection, &target_id, &source);
+        insert_artifact(&connection, "source-race", &target_id, &source, json!({}));
+        let job = create_running_job(
+            &connection,
+            &target_id,
+            "export",
+            Some("source-race".to_string()),
+        )
+        .unwrap();
+
+        let guard = project_storage_mutation_guard();
+        let (started_tx, started_rx) = mpsc::channel();
+        let (done_tx, done_rx) = mpsc::channel();
+        let database_path = temp.data.join("mobile.sqlite3");
+        let worker_staging = staging.clone();
+        let worker_job_id = job.id.clone();
+        let worker = std::thread::spawn(move || {
+            let worker_connection = Connection::open(database_path).unwrap();
+            started_tx.send(()).unwrap();
+            register_job_staging_path(&worker_connection, &worker_job_id, &worker_staging).unwrap();
+            write(&worker_staging, b"partial after registration");
+            done_tx.send(()).unwrap();
+        });
+        started_rx.recv().unwrap();
+        assert!(done_rx.recv_timeout(Duration::from_millis(50)).is_err());
+        assert!(!staging.exists());
+        drop(guard);
+        done_rx.recv_timeout(Duration::from_secs(2)).unwrap();
+        worker.join().unwrap();
+
+        reconcile_project_storage_after_commit(&connection, &temp.data, &target_id);
+        assert!(staging.exists());
+    }
+
+    #[test]
+    fn promotion_and_commit_cannot_cross_a_cleanup_plan_apply_window() {
+        let temp = TestRoot::new("promotion-cleanup-race");
+        let connection = db_at_root(&temp.data).unwrap();
+        let target_id = project_id('1');
+        let target_root = project_root_path(&temp.data, &target_id).unwrap();
+        let source = target_root.join("source/source.wav");
+        let staging = target_root.join("previews/.job_publish.wav");
+        let published = target_root.join("previews/job_publish.wav");
+        write(&source, b"source");
+        write(&staging, b"completed render");
+        insert_project(&connection, &target_id, &source);
+        insert_artifact(
+            &connection,
+            "source-publish",
+            &target_id,
+            &source,
+            json!({}),
+        );
+        let job = create_running_job(
+            &connection,
+            &target_id,
+            "preview",
+            Some("source-publish".to_string()),
+        )
+        .unwrap();
+        register_job_staging_path(&connection, &job.id, &staging).unwrap();
+
+        let guard = project_storage_mutation_guard();
+        let plan = build_project_storage_plan(&connection, &temp.data, &target_id).unwrap();
+        let (started_tx, started_rx) = mpsc::channel();
+        let (done_tx, done_rx) = mpsc::channel();
+        let database_path = temp.data.join("mobile.sqlite3");
+        let worker_root = temp.data.clone();
+        let worker_project_root = target_root.clone();
+        let worker_staging = staging.clone();
+        let worker_published = published.clone();
+        let worker_project_id = target_id.clone();
+        let worker_job_id = job.id.clone();
+        let worker = std::thread::spawn(move || {
+            let worker_connection = Connection::open(database_path).unwrap();
+            started_tx.send(()).unwrap();
+            let _guard = project_storage_mutation_guard();
+            worker_connection.execute_batch("BEGIN IMMEDIATE").unwrap();
+            let staged =
+                capture_owned_project_file(&worker_root, &worker_project_root, &worker_staging)
+                    .unwrap();
+            let published_file = move_owned_project_file(&staged, &worker_published).unwrap();
+            worker_connection.execute(
+                "INSERT INTO artifacts (id, project_id, type, format, path, size_bytes, generated_by, can_delete, can_regenerate, metadata_json, created_at) VALUES ('published-race', ?1, 'preview_mix', 'wav', ?2, 16, 'ffmpeg', 1, 1, '{}', ?3)",
+                params![worker_project_id, published_file.path.to_string_lossy(), now_iso()],
+            ).unwrap();
+            worker_connection
+                .execute(
+                    "UPDATE jobs SET status = 'completed', completed_at = ?1 WHERE id = ?2",
+                    params![now_iso(), worker_job_id],
+                )
+                .unwrap();
+            worker_connection.execute_batch("COMMIT").unwrap();
+            done_tx.send(()).unwrap();
+        });
+        started_rx.recv().unwrap();
+        assert!(done_rx.recv_timeout(Duration::from_millis(50)).is_err());
+        apply_project_storage_plan(plan).unwrap();
+        assert!(staging.exists());
+        assert!(!published.exists());
+        drop(guard);
+        done_rx.recv_timeout(Duration::from_secs(2)).unwrap();
+        worker.join().unwrap();
+
+        reconcile_project_storage_after_commit(&connection, &temp.data, &target_id);
+        assert!(!staging.exists());
+        assert!(published.exists());
     }
 }

--- a/apps/desktop/src-tauri/src/mobile_ffmpeg/bridge.c
+++ b/apps/desktop/src-tauri/src/mobile_ffmpeg/bridge.c
@@ -1,0 +1,427 @@
+#include "bridge.h"
+
+#include <libavcodec/avcodec.h>
+#include <libavfilter/avfilter.h>
+#include <libavfilter/buffersink.h>
+#include <libavfilter/buffersrc.h>
+#include <libavformat/avformat.h>
+#include <libavutil/avstring.h>
+#include <libavutil/error.h>
+#include <libavutil/log.h>
+#include <libavutil/mathematics.h>
+#include <libavutil/opt.h>
+#include <libavutil/samplefmt.h>
+
+#include <math.h>
+#include <limits.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+struct TfFfmpegJob {
+  char error[1024];
+  const TfFfmpegRenderRequest *request;
+  int output_sample_rate;
+  int output_channels;
+  int64_t output_samples;
+};
+
+typedef struct TfPipeline {
+  AVFormatContext *input;
+  AVFormatContext *output;
+  AVCodecContext *decoder;
+  AVCodecContext *encoder;
+  AVFilterGraph *filters;
+  AVFilterContext *source;
+  AVFilterContext *sink;
+  AVPacket *packet;
+  AVFrame *decoded;
+  AVFrame *filtered;
+  int input_stream;
+  int64_t encoded_samples;
+  int last_progress;
+} TfPipeline;
+
+static void tf_set_error(TfFfmpegJob *job, const char *operation, int code) {
+  char detail[AV_ERROR_MAX_STRING_SIZE] = {0};
+  av_strerror(code, detail, sizeof(detail));
+  snprintf(job->error, sizeof(job->error), "%s: %s", operation, detail);
+}
+
+static int tf_cancelled(TfFfmpegJob *job) {
+  const TfFfmpegRenderRequest *request = job->request;
+  return request && request->should_cancel && request->should_cancel(request->callback_opaque);
+}
+
+static int tf_interrupt(void *opaque) { return tf_cancelled((TfFfmpegJob *)opaque); }
+
+static void tf_progress(TfFfmpegJob *job, int progress) {
+  if (job->request->on_progress) {
+    job->request->on_progress(job->request->callback_opaque, progress);
+  }
+}
+
+static const char *tf_encoder_name(const char *format) {
+  if (strcmp(format, "wav") == 0) return "pcm_s16le";
+  if (strcmp(format, "flac") == 0) return "flac";
+  if (strcmp(format, "mp3") == 0) return "libmp3lame";
+  if (strcmp(format, "m4a") == 0) return "aac";
+  return NULL;
+}
+
+static void tf_close(TfPipeline *pipeline) {
+  av_packet_free(&pipeline->packet);
+  av_frame_free(&pipeline->decoded);
+  av_frame_free(&pipeline->filtered);
+  avfilter_graph_free(&pipeline->filters);
+  avcodec_free_context(&pipeline->decoder);
+  avcodec_free_context(&pipeline->encoder);
+  if (pipeline->input) avformat_close_input(&pipeline->input);
+  if (pipeline->output) {
+    if (!(pipeline->output->oformat->flags & AVFMT_NOFILE) && pipeline->output->pb) {
+      avio_closep(&pipeline->output->pb);
+    }
+    avformat_free_context(pipeline->output);
+  }
+}
+
+static int tf_open_input(TfFfmpegJob *job, TfPipeline *pipeline) {
+  pipeline->input = avformat_alloc_context();
+  if (!pipeline->input) return AVERROR(ENOMEM);
+  pipeline->input->interrupt_callback.callback = tf_interrupt;
+  pipeline->input->interrupt_callback.opaque = job;
+  int result = avformat_open_input(&pipeline->input, job->request->input_path, NULL, NULL);
+  if (result < 0) return result;
+  result = avformat_find_stream_info(pipeline->input, NULL);
+  if (result < 0) return result;
+  pipeline->input_stream = -1;
+  for (unsigned int index = 0; index < pipeline->input->nb_streams; index += 1) {
+    if (pipeline->input->streams[index]->codecpar->codec_type == AVMEDIA_TYPE_AUDIO) {
+      pipeline->input_stream = (int)index;
+      break;
+    }
+  }
+  if (pipeline->input_stream < 0) return AVERROR_STREAM_NOT_FOUND;
+  AVStream *stream = pipeline->input->streams[pipeline->input_stream];
+  const AVCodec *codec = avcodec_find_decoder(stream->codecpar->codec_id);
+  if (!codec) return AVERROR_DECODER_NOT_FOUND;
+  pipeline->decoder = avcodec_alloc_context3(codec);
+  if (!pipeline->decoder) return AVERROR(ENOMEM);
+  result = avcodec_parameters_to_context(pipeline->decoder, stream->codecpar);
+  if (result < 0) return result;
+  pipeline->decoder->pkt_timebase = stream->time_base;
+  return avcodec_open2(pipeline->decoder, codec, NULL);
+}
+
+static int tf_open_output(TfFfmpegJob *job, TfPipeline *pipeline) {
+  const char *format = job->request->output_format;
+  const char *muxer = strcmp(format, "m4a") == 0 ? "mp4" : format;
+  int result = avformat_alloc_output_context2(&pipeline->output, NULL, muxer, job->request->output_path);
+  if (result < 0 || !pipeline->output) return result < 0 ? result : AVERROR(EINVAL);
+  const AVCodec *codec = avcodec_find_encoder_by_name(tf_encoder_name(format));
+  if (!codec) return AVERROR_ENCODER_NOT_FOUND;
+  pipeline->encoder = avcodec_alloc_context3(codec);
+  if (!pipeline->encoder) return AVERROR(ENOMEM);
+  int desired_rate = pipeline->decoder->sample_rate;
+  if (desired_rate <= 0) return AVERROR(EINVAL);
+  const int *sample_rates = NULL;
+  int sample_rate_count = 0;
+  result = avcodec_get_supported_config(
+      pipeline->encoder, codec, AV_CODEC_CONFIG_SAMPLE_RATE, 0,
+      (const void **)&sample_rates, &sample_rate_count);
+  if (result < 0) return result;
+  pipeline->encoder->sample_rate = desired_rate;
+  if (sample_rate_count > 0) {
+    int best_distance = INT_MAX;
+    for (int index = 0; index < sample_rate_count; index += 1) {
+      if (sample_rates[index] <= 0) continue;
+      int distance = abs(sample_rates[index] - desired_rate);
+      if (distance < best_distance) {
+        pipeline->encoder->sample_rate = sample_rates[index];
+        best_distance = distance;
+      }
+    }
+  }
+  AVChannelLayout desired_layout = {0};
+  if (pipeline->decoder->ch_layout.order == AV_CHANNEL_ORDER_UNSPEC) {
+    av_channel_layout_default(&desired_layout, pipeline->decoder->ch_layout.nb_channels);
+  } else {
+    result = av_channel_layout_copy(&desired_layout, &pipeline->decoder->ch_layout);
+    if (result < 0) return result;
+  }
+  const AVChannelLayout *channel_layouts = NULL;
+  int channel_layout_count = 0;
+  result = avcodec_get_supported_config(
+      pipeline->encoder, codec, AV_CODEC_CONFIG_CHANNEL_LAYOUT, 0,
+      (const void **)&channel_layouts, &channel_layout_count);
+  if (result < 0) {
+    av_channel_layout_uninit(&desired_layout);
+    return result;
+  }
+  const AVChannelLayout *selected_layout = &desired_layout;
+  if (channel_layout_count > 0) {
+    int best_distance = INT_MAX;
+    for (int index = 0; index < channel_layout_count; index += 1) {
+      if (channel_layouts[index].nb_channels <= 0) continue;
+      int distance = abs(channel_layouts[index].nb_channels - desired_layout.nb_channels);
+      if (av_channel_layout_compare(&channel_layouts[index], &desired_layout) == 0) {
+        selected_layout = &channel_layouts[index];
+        break;
+      }
+      if (distance < best_distance) {
+        selected_layout = &channel_layouts[index];
+        best_distance = distance;
+      }
+    }
+  }
+  result = av_channel_layout_copy(&pipeline->encoder->ch_layout, selected_layout);
+  av_channel_layout_uninit(&desired_layout);
+  if (result < 0) return result;
+  const enum AVSampleFormat *sample_formats = NULL;
+  int sample_format_count = 0;
+  result = avcodec_get_supported_config(
+      pipeline->encoder, codec, AV_CODEC_CONFIG_SAMPLE_FORMAT, 0,
+      (const void **)&sample_formats, &sample_format_count);
+  if (result < 0) return result;
+  pipeline->encoder->sample_fmt = sample_format_count > 0
+                                      ? sample_formats[0]
+                                      : pipeline->decoder->sample_fmt;
+  pipeline->encoder->time_base = (AVRational){1, pipeline->encoder->sample_rate};
+  if (strcmp(format, "mp3") == 0 || strcmp(format, "m4a") == 0) {
+    pipeline->encoder->bit_rate = 192000;
+  }
+  if (strcmp(format, "flac") == 0) pipeline->encoder->compression_level = 5;
+  if (pipeline->output->oformat->flags & AVFMT_GLOBALHEADER) {
+    pipeline->encoder->flags |= AV_CODEC_FLAG_GLOBAL_HEADER;
+  }
+  result = avcodec_open2(pipeline->encoder, codec, NULL);
+  if (result < 0) return result;
+  AVStream *stream = avformat_new_stream(pipeline->output, NULL);
+  if (!stream) return AVERROR(ENOMEM);
+  stream->time_base = pipeline->encoder->time_base;
+  result = avcodec_parameters_from_context(stream->codecpar, pipeline->encoder);
+  if (result < 0) return result;
+  if (!(pipeline->output->oformat->flags & AVFMT_NOFILE)) {
+    result = avio_open(&pipeline->output->pb, job->request->output_path, AVIO_FLAG_WRITE);
+    if (result < 0) return result;
+  }
+  return avformat_write_header(pipeline->output, NULL);
+}
+
+static int tf_open_filters(TfFfmpegJob *job, TfPipeline *pipeline) {
+  pipeline->filters = avfilter_graph_alloc();
+  if (!pipeline->filters) return AVERROR(ENOMEM);
+  char layout[128] = {0};
+  int result = av_channel_layout_describe(&pipeline->decoder->ch_layout, layout, sizeof(layout));
+  if (result < 0) return result;
+  const char *sample_name = av_get_sample_fmt_name(pipeline->decoder->sample_fmt);
+  if (!sample_name) return AVERROR(EINVAL);
+  char source_args[512] = {0};
+  AVRational time_base = pipeline->input->streams[pipeline->input_stream]->time_base;
+  snprintf(source_args, sizeof(source_args),
+           "time_base=%d/%d:sample_rate=%d:sample_fmt=%s:channel_layout=%s",
+           time_base.num, time_base.den, pipeline->decoder->sample_rate, sample_name, layout);
+  result = avfilter_graph_create_filter(&pipeline->source, avfilter_get_by_name("abuffer"),
+                                        "source", source_args, NULL, pipeline->filters);
+  if (result < 0) return result;
+  result = avfilter_graph_create_filter(&pipeline->sink, avfilter_get_by_name("abuffersink"),
+                                        "sink", NULL, NULL, pipeline->filters);
+  if (result < 0) return result;
+
+  char encoder_layout[128] = {0};
+  result = av_channel_layout_describe(&pipeline->encoder->ch_layout, encoder_layout, sizeof(encoder_layout));
+  if (result < 0) return result;
+  const char *encoder_sample_name = av_get_sample_fmt_name(pipeline->encoder->sample_fmt);
+  double ratio = pow(2.0, job->request->pitch_cents / 1200.0);
+  char chain[1024] = {0};
+  if (fabs(job->request->pitch_cents) < 0.000001) {
+    snprintf(chain, sizeof(chain),
+             "aformat=sample_fmts=%s:sample_rates=%d:channel_layouts=%s",
+             encoder_sample_name, pipeline->encoder->sample_rate, encoder_layout);
+  } else {
+    char tempo[512] = {0};
+    double remaining = 1.0 / ratio;
+    while (remaining < 0.5) {
+      av_strlcat(tempo, "atempo=0.5,", sizeof(tempo));
+      remaining /= 0.5;
+    }
+    while (remaining > 2.0) {
+      av_strlcat(tempo, "atempo=2.0,", sizeof(tempo));
+      remaining /= 2.0;
+    }
+    char final_tempo[64] = {0};
+    snprintf(final_tempo, sizeof(final_tempo), "atempo=%.10f", remaining);
+    av_strlcat(tempo, final_tempo, sizeof(tempo));
+    snprintf(chain, sizeof(chain),
+             "asetrate=%d*%.10f,aresample=%d,%s,aformat=sample_fmts=%s:sample_rates=%d:channel_layouts=%s",
+             pipeline->decoder->sample_rate, ratio, pipeline->encoder->sample_rate, tempo,
+             encoder_sample_name, pipeline->encoder->sample_rate, encoder_layout);
+  }
+  AVFilterInOut *inputs = avfilter_inout_alloc();
+  AVFilterInOut *outputs = avfilter_inout_alloc();
+  if (!inputs || !outputs) {
+    avfilter_inout_free(&inputs);
+    avfilter_inout_free(&outputs);
+    return AVERROR(ENOMEM);
+  }
+  outputs->name = av_strdup("in");
+  outputs->filter_ctx = pipeline->source;
+  outputs->pad_idx = 0;
+  inputs->name = av_strdup("out");
+  inputs->filter_ctx = pipeline->sink;
+  inputs->pad_idx = 0;
+  result = avfilter_graph_parse_ptr(pipeline->filters, chain, &inputs, &outputs, NULL);
+  avfilter_inout_free(&inputs);
+  avfilter_inout_free(&outputs);
+  if (result < 0) return result;
+  result = avfilter_graph_config(pipeline->filters, NULL);
+  if (result < 0) return result;
+  if (pipeline->encoder->frame_size > 0) {
+    av_buffersink_set_frame_size(pipeline->sink, pipeline->encoder->frame_size);
+  }
+  return 0;
+}
+
+static int tf_encode_frame(TfPipeline *pipeline, AVFrame *frame) {
+  int result = avcodec_send_frame(pipeline->encoder, frame);
+  if (result < 0) return result;
+  while (1) {
+    result = avcodec_receive_packet(pipeline->encoder, pipeline->packet);
+    if (result == AVERROR(EAGAIN) || result == AVERROR_EOF) return 0;
+    if (result < 0) return result;
+    av_packet_rescale_ts(pipeline->packet, pipeline->encoder->time_base,
+                         pipeline->output->streams[0]->time_base);
+    pipeline->packet->stream_index = 0;
+    result = av_interleaved_write_frame(pipeline->output, pipeline->packet);
+    av_packet_unref(pipeline->packet);
+    if (result < 0) return result;
+  }
+}
+
+static int tf_drain_filters(TfFfmpegJob *job, TfPipeline *pipeline) {
+  while (1) {
+    int result = av_buffersink_get_frame(pipeline->sink, pipeline->filtered);
+    if (result == AVERROR(EAGAIN) || result == AVERROR_EOF) return 0;
+    if (result < 0) return result;
+    pipeline->filtered->pts = pipeline->encoded_samples;
+    pipeline->encoded_samples += pipeline->filtered->nb_samples;
+    result = tf_encode_frame(pipeline, pipeline->filtered);
+    av_frame_unref(pipeline->filtered);
+    if (result < 0) return result;
+    if (tf_cancelled(job)) return AVERROR_EXIT;
+  }
+}
+
+static int tf_decode_packet(TfFfmpegJob *job, TfPipeline *pipeline, AVPacket *packet) {
+  int result = avcodec_send_packet(pipeline->decoder, packet);
+  if (result < 0) return result;
+  while (1) {
+    result = avcodec_receive_frame(pipeline->decoder, pipeline->decoded);
+    if (result == AVERROR(EAGAIN) || result == AVERROR_EOF) return 0;
+    if (result < 0) return result;
+    result = av_buffersrc_add_frame_flags(pipeline->source, pipeline->decoded, AV_BUFFERSRC_FLAG_KEEP_REF);
+    av_frame_unref(pipeline->decoded);
+    if (result < 0) return result;
+    result = tf_drain_filters(job, pipeline);
+    if (result < 0) return result;
+  }
+}
+
+static void tf_packet_progress(TfFfmpegJob *job, TfPipeline *pipeline,
+                               const AVPacket *packet) {
+  if (packet->pts == AV_NOPTS_VALUE || pipeline->input->duration <= 0) return;
+  const AVStream *stream = pipeline->input->streams[pipeline->input_stream];
+  int64_t elapsed = av_rescale_q(packet->pts, stream->time_base, AV_TIME_BASE_Q);
+  if (stream->start_time != AV_NOPTS_VALUE) {
+    elapsed -= av_rescale_q(stream->start_time, stream->time_base, AV_TIME_BASE_Q);
+  }
+  int progress = 10 + (int)av_rescale_rnd(elapsed, 80, pipeline->input->duration,
+                                          AV_ROUND_DOWN);
+  if (progress > 90) progress = 90;
+  if (progress > pipeline->last_progress) {
+    pipeline->last_progress = progress;
+    tf_progress(job, progress);
+  }
+}
+
+TfFfmpegJob *tf_ffmpeg_job_create(void) {
+  av_log_set_level(AV_LOG_QUIET);
+  return calloc(1, sizeof(TfFfmpegJob));
+}
+
+void tf_ffmpeg_job_destroy(TfFfmpegJob *job) { free(job); }
+
+const char *tf_ffmpeg_job_error(const TfFfmpegJob *job) {
+  return job ? job->error : "FFmpeg job was not allocated";
+}
+
+int tf_ffmpeg_job_output_sample_rate(const TfFfmpegJob *job) {
+  return job ? job->output_sample_rate : 0;
+}
+
+int tf_ffmpeg_job_output_channels(const TfFfmpegJob *job) {
+  return job ? job->output_channels : 0;
+}
+
+int64_t tf_ffmpeg_job_output_samples(const TfFfmpegJob *job) {
+  return job ? job->output_samples : 0;
+}
+
+int tf_ffmpeg_render(TfFfmpegJob *job, const TfFfmpegRenderRequest *request) {
+  if (!job || !request || !request->input_path || !request->output_path ||
+      !request->output_format || !tf_encoder_name(request->output_format) ||
+      !isfinite(request->pitch_cents) || fabs(request->pitch_cents) > 4800.0) {
+    return AVERROR(EINVAL);
+  }
+  memset(job->error, 0, sizeof(job->error));
+  job->output_sample_rate = 0;
+  job->output_channels = 0;
+  job->output_samples = 0;
+  job->request = request;
+  TfPipeline pipeline = {0};
+  if (tf_cancelled(job)) {
+    int cancelled = AVERROR_EXIT;
+    tf_set_error(job, "cancelled", cancelled);
+    job->request = NULL;
+    return cancelled;
+  }
+  int result = tf_open_input(job, &pipeline);
+  if (result < 0) { tf_set_error(job, tf_cancelled(job) ? "cancelled" : "open input", result); goto done; }
+  pipeline.last_progress = 10;
+  tf_progress(job, 10);
+  result = tf_open_output(job, &pipeline);
+  if (result < 0) { tf_set_error(job, tf_cancelled(job) ? "cancelled" : "open output", result); goto done; }
+  job->output_sample_rate = pipeline.encoder->sample_rate;
+  job->output_channels = pipeline.encoder->ch_layout.nb_channels;
+  result = tf_open_filters(job, &pipeline);
+  if (result < 0) { tf_set_error(job, tf_cancelled(job) ? "cancelled" : "configure audio filters", result); goto done; }
+  pipeline.packet = av_packet_alloc();
+  pipeline.decoded = av_frame_alloc();
+  pipeline.filtered = av_frame_alloc();
+  if (!pipeline.packet || !pipeline.decoded || !pipeline.filtered) {
+    result = AVERROR(ENOMEM); tf_set_error(job, "allocate bounded frames", result); goto done;
+  }
+  while ((result = av_read_frame(pipeline.input, pipeline.packet)) >= 0) {
+    if (tf_cancelled(job)) { result = AVERROR_EXIT; break; }
+    if (pipeline.packet->stream_index == pipeline.input_stream) {
+      tf_packet_progress(job, &pipeline, pipeline.packet);
+      result = tf_decode_packet(job, &pipeline, pipeline.packet);
+      if (result < 0) break;
+    }
+    av_packet_unref(pipeline.packet);
+  }
+  if (result == AVERROR_EOF) result = tf_decode_packet(job, &pipeline, NULL);
+  if (result >= 0) result = av_buffersrc_add_frame_flags(pipeline.source, NULL, 0);
+  if (result >= 0) result = tf_drain_filters(job, &pipeline);
+  if (result >= 0) result = tf_encode_frame(&pipeline, NULL);
+  if (result >= 0) result = av_write_trailer(pipeline.output);
+  if (result < 0) tf_set_error(job, tf_cancelled(job) ? "cancelled" : "render audio", result);
+  else {
+    job->output_samples = pipeline.encoded_samples;
+    tf_progress(job, 100);
+  }
+done:
+  tf_close(&pipeline);
+  job->request = NULL;
+  return result;
+}

--- a/apps/desktop/src-tauri/src/mobile_ffmpeg/bridge.h
+++ b/apps/desktop/src-tauri/src/mobile_ffmpeg/bridge.h
@@ -1,0 +1,36 @@
+#ifndef TUNEFORGE_FFMPEG_BRIDGE_H
+#define TUNEFORGE_FFMPEG_BRIDGE_H
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct TfFfmpegJob TfFfmpegJob;
+typedef int (*TfFfmpegCancelCallback)(void *opaque);
+typedef void (*TfFfmpegProgressCallback)(void *opaque, int progress);
+
+typedef struct TfFfmpegRenderRequest {
+  const char *input_path;
+  const char *output_path;
+  const char *output_format;
+  double pitch_cents;
+  void *callback_opaque;
+  TfFfmpegCancelCallback should_cancel;
+  TfFfmpegProgressCallback on_progress;
+} TfFfmpegRenderRequest;
+
+TfFfmpegJob *tf_ffmpeg_job_create(void);
+void tf_ffmpeg_job_destroy(TfFfmpegJob *job);
+int tf_ffmpeg_render(TfFfmpegJob *job, const TfFfmpegRenderRequest *request);
+const char *tf_ffmpeg_job_error(const TfFfmpegJob *job);
+int tf_ffmpeg_job_output_sample_rate(const TfFfmpegJob *job);
+int tf_ffmpeg_job_output_channels(const TfFfmpegJob *job);
+int64_t tf_ffmpeg_job_output_samples(const TfFfmpegJob *job);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/apps/desktop/src-tauri/src/mobile_ffmpeg/bridge_test.c
+++ b/apps/desktop/src-tauri/src/mobile_ffmpeg/bridge_test.c
@@ -1,0 +1,54 @@
+#include "bridge.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+typedef struct TestCallbacks {
+  int cancel_immediately;
+  int cancel_after_progress;
+  int last_progress;
+} TestCallbacks;
+
+static int should_cancel(void *opaque) {
+  TestCallbacks *callbacks = (TestCallbacks *)opaque;
+  return callbacks->cancel_immediately ||
+         (callbacks->cancel_after_progress >= 0 &&
+          callbacks->last_progress >= callbacks->cancel_after_progress);
+}
+
+static void on_progress(void *opaque, int progress) {
+  ((TestCallbacks *)opaque)->last_progress = progress;
+}
+
+int main(int argc, char **argv) {
+  if (argc != 6) {
+    fprintf(stderr,
+            "usage: bridge-test INPUT OUTPUT FORMAT CENTS CANCEL_MODE\n");
+    return 64;
+  }
+  TestCallbacks callbacks = {
+      .cancel_immediately = strcmp(argv[5], "immediate") == 0,
+      .cancel_after_progress = strcmp(argv[5], "never") == 0
+                                   ? -1
+                                   : atoi(argv[5]),
+      .last_progress = 0,
+  };
+  TfFfmpegRenderRequest request = {
+      .input_path = argv[1],
+      .output_path = argv[2],
+      .output_format = argv[3],
+      .pitch_cents = strtod(argv[4], NULL),
+      .callback_opaque = &callbacks,
+      .should_cancel = should_cancel,
+      .on_progress = on_progress,
+  };
+  TfFfmpegJob *job = tf_ffmpeg_job_create();
+  if (!job) return 70;
+  int result = tf_ffmpeg_render(job, &request);
+  fprintf(stderr, "result=%d progress=%d error=%s\n", result,
+          callbacks.last_progress, tf_ffmpeg_job_error(job));
+  tf_ffmpeg_job_destroy(job);
+  if (result < 0) remove(argv[2]);
+  return result < 0 ? 1 : 0;
+}

--- a/apps/desktop/src-tauri/src/mobile_ffmpeg/mod.rs
+++ b/apps/desktop/src-tauri/src/mobile_ffmpeg/mod.rs
@@ -1,0 +1,3 @@
+mod render;
+
+pub(crate) use render::{render_audio, AudioOutputFormat};

--- a/apps/desktop/src-tauri/src/mobile_ffmpeg/render.rs
+++ b/apps/desktop/src-tauri/src/mobile_ffmpeg/render.rs
@@ -1,0 +1,158 @@
+use std::{
+    ffi::{c_char, c_int, c_void, CStr, CString},
+    path::Path,
+};
+
+pub(crate) enum AudioOutputFormat {
+    Wav,
+    Flac,
+    Mp3,
+    M4a,
+}
+
+impl AudioOutputFormat {
+    pub(crate) fn parse(value: &str) -> Result<Self, String> {
+        match value {
+            "wav" => Ok(Self::Wav),
+            "flac" => Ok(Self::Flac),
+            "mp3" => Ok(Self::Mp3),
+            "m4a" => Ok(Self::M4a),
+            _ => Err("Android audio conversion requires WAV, FLAC, MP3, or M4A.".to_string()),
+        }
+    }
+
+    fn as_str(&self) -> &'static str {
+        match self {
+            Self::Wav => "wav",
+            Self::Flac => "flac",
+            Self::Mp3 => "mp3",
+            Self::M4a => "m4a",
+        }
+    }
+}
+
+#[repr(C)]
+struct TfFfmpegJob {
+    _private: [u8; 0],
+}
+
+#[repr(C)]
+struct TfFfmpegRenderRequest {
+    input_path: *const c_char,
+    output_path: *const c_char,
+    output_format: *const c_char,
+    pitch_cents: f64,
+    callback_opaque: *mut c_void,
+    should_cancel: Option<unsafe extern "C" fn(*mut c_void) -> c_int>,
+    on_progress: Option<unsafe extern "C" fn(*mut c_void, c_int)>,
+}
+
+unsafe extern "C" {
+    fn tf_ffmpeg_job_create() -> *mut TfFfmpegJob;
+    fn tf_ffmpeg_job_destroy(job: *mut TfFfmpegJob);
+    fn tf_ffmpeg_render(job: *mut TfFfmpegJob, request: *const TfFfmpegRenderRequest) -> c_int;
+    fn tf_ffmpeg_job_error(job: *const TfFfmpegJob) -> *const c_char;
+    fn tf_ffmpeg_job_output_sample_rate(job: *const TfFfmpegJob) -> c_int;
+    fn tf_ffmpeg_job_output_channels(job: *const TfFfmpegJob) -> c_int;
+    fn tf_ffmpeg_job_output_samples(job: *const TfFfmpegJob) -> i64;
+}
+
+pub(crate) struct RenderedAudio {
+    pub(crate) duration_seconds: f64,
+    pub(crate) sample_rate: u32,
+    pub(crate) channels: u32,
+}
+
+struct Job(*mut TfFfmpegJob);
+
+impl Job {
+    fn new() -> Result<Self, String> {
+        let job = unsafe { tf_ffmpeg_job_create() };
+        if job.is_null() {
+            Err("Android FFmpeg could not allocate an operation context.".to_string())
+        } else {
+            Ok(Self(job))
+        }
+    }
+
+    fn error(&self) -> String {
+        let value = unsafe { tf_ffmpeg_job_error(self.0) };
+        if value.is_null() {
+            return "Android FFmpeg conversion failed.".to_string();
+        }
+        unsafe { CStr::from_ptr(value) }
+            .to_string_lossy()
+            .into_owned()
+    }
+}
+
+impl Drop for Job {
+    fn drop(&mut self) {
+        unsafe { tf_ffmpeg_job_destroy(self.0) };
+    }
+}
+
+struct Callbacks<'a> {
+    should_cancel: &'a mut dyn FnMut() -> bool,
+    on_progress: &'a mut dyn FnMut(i32),
+}
+
+unsafe extern "C" fn should_cancel(opaque: *mut c_void) -> c_int {
+    let callbacks = unsafe { &mut *(opaque.cast::<Callbacks<'_>>()) };
+    i32::from((callbacks.should_cancel)())
+}
+
+unsafe extern "C" fn on_progress(opaque: *mut c_void, progress: c_int) {
+    let callbacks = unsafe { &mut *(opaque.cast::<Callbacks<'_>>()) };
+    (callbacks.on_progress)(progress);
+}
+
+pub(crate) fn render_audio(
+    input: &Path,
+    output: &Path,
+    format: AudioOutputFormat,
+    pitch_cents: f64,
+    should_cancel_callback: &mut dyn FnMut() -> bool,
+    progress_callback: &mut dyn FnMut(i32),
+) -> Result<RenderedAudio, String> {
+    if !pitch_cents.is_finite() || pitch_cents.abs() > 4800.0 {
+        return Err(
+            "Android audio conversion received an invalid pitch transformation.".to_string(),
+        );
+    }
+    let input = CString::new(input.to_string_lossy().as_bytes())
+        .map_err(|_| "Android audio input path contained an invalid NUL byte.".to_string())?;
+    let output = CString::new(output.to_string_lossy().as_bytes())
+        .map_err(|_| "Android audio output path contained an invalid NUL byte.".to_string())?;
+    let format = CString::new(format.as_str()).expect("fixed format names never contain NUL");
+    let mut callbacks = Callbacks {
+        should_cancel: should_cancel_callback,
+        on_progress: progress_callback,
+    };
+    let request = TfFfmpegRenderRequest {
+        input_path: input.as_ptr(),
+        output_path: output.as_ptr(),
+        output_format: format.as_ptr(),
+        pitch_cents,
+        callback_opaque: (&mut callbacks as *mut Callbacks<'_>).cast(),
+        should_cancel: Some(should_cancel),
+        on_progress: Some(on_progress),
+    };
+    let job = Job::new()?;
+    let result = unsafe { tf_ffmpeg_render(job.0, &request) };
+    if result < 0 {
+        Err(job.error())
+    } else {
+        let sample_rate = unsafe { tf_ffmpeg_job_output_sample_rate(job.0) };
+        let channels = unsafe { tf_ffmpeg_job_output_channels(job.0) };
+        let samples = unsafe { tf_ffmpeg_job_output_samples(job.0) };
+        if sample_rate <= 0 || channels <= 0 || samples <= 0 {
+            return Err("Android FFmpeg returned invalid output audio properties.".to_string());
+        }
+        Ok(RenderedAudio {
+            duration_seconds: samples as f64 / sample_rate as f64,
+            sample_rate: sample_rate as u32,
+            channels: channels as u32,
+        })
+    }
+}

--- a/apps/desktop/src-tauri/src/native_audio/android_media.rs
+++ b/apps/desktop/src-tauri/src/native_audio/android_media.rs
@@ -359,10 +359,9 @@ mod android {
                         ndk_sys::AMEDIAFORMAT_KEY_CHANNEL_COUNT
                     })
                     .unwrap_or(output_channels);
-                    output_encoding = media_format_i32(output_format, unsafe {
-                        ndk_sys::AMEDIAFORMAT_KEY_PCM_ENCODING
-                    })
-                    .unwrap_or(PCM_ENCODING_16BIT);
+                    output_encoding =
+                        media_format_i32(output_format, b"pcm-encoding\0".as_ptr().cast())
+                            .unwrap_or(PCM_ENCODING_16BIT);
                     unsafe {
                         let _ = ndk_sys::AMediaFormat_delete(output_format);
                     }

--- a/apps/desktop/src/App.library.test.tsx
+++ b/apps/desktop/src/App.library.test.tsx
@@ -412,7 +412,7 @@ describe("Desktop app library", () => {
     expect(screen.getByRole("button", { name: "Hide Inspector" })).toBeInTheDocument();
   });
 
-  it("keeps Android imports on backend-default WAV and omits the hidden desktop preference", async () => {
+  it("uses the selected durable format for Android imports", async () => {
     const user = userEvent.setup();
     window.localStorage.setItem(
       "tuneforge.ui-preferences",
@@ -421,7 +421,11 @@ describe("Desktop app library", () => {
     mockGetExportCapabilities.mockResolvedValueOnce({
       capabilities: {
         platform: "android",
-        formats: [{ id: "wav", available: true, reason: null }],
+        formats: ["wav", "flac", "mp3", "m4a"].map((id) => ({
+          id,
+          available: true,
+          reason: null,
+        })),
         destinations: [],
         max_artifact_count: 1,
       },
@@ -431,7 +435,16 @@ describe("Desktop app library", () => {
 
     await user.click(await screen.findByRole("button", { name: "Import Track(s)" }));
     await waitFor(() => expect(mockImportProject).toHaveBeenCalled());
-    expect(mockImportProject.mock.calls[0]?.[0]).not.toHaveProperty("output_format");
+    expect(mockImportProject.mock.calls[0]?.[0]).toHaveProperty("output_format", "m4a");
+    expect(mockOpen).toHaveBeenCalledWith(
+      expect.objectContaining({
+        filters: [
+          expect.objectContaining({
+            extensions: expect.arrayContaining(["m4a", "aac", "audio/mp4", "audio/aac-adts"]),
+          }),
+        ],
+      }),
+    );
   });
 
   it("imports multiple tracks in order and stays on the library", async () => {

--- a/apps/desktop/src/App.project-export.test.tsx
+++ b/apps/desktop/src/App.project-export.test.tsx
@@ -6,6 +6,7 @@ import {
   mockCreateExport,
   mockCancelJob,
   mockDeleteProject,
+  mockCreatePreview,
   mockGetExportCapabilities,
   mockGetHealth,
   mockGetChords,
@@ -832,8 +833,9 @@ describe("project export workspace", () => {
     await user.click(screen.getByRole("checkbox", { name: /Lyrics$/i }));
 
     expect(screen.getByText("1 selected")).toBeVisible();
-    expect(screen.getByLabelText("File format")).toBeDisabled();
-    expect(screen.getByText(/Documents use TXT/)).toBeVisible();
+    expect(screen.queryByLabelText("File format")).not.toBeInTheDocument();
+    expect(screen.getAllByText("TXT · UTF-8")).not.toHaveLength(0);
+    expect(screen.getByText(/Audio format does not apply/)).toBeVisible();
     expect(screen.getByText("Demo Song - Lyrics.txt")).toBeVisible();
     await user.click(screen.getByRole("button", { name: "Export 1 file" }));
 
@@ -917,6 +919,53 @@ describe("project export workspace", () => {
     expect(screen.getByText("1 selected")).toBeVisible();
   });
 
+  it("exports an existing Android artifact without applying current playback or mix settings", async () => {
+    const user = userEvent.setup();
+    installExportArtifacts();
+    localStorage.setItem("tuneforge.project-playback-state", JSON.stringify({
+      proj_123: {
+        tempoTargetBpm: 87,
+        capoTransposeSemitones: 5,
+      },
+    }));
+    mockGetHealth.mockResolvedValueOnce(health("wav"));
+    mockGetMobileCapabilities.mockResolvedValue({ platform: "android" });
+    mockGetExportCapabilities.mockResolvedValue({
+      capabilities: {
+        platform: "android",
+        formats: ["wav", "flac", "mp3", "m4a"].map((id) => ({
+          id,
+          available: true,
+          reason: null,
+        })),
+        destinations: [
+          { id: "single_file", available: true, reason: null },
+          { id: "folder", available: false, reason: "Android exports one file." },
+          { id: "zip", available: false, reason: "Android exports one file." },
+        ],
+        max_artifact_count: 1,
+      },
+    });
+    renderApp(["/projects/proj_123"]);
+    await screen.findByRole("heading", { name: "Demo Song" });
+    await user.click(screen.getByRole("button", { name: "Reference Hz" }));
+    await user.clear(screen.getByLabelText("Target Reference Hz"));
+    await user.type(screen.getByLabelText("Target Reference Hz"), "432");
+    await openExportPanel(user);
+
+    await user.click(screen.getByRole("radio", { name: /Practice Mix 1/i }));
+    await user.selectOptions(screen.getByLabelText("File format"), "m4a");
+    expect(screen.getByText("Demo Song - Practice Mix 1.m4a")).toBeVisible();
+    await user.click(screen.getByRole("button", { name: "Export Practice Mix 1" }));
+
+    expect(mockCreateExport).toHaveBeenCalledWith("proj_123", {
+      artifact_ids: ["art_mix"],
+      output_format: "m4a",
+      filename_base: "Demo Song",
+    });
+    expect(mockCreatePreview).not.toHaveBeenCalled();
+  });
+
   it("uses one Android file choice, keeps chord context separate, and submits without a destination", async () => {
     const user = userEvent.setup();
     installExportArtifacts();
@@ -927,9 +976,9 @@ describe("project export workspace", () => {
         platform: "android",
         formats: [
           { id: "wav", available: true, reason: null },
-          { id: "flac", available: false, reason: "No Android FLAC encoder." },
-          { id: "mp3", available: false, reason: "No Android MP3 encoder." },
-          { id: "m4a", available: false, reason: "No Android M4A encoder." },
+          { id: "flac", available: true, reason: null },
+          { id: "mp3", available: true, reason: null },
+          { id: "m4a", available: true, reason: null },
         ],
         destinations: [
           { id: "single_file", available: true, reason: null },
@@ -968,7 +1017,7 @@ describe("project export workspace", () => {
     await screen.findByRole("heading", { name: "Demo Song" });
     await openExportPanel(user);
 
-    expect(screen.getByText(/Android exports one WAV, Lyrics TXT, or Lyrics \+ chords TXT/)).toBeVisible();
+    expect(screen.getByText(/Android exports one existing audio artifact/)).toBeVisible();
     await user.click(screen.getByRole("radio", { name: /Practice Mix 1/i }));
     const fileGroup = screen.getByRole("group", { name: "File to export" });
     expect(within(fileGroup).getAllByRole("radio")).toHaveLength(7);
@@ -977,7 +1026,9 @@ describe("project export workspace", () => {
     expect(screen.getByRole("button", { name: "Folder" })).toBeDisabled();
     expect(screen.getByRole("button", { name: "ZIP" })).toBeDisabled();
     expect(screen.queryByRole("button", { name: "Choose destination" })).not.toBeInTheDocument();
-    expect(screen.getByText(/FLAC, MP3, and M4A are unavailable/)).toBeVisible();
+    expect(screen.getByLabelText("File format")).toHaveValue("wav");
+    await user.selectOptions(screen.getByLabelText("File format"), "m4a");
+    expect(screen.getByLabelText("Suggested file name")).toHaveValue("Demo Song");
     expect(screen.getByLabelText("Suggested file name")).toHaveValue("Demo Song");
     expect(screen.getByText(/picker was closed/i).closest("[role='status']")).toHaveTextContent(
       /cancelled/i,
@@ -988,7 +1039,7 @@ describe("project export workspace", () => {
     expect(within(fileGroup).getByRole("radio", { name: /Practice Mix 1/i })).not.toBeChecked();
     expect(screen.getByText(/Matches Practice Mix 1 \(-2 semitones\)/)).toBeVisible();
     expect(screen.getByText(/Suggested name: Demo Song - Lyrics and Chords.txt/)).toBeVisible();
-    expect(screen.queryByText(/FLAC, MP3, and M4A are unavailable/)).not.toBeInTheDocument();
+    expect(screen.getByText(/Audio format does not apply/)).toBeVisible();
     expect(screen.getByText(/UTF-8 plain text with Unix line endings/)).toBeVisible();
 
     await user.click(screen.getByRole("button", { name: "Export Lyrics + chords" }));

--- a/apps/desktop/src/App.settings-theme.test.tsx
+++ b/apps/desktop/src/App.settings-theme.test.tsx
@@ -303,21 +303,24 @@ describe("Desktop app settings theme", () => {
     await waitFor(() => expect(screen.getByRole("button", { name: /^WAV\/PCM/ })).toBeEnabled());
   });
 
-  it("hides audio storage settings when capabilities report Android", async () => {
+  it("shows owned audio storage formats when capabilities report Android", async () => {
     mockGetExportCapabilities.mockResolvedValueOnce({
       capabilities: {
         platform: "android",
-        formats: [{ id: "wav", available: true, reason: null }],
+        formats: ["wav", "flac", "mp3", "m4a"].map((id) => ({
+          id,
+          available: true,
+          reason: null,
+        })),
         destinations: [],
         max_artifact_count: 1,
       },
     });
     renderApp(["/settings"]);
 
-    await waitFor(() => expect(screen.queryByRole("heading", { name: "Audio Storage" })).not.toBeInTheDocument());
-    expect(screen.queryByText("New audio format")).not.toBeInTheDocument();
-    expect(screen.getByText("App-wide appearance, notation, and playback defaults.")).toBeInTheDocument();
-    expect(screen.queryByText(/audio storage/i)).not.toBeInTheDocument();
+    await screen.findByRole("heading", { name: "Audio Storage" });
+    expect(screen.getByText("New audio format")).toBeInTheDocument();
+    await waitFor(() => expect(screen.getByRole("button", { name: /^M4A/ })).toBeEnabled());
   });
 
   it("persists theme and visible UI preferences", async () => {
@@ -1142,14 +1145,18 @@ describe("Desktop app settings theme", () => {
     }
   });
 
-  it("preserves a hidden compressed snapshot preference on Android without prompting", async () => {
+  it("confirms and applies a compressed snapshot preference on Android", async () => {
     const user = userEvent.setup();
     const defaultInvoke = mockInvoke.getMockImplementation();
     if (!defaultInvoke) throw new Error("Mock invoke implementation was not installed.");
     mockGetExportCapabilities.mockResolvedValueOnce({
       capabilities: {
         platform: "android",
-        formats: [{ id: "wav", available: true, reason: null }],
+        formats: ["wav", "flac", "mp3", "m4a"].map((id) => ({
+          id,
+          available: true,
+          reason: null,
+        })),
         destinations: [],
         max_artifact_count: 1,
       },
@@ -1163,11 +1170,11 @@ describe("Desktop app settings theme", () => {
 
     try {
       renderApp(["/settings"]);
-      await waitFor(() => expect(screen.queryByRole("heading", { name: "Audio Storage" })).not.toBeInTheDocument());
+      await screen.findByRole("heading", { name: "Audio Storage" });
       await user.click(screen.getByRole("button", { name: "Import Settings" }));
 
       await screen.findByText("Settings imported.");
-      expect(mockConfirm).not.toHaveBeenCalled();
+      expect(mockConfirm).toHaveBeenCalled();
       expect(JSON.parse(window.localStorage.getItem("tuneforge.ui-preferences") ?? "{}"))
         .toMatchObject({ defaultDurableAudioFormat: "m4a" });
     } finally {

--- a/apps/desktop/src/features/projects/LibraryView.tsx
+++ b/apps/desktop/src/features/projects/LibraryView.tsx
@@ -17,6 +17,8 @@ import { useChordBackendActionSelection } from "./hooks/useChordBackendActionSel
 
 const MAX_IMPORT_SELECTION = 25;
 const LIBRARY_PROJECTS_PAGE_SIZE = 50;
+const IMPORT_FILE_EXTENSIONS = ["mp3", "wav", "flac", "m4a", "aac", "ogg", "mp4", "webm"];
+const ANDROID_IMPORT_MIME_ALIASES = ["audio/mp4", "audio/aac-adts"];
 
 function formatDuration(durationSeconds: number | null | undefined) {
   if (!durationSeconds) return "Unknown length";
@@ -323,7 +325,10 @@ export function LibraryView() {
         filters: [
           {
             name: "Audio / Video",
-            extensions: ["mp3", "wav", "flac", "m4a", "aac", "ogg", "mp4", "webm"],
+            extensions:
+              capabilities.platform === "android"
+                ? [...IMPORT_FILE_EXTENSIONS, ...ANDROID_IMPORT_MIME_ALIASES]
+                : IMPORT_FILE_EXTENSIONS,
           },
         ],
       });

--- a/apps/desktop/src/features/projects/components/ExportWorkspace.tsx
+++ b/apps/desktop/src/features/projects/components/ExportWorkspace.tsx
@@ -120,7 +120,7 @@ export function ExportWorkspace() {
           <span className="eyebrow">Project delivery</span>
           <h2 id="export-workspace-title">Export files</h2>
           <p>{isMobileRuntime
-            ? "Choose one local WAV or project text file, then save it with Android’s system picker."
+            ? "Choose one existing audio artifact or project text file, then save it with Android’s system picker."
             : "Choose project audio and documents, then package local files."}</p>
         </div>
         <div className="export-workspace__header-actions">
@@ -146,7 +146,7 @@ export function ExportWorkspace() {
 
       {isMobileRuntime ? (
         <div className="notice notice--info" id="android-export-format-notice" role="status">
-          Android exports one WAV, Lyrics TXT, or Lyrics + chords TXT at a time. The system
+          Android exports one existing audio artifact, Lyrics TXT, or Lyrics + chords TXT at a time. The system
           provider chooses the location and handles name collisions.
         </div>
       ) : null}
@@ -428,7 +428,7 @@ export function ExportWorkspace() {
                   ) : null}
                 </div>
               ) : null}
-              {!isMobileRuntime ? <label className="export-field">
+              {selectedIds.size ? <label className="export-field">
                 <span>File format</span>
                 <select
                   aria-describedby={isMobileRuntime ? "android-export-format-notice" : undefined}
@@ -444,18 +444,15 @@ export function ExportWorkspace() {
               </label> : (
                 <div className="export-field" aria-describedby="android-export-format-reasons">
                   <span>Format</span>
-                  <strong>{selectedIds.size ? "WAV" : "TXT · UTF-8"}</strong>
+                  <strong>TXT · UTF-8</strong>
                   <p className="field-reason" id="android-export-format-reasons">
-                    {selectedIds.size
-                      ? "FLAC, MP3, and M4A are unavailable because Android copies existing WAV bytes without an encoder."
-                      : "Project documents use UTF-8 plain text with Unix line endings."}
+                    Project documents use UTF-8 plain text with Unix line endings. Audio format does not apply.
                   </p>
                 </div>
               )}
-              {!isMobileRuntime && !selectedIds.size && totalSelectedCount ? (
-                <p className="field-reason">Audio format does not apply to document-only exports. Documents use TXT.</p>
-              ) : null}
-              {selectedFormatCapability?.available === false ? <p className="field-reason">{selectedFormatCapability.reason}</p> : null}
+              {selectedIds.size > 0 && selectedFormatCapability?.available === false
+                ? <p className="field-reason">{selectedFormatCapability.reason}</p>
+                : null}
               <label className="export-field">
                 <span>{isMobileRuntime ? "Suggested file name" : "File name base"}</span>
                 <input onChange={(event) => setFilenameBase(event.target.value)} value={filenameBase} />

--- a/apps/desktop/src/features/projects/exportWorkspaceUtils.test.ts
+++ b/apps/desktop/src/features/projects/exportWorkspaceUtils.test.ts
@@ -340,13 +340,13 @@ describe("export workspace utilities", () => {
     };
     const androidCapabilities = capabilities({
       platform: "android",
-      formats: ["wav"],
+      formats: ["wav", "flac", "mp3", "m4a"],
       destinations: ["single_file"],
       maxArtifactCount: 1,
     });
 
     expect(androidAudioExportUnavailableReason(source)).toBeNull();
-    expect(androidAudioExportUnavailableReason(mp3Mix)).toMatch(/locally stored WAV/);
+    expect(androidAudioExportUnavailableReason(mp3Mix)).toBeNull();
     expect(reconcileExportWorkspaceState({
       storedState: {
         audioSetId: "source",
@@ -368,7 +368,7 @@ describe("export workspace utilities", () => {
       state: {
         selectedArtifactIds: ["source"],
         selectedGeneratedDocumentIds: [],
-        outputFormat: "wav",
+        outputFormat: "m4a",
         destinationType: "single_file",
         desktopDestinationTarget: null,
       },
@@ -379,6 +379,6 @@ describe("export workspace utilities", () => {
       filenameBase: "Demo Song",
       capabilities: androidCapabilities,
       defaultOutputFormat: "m4a",
-    })?.selectedArtifactIds).toEqual([]);
+    })?.selectedArtifactIds).toEqual(["mix"]);
   });
 });

--- a/apps/desktop/src/features/projects/exportWorkspaceUtils.ts
+++ b/apps/desktop/src/features/projects/exportWorkspaceUtils.ts
@@ -64,11 +64,8 @@ function availableOptionIds(
 }
 
 export function androidAudioExportUnavailableReason(artifact: ArtifactSchema) {
-  if (artifact.format.toLowerCase() !== "wav") {
-    return "Android can export only locally stored WAV audio without re-encoding.";
-  }
   if (!artifact.path.trim() || /^(?:content|https?):/i.test(artifact.path)) {
-    return "This WAV is not available as a locally readable project file.";
+    return "This audio artifact is not available as a locally readable project file.";
   }
   return null;
 }

--- a/apps/desktop/src/features/projects/hooks/useExportWorkspace.ts
+++ b/apps/desktop/src/features/projects/hooks/useExportWorkspace.ts
@@ -434,7 +434,7 @@ export function useExportWorkspace() {
               ...(selectedDocumentIds.includes("lyrics")
                 ? { generated_document_ids: ["lyrics"] as const }
                 : {}),
-              output_format: "wav",
+              output_format: selectedArtifacts.length ? outputFormat : "wav",
               filename_base: filenameBase.trim(),
               ...(selectedDocumentIds.length && audioSet ? {
                 document_audio_set_artifact_id: audioSet.artifact.id,

--- a/apps/desktop/src/features/settings/SettingsView.tsx
+++ b/apps/desktop/src/features/settings/SettingsView.tsx
@@ -769,7 +769,6 @@ export function SettingsView() {
     queryFn: api.listStemModels,
   });
   const exportCapabilitiesQuery = useQuery({
-    enabled: !androidRuntime,
     queryKey: DURABLE_AUDIO_CAPABILITIES_QUERY_KEY,
     queryFn: api.getExportCapabilities,
     staleTime: Infinity,
@@ -826,9 +825,7 @@ export function SettingsView() {
     exportCapabilitiesQuery.isError,
     defaultDurableAudioFormat,
   );
-  const androidSettings =
-    androidRuntime || exportCapabilitiesQuery.data?.capabilities.platform === "android";
-  const showAudioStoragePanel = !androidSettings;
+  const showAudioStoragePanel = true;
   const chordFallbackNotice =
     "Imports may use Built-in Chords if the saved backend is unavailable; generate, refresh, and bulk actions keep the saved backend.";
 
@@ -957,8 +954,7 @@ export function SettingsView() {
 
       const snapshot = parseSettingsSnapshot(contents);
       if (
-        !androidSettings
-        && snapshot.preferences.defaultDurableAudioFormat !== defaultDurableAudioFormat
+        snapshot.preferences.defaultDurableAudioFormat !== defaultDurableAudioFormat
         && !await confirmLossyDurableAudioFormat(snapshot.preferences.defaultDurableAudioFormat)
       ) {
         return;
@@ -1034,9 +1030,7 @@ export function SettingsView() {
           <p className="eyebrow">Settings</p>
           <h1>Control Room</h1>
           <p className="screen__subtitle">
-            {androidSettings
-              ? "App-wide appearance, notation, and playback defaults."
-              : "App-wide appearance, audio storage, notation, and playback defaults."}
+            App-wide appearance, audio storage, notation, and playback defaults.
           </p>
         </div>
       </div>
@@ -1145,7 +1139,7 @@ export function SettingsView() {
             <div>
               <h2 id="audio-storage-title">Audio Storage</h2>
               <p className="subpanel__copy">
-                Choose the storage format for new audio created on this desktop.
+                Choose the storage format for new durable audio.
               </p>
             </div>
           </div>
@@ -1168,7 +1162,9 @@ export function SettingsView() {
             <>
               {!exportCapabilitiesQuery.isFetching ? (
                 <p className="settings-feedback settings-feedback--error" role="alert">
-                  Audio format availability could not be checked. Check FFmpeg, then try again.
+                  {androidRuntime
+                    ? "Audio format availability could not be checked. Try again."
+                    : "Audio format availability could not be checked. Check FFmpeg, then try again."}
                 </p>
               ) : null}
               <div className="button-row">

--- a/apps/desktop/src/lib/api.mobile-sync.test.ts
+++ b/apps/desktop/src/lib/api.mobile-sync.test.ts
@@ -238,9 +238,9 @@ describe("mobile sync API adapter", () => {
       max_artifact_count: 1,
       formats: [
         { id: "wav", available: true },
-        { id: "flac", available: false },
-        { id: "mp3", available: false },
-        { id: "m4a", available: false },
+        { id: "flac", available: true },
+        { id: "mp3", available: true },
+        { id: "m4a", available: true },
       ],
       destinations: [
         { id: "single_file", available: true },
@@ -289,22 +289,19 @@ describe("mobile sync API adapter", () => {
   });
 
   it.each(["flac", "mp3", "m4a"] as const)(
-    "rejects %s durable import format on mobile before native invoke",
+    "forwards %s durable import format to the owned mobile converter",
     async (outputFormat) => {
       const api = await loadMobileApi();
 
-      await expect(
-        api.importProject({
-          source_path: "/music/song.wav",
-          copy_into_project: true,
-          output_format: outputFormat,
-        }),
-      ).rejects.toMatchObject({
-        code: "UNSUPPORTED_RUNTIME",
-        details: { output_format: outputFormat },
+      const request = {
+        source_path: "/music/song.wav",
+        copy_into_project: true,
+        output_format: outputFormat,
+      } as const;
+      await api.importProject(request);
+      expect(mockInvoke).toHaveBeenCalledWith("mobile_import_project", {
+        payload: request,
       });
-
-      expect(mockInvoke).not.toHaveBeenCalled();
     },
   );
 

--- a/apps/desktop/src/lib/api.ts
+++ b/apps/desktop/src/lib/api.ts
@@ -2500,16 +2500,6 @@ function createMobileTuneForgeClient(capabilities: MobileCapabilities): TuneForg
       });
     }
   };
-  const requireSupportedMobileImportFormat = (request: ProjectImportRequest) => {
-    if (request.output_format !== undefined && request.output_format !== "wav") {
-      throw new ApiError({
-        code: "UNSUPPORTED_RUNTIME",
-        message: "Selecting a compressed durable audio format is not available on mobile yet.",
-        details: { output_format: request.output_format },
-      });
-    }
-  };
-
   return {
     getMobileCapabilities: async () => capabilities,
     ensureWebMediaTransport,
@@ -2519,21 +2509,9 @@ function createMobileTuneForgeClient(capabilities: MobileCapabilities): TuneForg
         platform: "android",
         formats: [
           { id: "wav", available: true, reason: null },
-          {
-            id: "flac",
-            available: false,
-            reason: "Android exports existing WAV bytes and does not encode FLAC yet.",
-          },
-          {
-            id: "mp3",
-            available: false,
-            reason: "Android exports existing WAV bytes and does not encode MP3 yet.",
-          },
-          {
-            id: "m4a",
-            available: false,
-            reason: "Android exports existing WAV bytes and does not encode M4A yet.",
-          },
+          { id: "flac", available: true, reason: null },
+          { id: "mp3", available: true, reason: null },
+          { id: "m4a", available: true, reason: null },
         ],
         destinations: [
           { id: "single_file", available: true, reason: null },
@@ -2556,7 +2534,6 @@ function createMobileTuneForgeClient(capabilities: MobileCapabilities): TuneForg
     importProject: async (body: ProjectImportRequest) => {
       requireSupportedMobileAnalysisBackend(body);
       requireSupportedMobileChordBackend(body);
-      requireSupportedMobileImportFormat(body);
       return invokeMobile("mobile_import_project", { payload: body });
     },
     getProject: (projectId: string) => invokeMobile("mobile_get_project", { projectId }),

--- a/apps/desktop/src/lib/durableAudio.test.ts
+++ b/apps/desktop/src/lib/durableAudio.test.ts
@@ -32,7 +32,8 @@ describe("durable audio capability guard", () => {
 
   it("keeps Android actions on omitted-field WAV despite a hidden compressed preference", () => {
     expect(requireDurableAudioActionFormat(capabilities("android"), "m4a")).toEqual({
-      format: "wav",
+      format: "m4a",
+      outputFormat: "m4a",
     });
   });
 });

--- a/apps/desktop/src/lib/durableAudio.ts
+++ b/apps/desktop/src/lib/durableAudio.ts
@@ -59,14 +59,6 @@ export function requireDurableAudioActionFormat(
   capabilities: ExportCapabilities,
   preferredFormat: DurableAudioFormat,
 ): DurableAudioActionFormat {
-  if (capabilities.platform === "android") {
-    const wav = capabilities.formats.find((format) => format.id === "wav");
-    if (!wav?.available) {
-      throw new Error(wav?.reason || "WAV durable audio is unavailable on this device.");
-    }
-    return { format: "wav" };
-  }
-
   const capability = capabilities.formats.find((format) => format.id === preferredFormat);
   if (!capability?.available) {
     const label = durableAudioFormatLabel(preferredFormat);

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -52,7 +52,8 @@ Desktop uses:
 - FastAPI backend bound to `127.0.0.1`.
 - SQLite database and local filesystem artifacts.
 - Python engines for audio analysis, lyrics, stems, and transforms.
-- Host-installed `ffmpeg` and `ffprobe` for desktop transform/export work.
+- FFmpeg conversion through host tools in development, an owned LGPL runtime in packaged macOS,
+  and Flatpak runtime wrappers on Linux.
 
 Development normally runs two local processes:
 
@@ -60,7 +61,8 @@ Development normally runs two local processes:
 React/Tauri frontend -> http://127.0.0.1:8765/api/v1 -> FastAPI backend
 ```
 
-Packaged desktop builds launch the bundled backend process from the Tauri shell and still require host FFmpeg/FFprobe.
+Packaged desktop builds launch the bundled backend process from the Tauri shell. macOS arm64 resolves
+absolute executables from its owned runtime and supplies its library path to child processes.
 
 ## Mobile Runtime
 
@@ -216,19 +218,22 @@ Validation failures return `INVALID_REQUEST` with serialized validation details.
 
 ## Packaging Constraints
 
-- FFmpeg is a host dependency and is not bundled.
+- Development keeps host FFmpeg resolution and explicit overrides. Packaged macOS arm64 owns its
+  verified LGPL runtime; Flatpak owns no Linux payload and resolves only inside its runtime.
 - Normal Tauri project playback, metronome output, and tuner microphone capture use the native
   audio control plane. Native failure remains terminal until a later explicit action; it does not
   fall back to Web Audio. Browser, non-Tauri, and forced-Web Tauri builds use Web Audio.
 - Native desktop tempo playback uses `signalsmith-stretch` for pitch preservation.
-- Native desktop playback decodes local files through a WAV fast path or Symphonia. FFmpeg remains a host dependency for transform/export work.
+- Native desktop playback decodes local files through a WAV fast path or Symphonia. FFmpeg remains
+  separate conversion infrastructure and does not replace realtime playback.
 - Native audio development notes live in [NATIVE_AUDIO.md](NATIVE_AUDIO.md).
 - Cross-platform wake, sleep, and power-inhibition behavior lives in [POWER_PROTECTION.md](POWER_PROTECTION.md).
 - Desktop system microphone volume control uses CoreAudio on macOS, or host `wpctl`/`pactl` tools on Linux with an active PipeWire/PulseAudio session.
 - Advanced Chords and Advanced Beat Analysis are default desktop/dev/package engines. Advanced Chords uses ONNX Runtime and packages the exact pinned converted Crema model/state; the Crema Python package, TensorFlow, and Keras are absent. Packaged builds must treat ONNX Runtime, model provenance, beat-this, and their runtime dependencies as default-runtime notice scope. Built-in chord and beat engines remain fallback paths when advanced dependencies are unavailable, unsupported, or explicitly excluded.
 - Demucs and lyrics models follow first-use local download/cache behavior.
 - The Linux legacy NVIDIA profile is an opt-in local backend environment override; it does not change the default lockfile, CI setup, or packaged dependency baseline.
-- Mobile avoids FFmpeg and uses platform media APIs where possible.
+- Android arm64 uses a narrow in-process FFmpeg bridge for durable conversion and keeps platform
+  media APIs plus Symphonia/Signalsmith for existing playback and validation paths.
 - Mobile does not run the desktop Python/FastAPI backend today.
 
 ## Extensibility Rules

--- a/docs/MOBILE.md
+++ b/docs/MOBILE.md
@@ -6,8 +6,8 @@ TuneForge mobile is Android-first and keeps the local-only product rule: no acco
 
 The mobile app includes its backend inside the Tauri app. It does not run the desktop Python/FastAPI backend on Android.
 
-- Desktop: React -> Tauri -> FastAPI -> Python engines -> host FFmpeg -> SQLite/filesystem.
-- Mobile: React -> Tauri commands -> embedded Rust/Kotlin backend -> Android media APIs -> SQLite/filesystem.
+- Desktop: React -> Tauri -> FastAPI -> Python engines -> platform FFmpeg runtime -> SQLite/filesystem.
+- Mobile: React -> Tauri commands -> embedded Rust/Kotlin backend -> owned FFmpeg conversion plus Android media APIs -> SQLite/filesystem.
 
 The frontend talks through a `TuneForgeClient` boundary. Desktop uses the existing generated OpenAPI HTTP client. Mobile uses Tauri commands that return the same project, job, artifact, lyrics, chord, and analysis response shapes where possible.
 
@@ -79,31 +79,32 @@ The supported lookup priority is `ggml-base.bin`, `ggml-base.en.bin`, `ggml-tiny
 
 ## FFmpeg Policy
 
-Mobile does not bundle FFmpeg. Android uses platform media APIs instead.
+Android arm64, API 26+, packages the audited LGPL FFmpeg/LAME runtime. Rust owns operation lifetime,
+cancellation, staging, validation, and persistence; a narrow C shim owns opaque libav contexts.
 
-- Import keeps the original file inside app storage.
-- WAV/PCM can be read directly for CPU analysis and basic chord detection.
-- Compressed audio should decode through Android media APIs before waveform or ML processing.
-- Android receives and preserves app-owned PCM16 WAV, FLAC, MP3, and AAC-LC M4A audio. Platform
-  decoding remains a runtime capability; mobile does not expose the desktop storage preference or
-  add an encoder.
-- Desktop currently keeps WAV intermediates and `wav`/`mp3`/`flac` exports through host-installed FFmpeg.
-- Unsupported mobile export formats stay unavailable until a native encoder path exists.
+- Import decodes the selected first audio stream and creates the requested durable WAV/PCM16,
+  FLAC level 5, MP3 192 kbps, or AAC-LC M4A 192 kbps artifact in app storage.
+- Analysis and realtime playback keep their existing WAV, Android media, Symphonia, and
+  Signalsmith paths. The conversion engine does not replace them.
+- Preview, retune, and transpose use bounded in-process conversion on background workers, validate
+  before promotion, and compensate failed or interrupted filesystem/database work.
+- Source hashes identify the selected input; artifact hashes always describe the converted bytes.
+- Network, GPL, nonfree, version3, and unused FFmpeg features are disabled.
 
 ## Android Export
 
 The project Export workspace uses Android's native create-document picker for exactly one
-deliverable at a time. The available choices are a locally readable WAV artifact, saved Lyrics as
-UTF-8 TXT, or saved Lyrics + chords as UTF-8 TXT. FLAC, MP3, M4A, folder, and ZIP export remain
-unavailable because this path does not encode audio or assemble multi-file packages.
+deliverable at a time. Existing local audio artifacts can be serialized as WAV, FLAC, MP3, or M4A;
+saved Lyrics and Lyrics + chords remain UTF-8 TXT. Folder and ZIP export remain unavailable.
 
 The renderer sends only the selected artifact or document, a suggested file-name base, and document
 chord context. It never supplies a destination or URI. The native picker owns the fresh provider
 grant, final name, location, and collision behavior. TuneForge does not retain `content://` state in
 the Export draft and does not delete provider-owned output.
 
-WAV bytes stream directly from app-local project storage without decoding or re-encoding. TXT is
-rendered from a snapshot of the current saved lyrics and chords in memory and is never staged under
+Audio is converted from the selected saved artifact only. Export does not create a practice mix or
+apply current playback tempo, tuning, pitch, gains, or mutes. TXT is rendered from a snapshot of the
+current saved lyrics and chords in memory and is never staged under
 project storage. Lyrics + chords uses the selected Source Track or Practice Mix as its chord context,
 including corrected source key, mix transpose, and the current enharmonic display mode. Retune-only
 mixes do not transpose chord labels.

--- a/docs/PACKAGING.md
+++ b/docs/PACKAGING.md
@@ -1,6 +1,6 @@
 # Packaging
 
-TuneForge packaging creates local unsigned desktop builds. Packaged builds launch the bundled backend locally and include Advanced Chords, Advanced Beat Analysis, and LV Chordia by default. LV Chordia includes five dependency-owned MIT checkpoints (28,730,939 bytes); other external model weights remain excluded by default. TuneForge does not bundle FFmpeg: macOS packages use host-installed `ffmpeg` and `ffprobe`, while Flatpak routes backend lookups through sandbox wrappers at `/app/bin/ffmpeg` and `/app/bin/ffprobe`.
+TuneForge packaging creates local unsigned desktop builds. Packaged builds launch the bundled backend locally and include Advanced Chords, Advanced Beat Analysis, and LV Chordia by default. LV Chordia includes five dependency-owned MIT checkpoints (28,730,939 bytes); other external model weights remain excluded by default. macOS arm64 and Android arm64 own the pinned LGPL FFmpeg/LAME runtime. Flatpak owns no codec payload and routes lookup through sandbox wrappers.
 
 See [Third-party notices](../THIRD_PARTY_NOTICES.md) for the dependency and model-weight distribution policy.
 
@@ -12,7 +12,7 @@ See [Third-party notices](../THIRD_PARTY_NOTICES.md) for the dependency and mode
 - Source distribution is the repository checkout or source archive from version control. These package commands do not create a separate source tarball.
 - Packaging, model-bundle review, ONNX Advanced Chords, beat-this, CUDA/MPS/legacy NVIDIA GPU behavior, and install smoke checks are manual or special coverage unless a CI workflow explicitly runs them.
 - Release/default package commands do not use `--model-bundle`. Publishable model-bundled artifacts require an explicit review of the selected weights and package distribution evidence.
-- Default packages may still download Demucs, Whisper, or beat-this weights on first use when caches are missing. Fully offline operation requires host/sandbox FFmpeg access plus the relevant local caches or package assets to already exist.
+- Default packages may still download Demucs, Whisper, or beat-this weights on first use when caches are missing. Fully offline operation requires the packaged/platform FFmpeg runtime plus the relevant local caches or package assets to already exist.
 - Advanced Chords uses ONNX Runtime. Every package that enables it includes the exact pinned 2.2 MB converted model, runtime state, and Brian McFee BSD-2-Clause notice; startup verifies and seeds the normal cache. This is independent of the broader `--model-bundle` option.
 - LV Chordia checkpoints ship inside its pinned dependency for offline first use. `--no-lv-chordia` excludes both the runtime and checkpoints; damaged assets fail closed and are repaired by reinstalling.
 
@@ -102,7 +102,7 @@ For the macOS DMG, install or open the packaged app and confirm:
 - the UI loads and core navigation is usable;
 - Settings/About release identity is visible;
 - observed behavior matches the package policy above: unsigned/not-notarized local builds, no
-  bundled FFmpeg, and no external Demucs, Whisper, or beat-this model weights unless
+  external Demucs, Whisper, or beat-this model weights unless
   `--model-bundle` was explicitly reviewed and used.
 
 For the Android APK, install it on an isolated emulator or device and confirm:
@@ -155,6 +155,37 @@ signing, notarization, checksums, or GitHub Release upload.
 
 ## macOS
 
+### Owned FFmpeg sources and rebuild
+
+[`packaging/ffmpeg/sources.lock.json`](../packaging/ffmpeg/sources.lock.json) pins the FFmpeg and LAME
+versions, archive hashes, FFmpeg signing key, local patch hash, configure policy, targets, libraries,
+and codec profiles. Build and validate a target with:
+
+```sh
+pnpm ffmpeg:sources
+pnpm ffmpeg:build -- --target macos-arm64
+pnpm ffmpeg:validate -- --target macos-arm64 --root packaging/ffmpeg/generated/macos-arm64
+ANDROID_NDK_HOME=/path/to/android-ndk pnpm ffmpeg:build -- --target android-arm64-v8a
+LLVM_READELF=/path/to/android-ndk/toolchains/llvm/prebuilt/darwin-x86_64/bin/llvm-readelf \
+  pnpm ffmpeg:validate -- --target android-arm64-v8a \
+  --root packaging/ffmpeg/generated/android-arm64-v8a
+```
+
+The recipe verifies every archive before extraction and verifies FFmpeg's detached signature in an
+isolated keyring against the signing key pinned by the source lock. LAME publishes no
+signature/checksum sidecar; its official HTTPS archive is pinned by reviewed SHA-256. Generated
+payload provenance records exact sources, flags, file hashes, sizes, architecture, and linkage.
+Validators reject symlinks, unrecorded files, GPL/nonfree/version3/network flags, extra libraries,
+and dependencies outside the owned/system closure.
+
+Every target build also writes the corresponding-sources archive and its SHA-256 sidecar under
+`packaging/ffmpeg/generated/`. The deterministic companion contains the complete pinned upstream archives,
+FFmpeg signature and key, TuneForge patch, exact recipe, source lock, validation code, notices, and
+an internal file manifest. Its hash is bound into each target's provenance. Distribute this
+companion with owned-runtime binaries and retain it for the LGPL offer period required by the
+license. Recipients can extract it over the matching TuneForge source release, rebuild either
+target, replace `packaging/ffmpeg/generated/<target>`, re-run validation, and package normally.
+
 Build the app bundle and DMG with:
 
 ```sh
@@ -192,7 +223,10 @@ The generated artifacts are written under `apps/desktop/src-tauri/target/release
 
 Run packaging from a normal macOS shell so `hdiutil` can create the disk image. The generated app is unsigned and not notarized.
 
-The packaged backend checks the inherited `PATH` plus common Homebrew and MacPorts install locations when looking for `ffmpeg` and `ffprobe`. System microphone volume control uses the built-in CoreAudio API on macOS.
+The packaged backend resolves absolute `ffmpeg`/`ffprobe` paths inside the app and prepends the
+owned `bin`/`lib` directories for Demucs child processes. Missing or invalid payloads fail package
+preparation or launch clearly; validators reject Homebrew/MacPorts linkage. Development keeps host
+lookup and explicit overrides. System microphone volume control uses CoreAudio.
 
 By default, Demucs, Whisper, and beat-this weights are read from their normal caches and downloaded on first use if missing. Demucs uses immutable Hugging Face YAML+safetensors in the standard Hub cache: `HF_HUB_CACHE`, legacy `HUGGINGFACE_HUB_CACHE`, `HF_HOME/hub`, `XDG_CACHE_HOME/huggingface/hub`, then `~/.cache/huggingface/hub`. `TUNEFORGE_DATA_DIR` does not control the upstream Demucs, Whisper, or beat-this caches. Advanced Chords always stages the exact verified ONNX model and runtime state so packaged startup can seed `TUNEFORGE_DATA_DIR/cache/models/crema/` offline. It excludes the Crema Python package, TensorFlow, Keras, and their HDF5 model-loading closure; preserved LV Chordia support still brings its declared `h5py` dependency. LV Chordia ships exactly five validated checkpoints. `--model-bundle` independently stages required Demucs and Whisper weights, plus beat-this `small0` when included; Demucs is validated and loaded directly from its pinned bundle path without copying into the Hugging Face cache.
 
@@ -209,7 +243,14 @@ pnpm package:android:release
 ```
 
 Preparation owns toolchain validation, conditional Tauri Android initialization, icon generation,
-and generated-project preparation. All three build commands require this state and never prepare it.
+generated-project preparation, and staging the six audited shared libraries plus notices and
+provenance. All three build commands require this state and never prepare it. The owned target is
+arm64-v8a, API 26+, and every ELF LOAD segment must be aligned to at least 16 KB.
+
+Release validation checks the APK's single arm64-v8a payload, every shipped native dependency,
+owned-library closure, DEX/JNI entry points, notices/provenance, and `zipalign -P 16`. AAB release
+evidence must also use bundletool to generate APKs and repeat the same checks on the generated APK;
+the publication shape remains the existing single APK.
 
 The release command creates a direct GitHub Release APK. Its dedicated long-lived key provides a
 stable signing/update identity for sideloaded APKs. PKCS12 is the only supported release-key
@@ -351,7 +392,7 @@ with `node scripts/refresh-flatpak-torch-locks.mjs --cpu` or `--legacy-nvidia`, 
 closure, license inventory, and synchronized Node/Rust profile pair ID. NVIDIA derives from the
 committed backend `uv.lock` and is verified against its reviewed profile pair during source generation.
 
-Flatpak runtime lookups are not host `PATH` lookups. The manifest sets `TUNEFORGE_FFMPEG_PATH=/app/bin/ffmpeg` and `TUNEFORGE_FFPROBE_PATH=/app/bin/ffprobe`; those files are wrappers that search for `ffmpeg` and `ffprobe` inside the sandbox runtime/extension paths. If the runtime does not provide them, the Flatpak build or app reports the missing sandbox binary rather than falling back to the host shell.
+Flatpak runtime lookups are not host `PATH` lookups. The manifest sets `TUNEFORGE_FFMPEG_PATH=/app/bin/ffmpeg` and `TUNEFORGE_FFPROBE_PATH=/app/bin/ffprobe`; those files are wrappers that search for `ffmpeg` and `ffprobe` inside the sandbox runtime/extension paths. Flatpak ships zero owned FFmpeg/LAME payload and never falls back to host tools. Before release, audit the resolved GNOME 50 runtime/extension revision, binaries, licenses, linkage, and the full conversion matrix inside that exact sandbox.
 
 Plain Linux packages include ONNX Advanced Chords, beat-this Advanced Beat Analysis, and LV
 Chordia dependency stacks by default. Feature flags are independent:

--- a/docs/REFERENCES.md
+++ b/docs/REFERENCES.md
@@ -43,7 +43,7 @@ TuneForge differences:
 - no account or cloud processing requirement
 - desktop-first complete workflow
 - Android/mobile as a local companion direction
-- host-installed FFmpeg policy on desktop
+- audited LGPL FFmpeg ownership policy and platform-specific runtime resolution
 
 ### Transcription-oriented tools
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -49,8 +49,9 @@ a file, folder, or ZIP as appropriate; and supports WAV, FLAC, MP3, and M4A/AAC.
 
 Desktop and Android must expose their real encoder and destination capabilities.
 An unavailable combination is disabled or explained, never presented as a
-working action. TuneForge remains local-only and continues to rely on
-host-installed FFmpeg on desktop rather than bundling it.
+working action. TuneForge remains local-only. Development uses host-installed
+FFmpeg; packaged macOS and Android use the audited owned LGPL runtime; Flatpak
+uses only the pinned sandbox runtime or extension.
 
 Desktop lyrics and lyrics-with-chords TXT export from
 [#387](https://github.com/grazzolini/tuneforge/issues/387) and

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -13,7 +13,8 @@ TuneForge is not a SaaS product, web service, or multi-user system. It has no ac
 - Desktop is the complete supported workflow for import, local analysis/generation, playback practice, and export.
 - Android/mobile remains an in-progress local companion path, not a replacement for desktop processing.
 - macOS and Linux packages are local unsigned build artifacts until release signing/notarization work exists.
-- Host-installed `ffmpeg` and `ffprobe` remain required; TuneForge does not bundle FFmpeg.
+- Development uses host-installed `ffmpeg` and `ffprobe`; packaged macOS arm64 and Android arm64
+  ship an audited LGPL conversion runtime, while Flatpak owns no Linux codec payload.
 - Advanced Chords, Advanced Beat Analysis, GPU acceleration, loopback/browser playback, BlackHole capture, and virtual-output capture require manual or special validation unless a CI workflow explicitly covers them.
 
 ## Product Goals
@@ -31,7 +32,7 @@ TuneForge is not a SaaS product, web service, or multi-user system. It has no ac
 - Cloud processing, remote storage, user accounts, telemetry, or hosted collaboration.
 - Network-exposed backend deployment, public API hosting, reverse-proxy usage, or multi-user authorization.
 - Full DAW, production, mastering, or generic audio-editor workflows.
-- Bundling FFmpeg. Desktop builds rely on host-installed `ffmpeg` and `ffprobe`.
+- General-purpose FFmpeg distributions. Owned packages use the pinned, audited LGPL feature set.
 - Guaranteeing generated chords, lyrics, tempo, or stems as ground truth. Outputs are editable practice aids.
 
 ## Users and Workflows
@@ -122,11 +123,11 @@ Capo-relative display is a harmonic presentation feature. It should not alter au
 - Generate cached previews for practice before export.
 - Use the dedicated project Export workspace to target one Source Track or Practice Mix at a time.
 - Export the track, selected stems, all stems, or the track with all stems. Desktop multi-file exports
-  can target a folder or ZIP. Android exports exactly one locally readable WAV through the native
+  can target a folder or ZIP. Android exports exactly one locally readable audio artifact through the native
   create-document picker and does not expose an encoder, folder, or ZIP workflow.
 - Export saved Lyrics or Lyrics + chords as UTF-8 TXT. Desktop can export them alone or in the same ordered
   folder or ZIP batch as audio. Missing lyrics or chords remain visible with a Studio-directed reason.
-- Android offers one WAV, Lyrics TXT, or Lyrics + chords TXT in one unified choice. The selected Source
+- Android offers one WAV, FLAC, MP3, M4A, Lyrics TXT, or Lyrics + chords TXT in one unified choice. The selected Source
   Track or Practice Mix remains a separate chord context for document-only export.
 - Keep plain Lyrics TXT source-faithful. Spell and transpose Lyrics + chords TXT for the selected
   Source Track or Practice Mix, using the current enharmonic display setting and any corrected
@@ -141,7 +142,8 @@ Capo-relative display is a harmonic presentation feature. It should not alter au
   written size and SHA-256. Unsupported readback completes as unverified without a receipt; mismatch,
   cancellation, or restart fails or cancels without a receipt, retry, provider deletion, or stale URI.
 - Preserve deterministic, friendly output names based on the project, audio set, and stem label.
-- Desktop transform/export paths use host-installed FFmpeg.
+- Desktop transform/export paths use host FFmpeg in development, the owned runtime in packaged
+  macOS, and runtime-owned wrappers in Flatpak.
 
 ### Playback and Practice UX
 

--- a/package.json
+++ b/package.json
@@ -5,6 +5,10 @@
   "scripts": {
     "build:packaged-frontend": "node scripts/build-packaged-frontend.mjs",
     "bundle:prepare": "node scripts/prepare-bundle.mjs",
+    "ffmpeg:build": "node scripts/build-ffmpeg.mjs",
+    "ffmpeg:sources": "node scripts/build-ffmpeg.mjs --source-only",
+    "ffmpeg:validate": "node scripts/validate-packaged-ffmpeg.mjs",
+    "ffmpeg:test-shim": "node scripts/test-ffmpeg-shim.mjs",
     "chords:benchmark": "bash -c 'if [[ \"${1:-}\" == \"--\" ]]; then shift; fi; exec bash scripts/run-backend-module.sh app.benchmarks.chords \"$@\"' --",
     "contracts:generate": "pnpm --filter @tuneforge/shared-types generate",
     "dev": "concurrently -n backend,desktop -c blue,green \"pnpm dev:backend\" \"pnpm dev:desktop\"",

--- a/packaging/ffmpeg/patches/lame-unversioned-shared.patch
+++ b/packaging/ffmpeg/patches/lame-unversioned-shared.patch
@@ -1,0 +1,10 @@
+--- a/libmp3lame/Makefile.in
++++ b/libmp3lame/Makefile.in
+@@ -438,7 +438,7 @@
+ libmp3lame_la_LIBADD = $(cpu_ldadd) $(vector_ldadd) $(decoder_ldadd) \
+ 			@LIBMP3LAME_LDADD@ $(CONFIG_MATH_LIB)
+ 
+-libmp3lame_la_LDFLAGS = -version-info @LIB_MAJOR_VERSION@:@LIB_MINOR_VERSION@ \
++libmp3lame_la_LDFLAGS = -avoid-version \
+ 			-export-symbols $(top_srcdir)/include/libmp3lame.sym \
+ 			-no-undefined

--- a/packaging/ffmpeg/sources.lock.json
+++ b/packaging/ffmpeg/sources.lock.json
@@ -1,0 +1,77 @@
+{
+  "schemaVersion": 1,
+  "runtimeVersion": "ffmpeg-9.0.1-lame-4.0-1",
+  "targets": {
+    "macos-arm64": {
+      "minimumOsVersion": "13.0",
+      "architecture": "arm64",
+      "programs": ["ffmpeg", "ffprobe"],
+      "libraries": [
+        "libavcodec",
+        "libavfilter",
+        "libavformat",
+        "libavutil",
+        "libswresample",
+        "libmp3lame"
+      ]
+    },
+    "android-arm64-v8a": {
+      "apiLevel": 26,
+      "architecture": "aarch64",
+      "abi": "arm64-v8a",
+      "programs": [],
+      "libraries": [
+        "libavcodec",
+        "libavfilter",
+        "libavformat",
+        "libavutil",
+        "libswresample",
+        "libmp3lame"
+      ]
+    }
+  },
+  "sources": {
+    "ffmpeg": {
+      "version": "9.0.1",
+      "url": "https://ffmpeg.org/releases/ffmpeg-9.0.1.tar.xz",
+      "sha256": "cf38e0e28c7e5605942c4a77755349b0145804a397af37eb1fb4c77cb237f635",
+      "signatureUrl": "https://ffmpeg.org/releases/ffmpeg-9.0.1.tar.xz.asc",
+      "signatureSha256": "b613a00005232a1245ace7080088781ac23a916119d3e5b0d6c042368eee0177",
+      "signingKeyUrl": "https://ffmpeg.org/ffmpeg-devel.asc",
+      "signingKeySha256": "397b3becedcd5a98769967ff1ff8501ddc89f8368b8f766e4701377d7dbaabe5",
+      "signingFingerprint": "FCF986EA15E6E293A5644F10B4322F04D67658D8",
+      "license": "LGPL-2.1-or-later",
+      "sourceDirectory": "ffmpeg-9.0.1"
+    },
+    "lame": {
+      "version": "4.0",
+      "url": "https://downloads.sourceforge.net/project/lame/lame/4.0/lame-4.0.tar.gz",
+      "sha256": "3df5124d5ad3a98312ffd7ba6a9b36230e4f8a3e66d3ce0f425e336c32d216eb",
+      "license": "LGPL-2.0-or-later",
+      "sourceDirectory": "lame-4.0",
+      "verification": "HTTPS upstream archive pinned after local review; upstream publishes no detached signature or checksum sidecar."
+    }
+  },
+  "patches": [
+    {
+      "path": "packaging/ffmpeg/patches/lame-unversioned-shared.patch",
+      "sha256": "c8c5176924a3a3d6af6159c9f9295aaab88a6325352b99eb5637aabe811ae676",
+      "appliesTo": "lame-4.0",
+      "purpose": "Use an unversioned dynamic-library SONAME accepted by Android jniLibs and relocatable macOS packaging."
+    }
+  ],
+  "policy": {
+    "licenseFlagsRequired": ["--disable-gpl", "--disable-nonfree", "--disable-version3"],
+    "networkFlagsRequired": ["--disable-network"],
+    "forbiddenLibraries": ["libavdevice", "libpostproc", "libswscale"],
+    "inputContainers": ["aac", "flac", "matroska", "mov", "mp3", "ogg", "wav"],
+    "inputAudioCodecs": ["aac", "alac", "flac", "mp3", "opus", "pcm", "vorbis"],
+    "outputProfiles": {
+      "wav": "PCM signed 16-bit little-endian",
+      "flac": "FLAC compression level 5",
+      "mp3": "LAME 192 kbps",
+      "m4a": "AAC-LC 192 kbps in ISO BMFF"
+    },
+    "filters": ["amix", "aresample", "asetrate", "atempo", "aformat", "anull"]
+  }
+}

--- a/scripts/android-prepare-generated.sh
+++ b/scripts/android-prepare-generated.sh
@@ -10,6 +10,9 @@ MAIN_ACTIVITY="$ANDROID_MAIN/java/com/tuneforge/desktop/MainActivity.kt"
 POWER_SERVICE="$ANDROID_MAIN/java/com/tuneforge/desktop/PowerInhibitionService.kt"
 PROGUARD_RULES="$ROOT_DIR/apps/desktop/src-tauri/proguard-tuneforge.pro"
 PROGUARD_DEST="$ROOT_DIR/apps/desktop/src-tauri/gen/android/app/proguard-tuneforge.pro"
+FFMPEG_ROOT="${TUNEFORGE_ANDROID_FFMPEG_ROOT:?TUNEFORGE_ANDROID_FFMPEG_ROOT is required}"
+FFMPEG_JNI_DIR="$ANDROID_MAIN/jniLibs/arm64-v8a"
+FFMPEG_ASSET_DIR="$ANDROID_MAIN/assets/ffmpeg"
 
 if [[ ! -f "$MANIFEST" || ! -f "$MAIN_ACTIVITY" || ! -d "$ANDROID_RES" ]]; then
   echo "Android project is not initialized. Run pnpm --filter @tuneforge/desktop tauri android init first." >&2
@@ -22,6 +25,24 @@ if [[ ! -f "$PROGUARD_RULES" ]]; then
 fi
 
 cp "$PROGUARD_RULES" "$PROGUARD_DEST"
+
+copy_owned_ffmpeg_runtime() {
+  local required=(libavcodec.so libavfilter.so libavformat.so libavutil.so libswresample.so libmp3lame.so)
+  mkdir -p "$FFMPEG_JNI_DIR" "$FFMPEG_ASSET_DIR/licenses"
+  find "$FFMPEG_JNI_DIR" -maxdepth 1 -type f \( -name 'libav*.so' -o -name 'libswresample.so' -o -name 'libmp3lame.so' \) -delete
+  local library
+  for library in "${required[@]}"; do
+    if [[ ! -f "$FFMPEG_ROOT/lib/$library" ]]; then
+      echo "Verified Android FFmpeg library missing: $FFMPEG_ROOT/lib/$library" >&2
+      exit 1
+    fi
+    cp "$FFMPEG_ROOT/lib/$library" "$FFMPEG_JNI_DIR/$library"
+  done
+  cp "$FFMPEG_ROOT/provenance.json" "$FFMPEG_ASSET_DIR/provenance.json"
+  cp "$FFMPEG_ROOT/licenses/"*.txt "$FFMPEG_ASSET_DIR/licenses/"
+}
+
+copy_owned_ffmpeg_runtime
 
 copy_android_icons() {
   if [[ ! -d "$ANDROID_ICONS" ]]; then

--- a/scripts/android-prepare-generated.test.mjs
+++ b/scripts/android-prepare-generated.test.mjs
@@ -41,7 +41,18 @@ function generatedProject(t) {
   fs.mkdirSync(path.join(icons, "values"), { recursive: true });
   fs.writeFileSync(path.join(icons, "values/ic_launcher_background.xml"), "<resources />\n");
 
-  execFileSync(script, { cwd: root });
+  const ffmpeg = path.join(root, "owned-ffmpeg");
+  fs.mkdirSync(path.join(ffmpeg, "lib"), { recursive: true });
+  fs.mkdirSync(path.join(ffmpeg, "licenses"), { recursive: true });
+  for (const library of ["libavcodec.so", "libavfilter.so", "libavformat.so", "libavutil.so",
+    "libswresample.so", "libmp3lame.so"]) {
+    fs.writeFileSync(path.join(ffmpeg, "lib", library), `fixture ${library}\n`);
+  }
+  fs.writeFileSync(path.join(ffmpeg, "provenance.json"), "{}\n");
+  fs.writeFileSync(path.join(ffmpeg, "licenses", "FFmpeg-COPYING.LGPLv2.1.txt"), "fixture\n");
+  fs.writeFileSync(path.join(ffmpeg, "licenses", "LAME-COPYING.LGPL-2.0.txt"), "fixture\n");
+
+  execFileSync(script, { cwd: root, env: { ...process.env, TUNEFORGE_ANDROID_FFMPEG_ROOT: ffmpeg } });
   return {
     activity: fs.readFileSync(path.join(java, "MainActivity.kt"), "utf8"),
     service: fs.readFileSync(path.join(java, "PowerInhibitionService.kt"), "utf8"),

--- a/scripts/build-ffmpeg.mjs
+++ b/scripts/build-ffmpeg.mjs
@@ -1,0 +1,468 @@
+import { createHash } from "node:crypto";
+import {
+  chmodSync,
+  copyFileSync,
+  cpSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  realpathSync,
+  readdirSync,
+  rmSync,
+  statSync,
+  lstatSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { createFlatpakSourceSnapshot } from "./flatpak-source-snapshots.mjs";
+
+const scriptPath = fileURLToPath(import.meta.url);
+const workspaceRoot = path.resolve(path.dirname(scriptPath), "..");
+const lockPath = path.join(workspaceRoot, "packaging", "ffmpeg", "sources.lock.json");
+const lock = JSON.parse(readFileSync(lockPath, "utf8"));
+
+const COMMON_COMPONENTS = [
+  "--disable-everything",
+  "--disable-autodetect",
+  "--disable-debug",
+  "--disable-doc",
+  "--disable-gpl",
+  "--disable-network",
+  "--disable-nonfree",
+  "--disable-version3",
+  "--disable-avdevice",
+  "--disable-swscale",
+  "--enable-avcodec",
+  "--enable-avfilter",
+  "--enable-avformat",
+  "--enable-avutil",
+  "--enable-swresample",
+  "--enable-libmp3lame",
+  "--enable-protocol=file,pipe",
+  "--enable-demuxer=aac,flac,matroska,mov,mp3,ogg,wav",
+  "--enable-muxer=adts,flac,ipod,mp3,mp4,ogg,wav",
+  "--enable-decoder=aac,aac_fixed,alac,flac,mp3,mp3float,opus,vorbis",
+  "--enable-decoder=pcm_alaw,pcm_f32be,pcm_f32le,pcm_f64be,pcm_f64le,pcm_mulaw",
+  "--enable-decoder=pcm_s16be,pcm_s16le,pcm_s24be,pcm_s24le,pcm_s32be,pcm_s32le",
+  "--enable-decoder=pcm_s8,pcm_u16be,pcm_u16le,pcm_u24be,pcm_u24le,pcm_u32be,pcm_u32le,pcm_u8",
+  "--enable-encoder=aac,flac,libmp3lame,pcm_s16le",
+  "--enable-parser=aac,flac,mpegaudio,opus,vorbis",
+  "--enable-filter=amix,aformat,anull,aresample,asetrate,atempo",
+];
+
+function fail(message) {
+  throw new Error(message);
+}
+
+function run(command, args, options = {}) {
+  const result = spawnSync(command, args, {
+    cwd: options.cwd ?? workspaceRoot,
+    env: { ...process.env, ...options.env },
+    stdio: options.capture ? "pipe" : "inherit",
+    encoding: "utf8",
+  });
+  if (result.error) throw result.error;
+  if (result.status !== 0) {
+    fail(`${command} exited ${result.status}${result.stderr ? `: ${result.stderr.trim()}` : ""}`);
+  }
+  return result.stdout ?? "";
+}
+
+function sha256(filePath) {
+  return createHash("sha256").update(readFileSync(filePath)).digest("hex");
+}
+
+export function verifyFile(filePath, expected, label) {
+  if (!existsSync(filePath)) fail(`${label} missing: ${filePath}`);
+  const actual = sha256(filePath);
+  if (actual !== expected) fail(`${label} SHA-256 mismatch: expected ${expected}, got ${actual}`);
+}
+
+function parseArgs(argv) {
+  const args = argv[0] === "--" ? argv.slice(1) : argv;
+  let target = null;
+  let cacheDir = path.join(workspaceRoot, "packaging", "ffmpeg", "cache");
+  let outputDir = null;
+  let sourceOnly = false;
+  let jobs = String(Math.max(1, Number(process.env.TUNEFORGE_FFMPEG_BUILD_JOBS ?? 4)));
+  for (let index = 0; index < args.length; index += 1) {
+    const value = args[index];
+    if (value === "--target") target = args[++index];
+    else if (value === "--cache-dir") cacheDir = path.resolve(args[++index]);
+    else if (value === "--output-dir") outputDir = path.resolve(args[++index]);
+    else if (value === "--jobs") jobs = args[++index];
+    else if (value === "--source-only") sourceOnly = true;
+    else fail(`Unknown option: ${value}`);
+  }
+  if (!sourceOnly && !Object.hasOwn(lock.targets, target)) {
+    fail("--target must be macos-arm64 or android-arm64-v8a");
+  }
+  if (sourceOnly && (target || outputDir)) fail("--source-only cannot be combined with --target or --output-dir");
+  return {
+    target,
+    cacheDir,
+    outputDir: outputDir ?? path.join(
+      workspaceRoot,
+      "packaging",
+      "ffmpeg",
+      "generated",
+      sourceOnly ? "source-only" : target,
+    ),
+    jobs,
+    sourceOnly,
+  };
+}
+
+function archivePath(cacheDir, source) {
+  return path.join(cacheDir, new URL(source.url).pathname.split("/").pop());
+}
+
+function materializeCorrespondingSources(cacheDir, outputParent) {
+  const fileName = `TuneForge_${lock.runtimeVersion}_corresponding-sources.tar`;
+  const output = path.join(outputParent, fileName);
+  mkdirSync(outputParent, { recursive: true });
+  const staging = mkdtempSync(path.join(outputParent, ".tuneforge-ffmpeg-sources-"));
+  const payload = path.join(staging, "payload");
+  try {
+    mkdirSync(path.join(payload, "packaging", "ffmpeg", "cache"), { recursive: true });
+    mkdirSync(path.join(payload, "packaging", "ffmpeg", "patches"), { recursive: true });
+    mkdirSync(path.join(payload, "scripts"), { recursive: true });
+    for (const source of Object.values(lock.sources)) {
+      copyFileSync(archivePath(cacheDir, source), path.join(
+        payload, "packaging", "ffmpeg", "cache", path.basename(archivePath(cacheDir, source)),
+      ));
+    }
+    const ffmpeg = lock.sources.ffmpeg;
+    for (const [url, destination] of [
+      [ffmpeg.signatureUrl, path.basename(new URL(ffmpeg.signatureUrl).pathname)],
+      [ffmpeg.signingKeyUrl, "ffmpeg-devel.asc"],
+    ]) {
+      copyFileSync(path.join(cacheDir, destination), path.join(payload, "packaging", "ffmpeg", "cache", destination));
+      if (!url) fail(`Corresponding-source URL is missing for ${destination}`);
+    }
+    for (const entry of lock.patches ?? []) {
+      copyFileSync(path.join(workspaceRoot, entry.path), path.join(payload, entry.path));
+    }
+    for (const relative of [
+      "packaging/ffmpeg/sources.lock.json",
+      "scripts/build-ffmpeg.mjs",
+      "scripts/validate-packaged-ffmpeg.mjs",
+      "scripts/flatpak-source-snapshots.mjs",
+      "THIRD_PARTY_NOTICES.md",
+      "package.json",
+    ]) {
+      copyFileSync(path.join(workspaceRoot, relative), path.join(payload, relative));
+    }
+    writeFileSync(path.join(payload, "README-CORRESPONDING-SOURCES.md"), [
+      `# TuneForge ${lock.runtimeVersion} corresponding sources`,
+      "",
+      "This bundle contains the complete pinned FFmpeg and LAME upstream archives, FFmpeg's",
+      "detached signature and signing key, TuneForge's patch, build/validation recipe, source lock,",
+      "and notices. LAME publishes no signature or checksum sidecar; its reviewed SHA-256 pin is",
+      "recorded in `packaging/ffmpeg/sources.lock.json`.",
+      "",
+      "Extract this bundle over a TuneForge source checkout matching the distributed application.",
+      "Rebuild either owned target with:",
+      "",
+      "    node scripts/build-ffmpeg.mjs --target macos-arm64",
+      "    ANDROID_NDK_HOME=/path/to/ndk/29.0.14206865 node scripts/build-ffmpeg.mjs --target android-arm64-v8a",
+      "",
+      "The recipe verifies all pins before extraction and rebuilds dynamically linked LGPL payloads.",
+      "Replace `packaging/ffmpeg/generated/<target>`, validate it, then run normal packaging.",
+      "",
+    ].join("\n"));
+    const manifest = {
+      schemaVersion: 1,
+      runtimeVersion: lock.runtimeVersion,
+      files: inventoryFiles(payload),
+    };
+    writeFileSync(path.join(payload, "MANIFEST.json"), `${JSON.stringify(manifest, null, 2)}\n`);
+    createFlatpakSourceSnapshot({
+      root: staging,
+      outputPath: output,
+      inputs: [{ source: "payload", destination: `TuneForge-${lock.runtimeVersion}-sources` }],
+      sourceDateEpoch: "1",
+    });
+    const metadata = { fileName, sha256: sha256(output), size: statSync(output).size };
+    writeFileSync(`${output}.sha256`, `${metadata.sha256}  ${fileName}\n`);
+    return metadata;
+  } finally {
+    rmSync(staging, { recursive: true, force: true });
+  }
+}
+
+function verifyFfmpegSignature(cacheDir) {
+  const source = lock.sources.ffmpeg;
+  const archive = archivePath(cacheDir, source);
+  const signature = path.join(cacheDir, new URL(source.signatureUrl).pathname.split("/").pop());
+  const key = path.join(cacheDir, "ffmpeg-devel.asc");
+  verifyFile(archive, source.sha256, "FFmpeg source");
+  verifyFile(signature, source.signatureSha256, "FFmpeg signature");
+  verifyFile(key, source.signingKeySha256, "FFmpeg signing key");
+  const keyring = mkdtempSync(path.join(tmpdir(), "tuneforge-ffmpeg-gpg-"));
+  chmodSync(keyring, 0o700);
+  try {
+    run("gpg", ["--homedir", keyring, "--batch", "--import", key]);
+    const fingerprint = run(
+      "gpg",
+      ["--homedir", keyring, "--batch", "--with-colons", "--fingerprint", source.signingFingerprint],
+      { capture: true },
+    );
+    if (!fingerprint.includes(`fpr:::::::::${source.signingFingerprint}:`)) {
+      fail("Imported FFmpeg signing key fingerprint did not match the source lock");
+    }
+    run("gpg", ["--homedir", keyring, "--batch", "--verify", signature, archive]);
+  } finally {
+    rmSync(keyring, { recursive: true, force: true });
+  }
+}
+
+function extract(archive, destination) {
+  mkdirSync(destination, { recursive: true });
+  run("tar", ["-xf", archive, "-C", destination]);
+}
+
+function applyPatches(sourceRoot) {
+  for (const entry of lock.patches ?? []) {
+    const patchPath = path.join(workspaceRoot, entry.path);
+    if (!existsSync(patchPath)) fail(`Pinned FFmpeg patch missing: ${entry.path}`);
+    verifyFile(patchPath, entry.sha256, `Pinned patch ${entry.path}`);
+    run("patch", ["-p1", "--forward", "--input", patchPath], {
+      cwd: path.join(sourceRoot, entry.appliesTo),
+    });
+  }
+}
+
+function toolchain(target) {
+  if (target === "macos-arm64") {
+    const sdk = run("xcrun", ["--sdk", "macosx", "--show-sdk-path"], { capture: true }).trim();
+    const clang = run("xcrun", ["--sdk", "macosx", "--find", "clang"], { capture: true }).trim();
+    return {
+      target,
+      host: "aarch64-apple-darwin",
+      cc: clang,
+      ar: run("xcrun", ["--sdk", "macosx", "--find", "ar"], { capture: true }).trim(),
+      ranlib: run("xcrun", ["--sdk", "macosx", "--find", "ranlib"], { capture: true }).trim(),
+      cflags: `-arch arm64 -mmacosx-version-min=13.0 -isysroot ${sdk}`,
+      ldflags: `-arch arm64 -mmacosx-version-min=13.0 -isysroot ${sdk}`,
+      ffmpegCross: ["--arch=arm64", "--target-os=darwin", "--enable-cross-compile"],
+      programs: true,
+    };
+  }
+  const ndk = process.env.ANDROID_NDK_HOME || process.env.ANDROID_NDK_ROOT;
+  if (!ndk) fail("ANDROID_NDK_HOME is required for android-arm64-v8a");
+  const hostTag = process.platform === "darwin" ? "darwin-x86_64" : "linux-x86_64";
+  const bin = path.join(ndk, "toolchains", "llvm", "prebuilt", hostTag, "bin");
+  const triple = "aarch64-linux-android26";
+  return {
+    target,
+    host: "aarch64-linux-android",
+    cc: path.join(bin, `${triple}-clang`),
+    ar: path.join(bin, "llvm-ar"),
+    ranlib: path.join(bin, "llvm-ranlib"),
+    cflags: "-fPIC -D__ANDROID_API__=26",
+    ldflags: "-Wl,-z,max-page-size=16384 -Wl,-z,common-page-size=16384",
+    ffmpegCross: [
+      "--arch=aarch64",
+      "--target-os=android",
+      "--enable-cross-compile",
+      "--disable-symver",
+      `--cc=${path.join(bin, `${triple}-clang`)}`,
+      `--ar=${path.join(bin, "llvm-ar")}`,
+      `--ranlib=${path.join(bin, "llvm-ranlib")}`,
+      `--strip=${path.join(bin, "llvm-strip")}`,
+    ],
+    programs: false,
+    provenanceRoot: ndk,
+  };
+}
+
+function relocateMacBinaries(installRoot) {
+  const libraryRoot = path.join(installRoot, "lib");
+  const binaries = [...new Set([
+    ...readdirSync(libraryRoot).filter((name) => name.endsWith(".dylib")).map((name) => path.join(libraryRoot, name)),
+    ...["ffmpeg", "ffprobe"].map((name) => path.join(installRoot, "bin", name)).filter(existsSync),
+  ].map((file) => realpathSync(file)))];
+  for (const file of binaries) {
+    if (file.endsWith(".dylib")) {
+      run("install_name_tool", ["-id", `@rpath/${path.basename(file)}`, file]);
+    }
+    const dependencies = run("otool", ["-L", file], { capture: true })
+      .split("\n").slice(1).map((line) => line.trim().split(" ")[0]).filter(Boolean);
+    for (const dependency of dependencies) {
+      if (dependency.startsWith(`${installRoot}/lib/`)) {
+        run("install_name_tool", ["-change", dependency, `@rpath/${path.basename(dependency)}`, file]);
+      }
+    }
+    run("install_name_tool", ["-add_rpath", file.endsWith(".dylib") ? "@loader_path" : "@executable_path/../lib", file]);
+  }
+}
+
+function buildLame(sourceRoot, installRoot, tc, jobs) {
+  const args = [
+    `--prefix=${installRoot}`,
+    `--host=${tc.host}`,
+    "--disable-static",
+    "--enable-shared",
+    "--disable-frontend",
+    "--disable-decoder",
+  ];
+  run("sh", ["configure", ...args], {
+    cwd: sourceRoot,
+    env: { CC: tc.cc, AR: tc.ar, RANLIB: tc.ranlib, CFLAGS: `${tc.cflags} -O2`, LDFLAGS: tc.ldflags },
+  });
+  run("make", [`-j${jobs}`], { cwd: sourceRoot });
+  run("make", ["install"], { cwd: sourceRoot });
+  return args;
+}
+
+function buildFfmpeg(sourceRoot, installRoot, tc, jobs) {
+  const args = [
+    `--prefix=${installRoot}`,
+    "--enable-shared",
+    "--disable-static",
+    ...(tc.programs ? ["--enable-ffmpeg", "--enable-ffprobe"] : ["--disable-programs"]),
+    ...COMMON_COMPONENTS,
+    ...tc.ffmpegCross,
+    `--cc=${tc.cc}`,
+    `--ar=${tc.ar}`,
+    `--ranlib=${tc.ranlib}`,
+    `--extra-cflags=-I${path.join(installRoot, "include")} ${tc.cflags}`,
+    `--extra-ldflags=-L${path.join(installRoot, "lib")} ${tc.ldflags}`,
+  ];
+  run("sh", ["configure", ...args], { cwd: sourceRoot });
+  run("make", [`-j${jobs}`], { cwd: sourceRoot });
+  run("make", ["install"], { cwd: sourceRoot });
+  return args;
+}
+
+function inventoryFiles(root) {
+  const visit = (directory) => readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+    const full = path.join(directory, entry.name);
+    return entry.isDirectory() ? visit(full) : [full];
+  });
+  return visit(root).map((file) => ({
+    path: path.relative(root, file).split(path.sep).join("/"),
+    sha256: sha256(file),
+    size: statSync(file).size,
+  })).sort((left, right) => left.path.localeCompare(right.path));
+}
+
+function materializeSymlinks(root) {
+  for (const entry of readdirSync(root, { withFileTypes: true })) {
+    const file = path.join(root, entry.name);
+    if (entry.isDirectory()) {
+      materializeSymlinks(file);
+    } else if (entry.isSymbolicLink()) {
+      const resolved = realpathSync(file);
+      const metadata = statSync(resolved);
+      if (!metadata.isFile()) fail(`Owned FFmpeg symlink does not resolve to a file: ${file}`);
+      rmSync(file);
+      copyFileSync(resolved, file);
+      chmodSync(file, metadata.mode & 0o777);
+    } else if (!lstatSync(file).isFile()) {
+      fail(`Owned FFmpeg output contains an unsupported entry: ${file}`);
+    }
+  }
+}
+
+function main(argv) {
+  const options = parseArgs(argv);
+  mkdirSync(options.cacheDir, { recursive: true });
+  verifyFfmpegSignature(options.cacheDir);
+  const lameArchive = archivePath(options.cacheDir, lock.sources.lame);
+  verifyFile(lameArchive, lock.sources.lame.sha256, "LAME source");
+  const correspondingSources = materializeCorrespondingSources(
+    options.cacheDir,
+    path.dirname(options.outputDir),
+  );
+  if (options.sourceOnly) {
+    process.stdout.write(`${JSON.stringify(correspondingSources)}\n`);
+    return;
+  }
+
+  const work = mkdtempSync(path.join(tmpdir(), "tuneforge-ffmpeg-build-"));
+  const installRoot = path.join(work, "install");
+  const sourceRoot = path.join(work, "src");
+  try {
+    extract(archivePath(options.cacheDir, lock.sources.ffmpeg), sourceRoot);
+    extract(lameArchive, sourceRoot);
+    applyPatches(sourceRoot);
+    const tc = toolchain(options.target);
+    const lameConfigure = buildLame(path.join(sourceRoot, lock.sources.lame.sourceDirectory), installRoot, tc, options.jobs);
+    const ffmpegConfigure = buildFfmpeg(path.join(sourceRoot, lock.sources.ffmpeg.sourceDirectory), installRoot, tc, options.jobs);
+    if (options.target === "macos-arm64") relocateMacBinaries(installRoot);
+    const licenseRoot = path.join(installRoot, "licenses");
+    mkdirSync(licenseRoot, { recursive: true });
+    cpSync(
+      path.join(sourceRoot, lock.sources.ffmpeg.sourceDirectory, "COPYING.LGPLv2.1"),
+      path.join(licenseRoot, "FFmpeg-COPYING.LGPLv2.1.txt"),
+    );
+    cpSync(
+      path.join(sourceRoot, lock.sources.lame.sourceDirectory, "COPYING"),
+      path.join(licenseRoot, "LAME-COPYING.LGPL-2.0.txt"),
+    );
+    cpSync(
+      path.join(sourceRoot, lock.sources.lame.sourceDirectory, "LICENSE"),
+      path.join(licenseRoot, "LAME-LICENSE.txt"),
+    );
+    rmSync(options.outputDir, { recursive: true, force: true });
+    mkdirSync(options.outputDir, { recursive: true });
+    for (const directory of ["bin", "include", "lib", "licenses", "share"]) {
+      const source = path.join(installRoot, directory);
+      if (existsSync(source)) {
+        cpSync(source, path.join(options.outputDir, directory), {
+          recursive: true,
+          dereference: true,
+        });
+      }
+    }
+    materializeSymlinks(options.outputDir);
+    const replacements = [
+      [installRoot, "${INSTALL_ROOT}"],
+      ...(tc.provenanceRoot ? [[tc.provenanceRoot, "${ANDROID_NDK_HOME}"]] : []),
+    ];
+    const sanitize = (value) => replacements.reduce(
+      (result, [source, replacement]) => result.replaceAll(source, replacement),
+      value,
+    );
+    const provenance = {
+      schemaVersion: 1,
+      runtimeVersion: lock.runtimeVersion,
+      target: options.target,
+      sources: lock.sources,
+      correspondingSources,
+      configure: {
+        ffmpeg: ffmpegConfigure.map(sanitize),
+        lame: lameConfigure.map(sanitize),
+      },
+      buildEnvironment: {
+        ffmpeg: {
+          cc: sanitize(tc.cc), ar: sanitize(tc.ar), ranlib: sanitize(tc.ranlib),
+          cflags: sanitize(tc.cflags), ldflags: sanitize(tc.ldflags),
+        },
+        lame: {
+          cc: sanitize(tc.cc), ar: sanitize(tc.ar), ranlib: sanitize(tc.ranlib),
+          cflags: sanitize(`${tc.cflags} -O2`), ldflags: sanitize(tc.ldflags),
+        },
+      },
+      files: inventoryFiles(options.outputDir),
+    };
+    writeFileSync(path.join(options.outputDir, "provenance.json"), `${JSON.stringify(provenance, null, 2)}\n`);
+  } finally {
+    rmSync(work, { recursive: true, force: true });
+  }
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === scriptPath) {
+  try {
+    main(process.argv.slice(2));
+  } catch (error) {
+    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+    process.exitCode = 1;
+  }
+}

--- a/scripts/capture-release-media.mjs
+++ b/scripts/capture-release-media.mjs
@@ -138,6 +138,23 @@ const releaseMediaCaptureCatalog = [
     capture: captureScreenshotEntry,
   },
   {
+    id: "mobile-export",
+    enabled: true,
+    kind: "screenshot",
+    fileName: "mobile-export.png",
+    title: "Android export with owned audio formats",
+    caption: "Android saves one existing audio artifact through the system picker in WAV, FLAC, MP3, or M4A.",
+    alt: "TuneForge Android Export showing one saved practice mix selected with M4A and the system picker guidance",
+    fixture: "release-showcase-mobile-export-v1",
+    runtime: "mobile",
+    mobileFixtureOptions: { exportFocused: true },
+    viewport: { width: 411, height: 2000 },
+    route: "/projects/proj_release_showcase",
+    prepare: prepareMobileExport,
+    ready: readyMobileExport,
+    capture: captureScreenshotEntry,
+  },
+  {
     id: "export-workspace",
     enabled: true,
     kind: "screenshot",
@@ -666,8 +683,8 @@ async function installPageStabilizers(
             selectedArtifactId: "art_source",
             selectedPrimaryArtifactId: "art_source",
             selectedStemSourceArtifactId: null,
-            activeWorkspace: "playback",
-            activeProjectPanel: "studio",
+            activeWorkspace: mobileFixture?.initialWorkspace ?? "playback",
+            activeProjectPanel: mobileFixture?.initialProjectPanel ?? "studio",
             playbackDisplayMode: "combined",
             capoTransposeSemitones: 0,
             precountEnabled: false,
@@ -1375,7 +1392,13 @@ async function captureCatalogScreenshots({ appUrl, browser, catalog, entries, no
     const context = await createCaptureContext(browser, options, { entry });
     try {
       const page = await context.newPage();
-      await installPageStabilizers(page, options, "screenshot", entry);
+      await installPageStabilizers(
+        page,
+        options,
+        "screenshot",
+        entry,
+        entry.mobileFixtureOptions ?? {},
+      );
       try {
         await entry.capture({ appUrl, entry, options, page });
         capturedItems.push(manifestItemForCatalogEntry(entry, catalog));
@@ -1454,6 +1477,20 @@ async function prepareMobilePlayback({ page, timeoutMs }) {
   if (await bothMode.getAttribute("aria-pressed") !== "true") {
     await bothMode.click();
   }
+}
+
+async function prepareMobileExport({ page, timeoutMs }) {
+  const practiceSet = page.getByRole("radio", { name: /Practice Mix 1 Shift \+2/i });
+  await practiceSet.waitFor({ state: "visible", timeout: timeoutMs });
+  await practiceSet.click();
+  await practiceSet.locator("..").evaluate((element) => {
+    element.scrollIntoView({ block: "nearest", inline: "end" });
+  });
+  const practiceMix = page.getByRole("radio", { name: "Practice Mix 1", exact: true });
+  await practiceMix.waitFor({ state: "visible", timeout: timeoutMs });
+  await practiceMix.click();
+  await page.getByLabel("File format").selectOption("m4a");
+  await page.locator(".main-content").evaluate((element) => { element.scrollTop = 235; });
 }
 
 async function prepareExportWorkspace({ page, timeoutMs }) {
@@ -1662,6 +1699,74 @@ async function readyMobilePlayback({ page, timeoutMs }) {
   const value = Number(await position.inputValue());
   if (value !== 0) {
     throw new Error(`Mobile Playback screenshot must stay stopped at 0 seconds; received ${value}.`);
+  }
+}
+
+async function readyMobileExport({ page, timeoutMs }) {
+  await page.getByRole("heading", { name: "Export files" }).waitFor({ timeout: timeoutMs });
+  const guidance = page.getByText(/Android exports one existing audio artifact/);
+  await guidance.waitFor({ state: "visible", timeout: timeoutMs });
+  const projectDelivery = page.getByText("Project delivery", { exact: true });
+  const exportPackage = page.getByRole("complementary", { name: "Export package" });
+  const activityLink = page.getByRole("link", { name: "View export history in Activity" });
+  const practiceMix = page.getByRole("radio", { name: "Practice Mix 1", exact: true });
+  if (!await practiceMix.isChecked()) throw new Error("Android Export fixture must select Practice Mix 1.");
+  const practiceSet = page.getByRole("radio", { name: /Practice Mix 1 Shift \+2/i });
+  const format = page.getByLabel("File format");
+  if (await format.inputValue() !== "m4a") throw new Error("Android Export fixture must select M4A.");
+  const options = await format.locator("option").allTextContents();
+  for (const expected of ["WAV", "FLAC", "MP3", "M4A"]) {
+    if (!options.some((option) => option.startsWith(expected))) {
+      throw new Error(`Android Export fixture is missing ${expected}.`);
+    }
+  }
+  const disabledOptions = await format.locator("option:disabled").count();
+  if (disabledOptions !== 0) {
+    throw new Error("Android Export fixture must enable all four owned audio formats.");
+  }
+  const previewName = page.getByText("Midnight Count-In - Practice Mix 1.m4a", { exact: true });
+  await previewName.waitFor({ state: "visible", timeout: timeoutMs });
+  await page.getByText("1 selected", { exact: true }).waitFor({ timeout: timeoutMs });
+  const fileDestination = page.getByRole("button", { name: "File" });
+  await fileDestination.waitFor({ state: "visible", timeout: timeoutMs });
+  if (await fileDestination.getAttribute("aria-pressed") !== "true") {
+    throw new Error("Android Export fixture must keep File selected.");
+  }
+  if (!await page.getByRole("button", { name: "Folder" }).isDisabled() ||
+      !await page.getByRole("button", { name: "ZIP" }).isDisabled()) {
+    throw new Error("Android Export fixture must preserve the one-file destination boundary.");
+  }
+  const exportButton = page.getByRole("button", { name: "Export Practice Mix 1" });
+  await exportButton.waitFor({ state: "visible", timeout: timeoutMs });
+  if (await exportButton.isDisabled()) {
+    throw new Error("Android Export fixture must enable the system-picker handoff.");
+  }
+  const viewport = page.viewportSize();
+  for (const [name, locator] of [
+    ["guidance", guidance],
+    ["Project delivery label", projectDelivery],
+    ["saved artifact", practiceMix],
+    ["format", format],
+    ["suggested name", previewName],
+    ["export action", exportButton],
+    ["export package", exportPackage],
+    ["Activity link", activityLink],
+  ]) {
+    const box = await locator.boundingBox();
+    if (!box || !viewport || box.y < 0 || box.y + box.height > viewport.height) {
+      throw new Error(
+        `Android Export ${name} must fit within the capture viewport; ` +
+          `received ${JSON.stringify(box)} in ${JSON.stringify(viewport)}.`,
+      );
+    }
+  }
+  const practiceSetBox = await practiceSet.locator("..").boundingBox();
+  if (!practiceSetBox || !viewport || practiceSetBox.x < 0 ||
+      practiceSetBox.x + practiceSetBox.width > viewport.width) {
+    throw new Error(
+      "Android Export selected audio-set card must fit horizontally; " +
+        `received ${JSON.stringify(practiceSetBox)} in ${JSON.stringify(viewport)}.`,
+    );
   }
 }
 
@@ -2068,7 +2173,7 @@ function project(id, displayName, sourcePath, durationSeconds, extra = {}) {
   };
 }
 
-function mobilePlaybackFixture({ timedLyrics = true } = {}) {
+function mobilePlaybackFixture({ timedLyrics = true, exportFocused = false } = {}) {
   const projectId = "proj_release_showcase";
   const fixtureProject = projects().find((candidate) => candidate.id === projectId);
   if (!fixtureProject) {
@@ -2082,6 +2187,8 @@ function mobilePlaybackFixture({ timedLyrics = true } = {}) {
     words: [],
   }));
   return {
+    initialWorkspace: exportFocused ? "project" : "playback",
+    initialProjectPanel: exportFocused ? "export" : "studio",
     capabilities: {
       platform: "android",
       mediaBackend: "android_media_codec",
@@ -2102,7 +2209,10 @@ function mobilePlaybackFixture({ timedLyrics = true } = {}) {
     lyrics: timedLyrics
       ? fixtureLyrics
       : { ...fixtureLyrics, source_segments: untimedSegments, segments: untimedSegments },
-    artifacts: { artifacts: artifacts(projectId) },
+    artifacts: {
+      artifacts: artifacts(projectId).filter((artifact) =>
+        !exportFocused || ["art_source", "art_preview"].includes(artifact.id)),
+    },
     jobs: jobs().filter((job) => job.project_id === projectId),
   };
 }

--- a/scripts/capture-release-media.test.mjs
+++ b/scripts/capture-release-media.test.mjs
@@ -137,8 +137,8 @@ test("settings scroll delta rounds bottom overflow up to whole pixels", () => {
 
 test("release-media catalog has unique identifiers, files, and required callbacks", () => {
   assert.equal(validateReleaseMediaCatalog(releaseMediaCaptureCatalog), releaseMediaCaptureCatalog);
-  assert.equal(releaseMediaCaptureCatalog.length, 9);
-  assert.equal(releaseMediaCaptureCatalog.filter((entry) => entry.kind === "screenshot").length, 8);
+  assert.equal(releaseMediaCaptureCatalog.length, 10);
+  assert.equal(releaseMediaCaptureCatalog.filter((entry) => entry.kind === "screenshot").length, 9);
   assert.equal(releaseMediaCaptureCatalog.filter((entry) => entry.kind === "video").length, 1);
 
   const ids = releaseMediaCaptureCatalog.map((entry) => entry.id);
@@ -316,16 +316,94 @@ test("Playback fixture anchors an explicit Am-Bb-F gap chord to the following wo
   }]);
 });
 
-test("mobile Playback is one deterministic compact screenshot fixture", () => {
+test("mobile screenshots provide deterministic Playback and Android Export fixtures", () => {
   const mobileScreenshots = releaseMediaCaptureCatalog.filter(
     (entry) => entry.kind === "screenshot" && entry.runtime === "mobile",
   );
 
-  assert.equal(mobileScreenshots.length, 1);
-  assert.equal(mobileScreenshots[0].id, "mobile-playback");
-  assert.equal(mobileScreenshots[0].fixture, "release-showcase-mobile-playback-v1");
-  assert.deepEqual(mobileScreenshots[0].viewport, { width: 411, height: 891 });
-  assert.equal(mobileScreenshots[0].route, "/projects/proj_release_showcase");
+  assert.deepEqual(mobileScreenshots.map((entry) => ({
+    fixture: entry.fixture,
+    id: entry.id,
+    mobileFixtureOptions: entry.mobileFixtureOptions,
+    route: entry.route,
+    viewport: entry.viewport,
+  })), [
+    {
+      fixture: "release-showcase-mobile-playback-v1",
+      id: "mobile-playback",
+      mobileFixtureOptions: undefined,
+      route: "/projects/proj_release_showcase",
+      viewport: { width: 411, height: 891 },
+    },
+    {
+      fixture: "release-showcase-mobile-export-v1",
+      id: "mobile-export",
+      mobileFixtureOptions: { exportFocused: true },
+      route: "/projects/proj_release_showcase",
+      viewport: { width: 411, height: 2000 },
+    },
+  ]);
+});
+
+test("Android Export preparation selects one saved mix and M4A", async () => {
+  const mobileExport = releaseMediaCaptureCatalog.find((entry) => entry.id === "mobile-export");
+  const actions = [];
+  const radio = (name) => ({
+    click: async () => actions.push(`click:${name}`),
+    locator: (selector) => {
+      assert.equal(selector, "..");
+      return {
+        evaluate: async (callback) => {
+          const element = {
+            scrollIntoView: (options) => actions.push({ options, type: "scrollIntoView" }),
+          };
+          callback(element);
+        },
+      };
+    },
+    waitFor: async (options) => actions.push({ name, options, type: "waitFor" }),
+  });
+  const practiceSet = radio("Practice Mix 1 Shift +2");
+  const practiceMix = radio("Practice Mix 1");
+  const page = {
+    getByLabel: (label) => {
+      assert.equal(label, "File format");
+      return { selectOption: async (format) => actions.push(`format:${format}`) };
+    },
+    getByRole: (role, options) => {
+      assert.equal(role, "radio");
+      return options.name instanceof RegExp ? practiceSet : practiceMix;
+    },
+    locator: (selector) => {
+      assert.equal(selector, ".main-content");
+      return {
+        evaluate: async (callback) => {
+          const element = { scrollTop: 0 };
+          callback(element);
+          actions.push(`scrollTop:${element.scrollTop}`);
+        },
+      };
+    },
+  };
+
+  await mobileExport.prepare({ page, timeoutMs: 321 });
+  assert.deepEqual(actions, [
+    {
+      name: "Practice Mix 1 Shift +2",
+      options: { state: "visible", timeout: 321 },
+      type: "waitFor",
+    },
+    "click:Practice Mix 1 Shift +2",
+    { options: { block: "nearest", inline: "end" }, type: "scrollIntoView" },
+    {
+      name: "Practice Mix 1",
+      options: { state: "visible", timeout: 321 },
+      type: "waitFor",
+    },
+    "click:Practice Mix 1",
+    "format:m4a",
+    "scrollTop:235",
+  ]);
 });
 
 test("catalog validation rejects duplicate identifiers and output files", () => {

--- a/scripts/package-android.mjs
+++ b/scripts/package-android.mjs
@@ -12,6 +12,7 @@ const androidDir = path.join(desktopDir, "src-tauri/gen/android");
 const tauriCli = path.join(desktopDir, "node_modules/.bin/tauri");
 const androidEnv = path.join(scriptDir, "android-arm64-env.sh");
 const prepareGenerated = path.join(scriptDir, "android-prepare-generated.sh");
+const defaultFfmpegRoot = path.join(repoRoot, "packaging/ffmpeg/generated/android-arm64-v8a");
 const packageLock = path.join(desktopDir, "src-tauri/target/.tuneforge-android-package.lock");
 const publishableVariables = [
   "TUNEFORGE_ANDROID_RELEASE_KEYSTORE_PATH", "TUNEFORGE_ANDROID_RELEASE_KEY_ALIAS",
@@ -236,7 +237,14 @@ export function generatedState(baseDir = androidDir) {
 }
 export function preparedState(baseDir = androidDir) {
   const required = ["app/proguard-tuneforge.pro", "app/src/main/java/com/tuneforge/desktop/PowerInhibitionService.kt",
-    "app/src/main/res/values/ic_launcher_background.xml"];
+    "app/src/main/res/values/ic_launcher_background.xml",
+    "app/src/main/jniLibs/arm64-v8a/libavcodec.so",
+    "app/src/main/jniLibs/arm64-v8a/libavfilter.so",
+    "app/src/main/jniLibs/arm64-v8a/libavformat.so",
+    "app/src/main/jniLibs/arm64-v8a/libavutil.so",
+    "app/src/main/jniLibs/arm64-v8a/libswresample.so",
+    "app/src/main/jniLibs/arm64-v8a/libmp3lame.so",
+    "app/src/main/assets/ffmpeg/provenance.json"];
   const missing = required.filter((relative) => !fs.statSync(path.join(baseDir, relative),
     { throwIfNoEntry: false })?.isFile());
   return { ready: missing.length === 0, missing };
@@ -394,7 +402,19 @@ export function main(argv = process.argv.slice(2)) {
     if (config) validatePublishableCredentials(java, config, { env: sourceEnv });
     const tools = requireTools(sdk, capture, cleanEnv);
     isolatedHome = fs.mkdtempSync(path.join(os.tmpdir(), "tuneforge-android-home-"));
-    const env = pinnedEnv(java, sdk, ndk, { env: cleanEnv, homeDir: isolatedHome });
+    const ffmpegRoot = path.resolve(sourceEnv.TUNEFORGE_ANDROID_FFMPEG_ROOT ?? defaultFfmpegRoot);
+    const ndkHost = process.platform === "darwin" ? "darwin-x86_64" : "linux-x86_64";
+    const llvmReadelf = path.join(ndk.path, "toolchains/llvm/prebuilt", ndkHost, "bin/llvm-readelf");
+    const env = {
+      ...pinnedEnv(java, sdk, ndk, { env: cleanEnv, homeDir: isolatedHome }),
+      TUNEFORGE_ANDROID_FFMPEG_ROOT: ffmpegRoot,
+      LLVM_READELF: llvmReadelf,
+    };
+    run(process.execPath, [
+      path.join(scriptDir, "validate-packaged-ffmpeg.mjs"),
+      "--target", "android-arm64-v8a",
+      "--root", ffmpegRoot,
+    ], { env, label: "Android FFmpeg runtime validation" });
     const buildEnv = publishable ? publishableBuildEnv(env, sourceEnv) : env;
     console.log(`[android package] JDK ${java.version}; SDK ${sdk}; NDK ${ndk.version} (${ndk.path})`);
     if (mode === "prepare") {

--- a/scripts/package-android.test.mjs
+++ b/scripts/package-android.test.mjs
@@ -109,7 +109,14 @@ test("prepared state requires outputs owned by the explicit preparation command"
   assert.throws(() => requirePrepared(root), /Run pnpm package:android:prepare/);
   for (const relative of ["app/proguard-tuneforge.pro",
     "app/src/main/java/com/tuneforge/desktop/PowerInhibitionService.kt",
-    "app/src/main/res/values/ic_launcher_background.xml"]) {
+    "app/src/main/res/values/ic_launcher_background.xml",
+    "app/src/main/jniLibs/arm64-v8a/libavcodec.so",
+    "app/src/main/jniLibs/arm64-v8a/libavfilter.so",
+    "app/src/main/jniLibs/arm64-v8a/libavformat.so",
+    "app/src/main/jniLibs/arm64-v8a/libavutil.so",
+    "app/src/main/jniLibs/arm64-v8a/libswresample.so",
+    "app/src/main/jniLibs/arm64-v8a/libmp3lame.so",
+    "app/src/main/assets/ffmpeg/provenance.json"]) {
     const candidate = path.join(root, relative); fs.mkdirSync(path.dirname(candidate), { recursive: true });
     fs.writeFileSync(candidate, "prepared");
   }

--- a/scripts/package-mac.mjs
+++ b/scripts/package-mac.mjs
@@ -40,6 +40,13 @@ function main() {
     printModelBundleWarning();
   }
 
+  run(process.execPath, [
+    path.join("scripts", "validate-packaged-ffmpeg.mjs"),
+    "--target", "macos-arm64",
+    "--root", process.env.TUNEFORGE_FFMPEG_RUNTIME_DIR
+      ?? path.join("packaging", "ffmpeg", "generated", "macos-arm64"),
+  ]);
+
   run("uv", backendSyncArgs(options), { cwd: backendRoot });
   run("pnpm", ["--filter", "@tuneforge/desktop", "tauri", "build", "--bundles", "app"], {
     env: packageOptionsEnvironment(options),

--- a/scripts/prepare-bundle.mjs
+++ b/scripts/prepare-bundle.mjs
@@ -14,6 +14,7 @@ import { spawnSync } from "node:child_process";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { resolveBuildInfo, writeResolvedBuildInfoFile } from "./build-info.mjs";
+import { validateOwnedFfmpeg } from "./validate-packaged-ffmpeg.mjs";
 import {
   packageOptionsFromEnvironmentOrArgv,
   printModelBundleWarning,
@@ -30,6 +31,7 @@ const stagedBackendSourceRoot = path.join(stagedBackendRoot, "src");
 const stagedPythonRoot = path.join(stagedBackendRoot, "python");
 const stagedSitePackagesRoot = path.join(stagedBackendRoot, "site-packages");
 const stagedModelBundleRoot = path.join(stagedBackendRoot, "models", "bundle");
+const stagedFfmpegRoot = path.join(stagedBackendRoot, "ffmpeg");
 const sourceDemucsManifestPath = path.join(workspaceRoot, "packaging", "demucs", "models.json");
 const stagedLvChordiaRoot = path.join(stagedPythonRoot, "share", "lv-chordia", "cache_data");
 const sourceLvChordiaRoot = path.join(backendRoot, ".venv", "share", "lv-chordia", "cache_data");
@@ -262,6 +264,31 @@ function stageLvChordiaAssets(options) {
   assertLvChordiaBundleLayout(stagedBackendRoot, options.lvChordia);
 }
 
+export function stageOwnedFfmpegRuntime() {
+  const source = path.resolve(
+    process.env.TUNEFORGE_FFMPEG_RUNTIME_DIR
+      ?? path.join(workspaceRoot, "packaging", "ffmpeg", "generated", "macos-arm64"),
+  );
+  validateOwnedFfmpeg({ root: source, target: "macos-arm64", requireCorrespondingSources: true });
+  rmSync(stagedFfmpegRoot, { recursive: true, force: true });
+  for (const directory of ["bin", "lib", "licenses"]) {
+    copyInto(path.join(source, directory), path.join(stagedFfmpegRoot, directory));
+  }
+  const provenance = JSON.parse(readFileSync(path.join(source, "provenance.json"), "utf8"));
+  delete provenance.correspondingSources;
+  provenance.files = provenance.files.filter(({ path: file }) =>
+    ["bin/", "lib/", "licenses/"].some((prefix) => file.startsWith(prefix)));
+  writeFileSync(
+    path.join(stagedFfmpegRoot, "provenance.json"),
+    `${JSON.stringify(provenance, null, 2)}\n`,
+  );
+  return validateOwnedFfmpeg({
+    root: stagedFfmpegRoot,
+    target: "macos-arm64",
+    requireCorrespondingSources: false,
+  });
+}
+
 function verifyStagedPython(options) {
   const stagedPython = path.join(stagedPythonRoot, "bin", "python3.14");
   const libraryPaths = [
@@ -331,6 +358,7 @@ async function main() {
   assertBundledPythonLayout(stagedPythonRoot);
   copyInto(sitePackagesRoot, stagedSitePackagesRoot, { filter: shouldIncludeBundledSitePackage });
   stageLvChordiaAssets(packageOptions);
+  const ownedFfmpeg = stageOwnedFfmpegRuntime();
   verifyStagedPython(packageOptions);
   prepareModelBundle(packageOptions);
   assertCremaOnnxBundleLayout(
@@ -345,6 +373,11 @@ async function main() {
     site_packages: path.relative(resourcesRoot, stagedSitePackagesRoot),
     backend_source: path.relative(resourcesRoot, stagedBackendSourceRoot),
     version_info: path.relative(resourcesRoot, path.join(stagedBackendRoot, "version.json")),
+    ffmpeg_runtime: path.relative(resourcesRoot, stagedFfmpegRoot),
+    ffmpeg_runtime_version: JSON.parse(
+      readFileSync(path.join(stagedFfmpegRoot, "provenance.json"), "utf8"),
+    ).runtimeVersion,
+    ffmpeg_runtime_bytes: ownedFfmpeg.bytes,
   };
   if (packageOptions.modelBundle || packageOptions.crema === "onnx") {
     manifest.model_bundle = path.relative(resourcesRoot, stagedModelBundleRoot);

--- a/scripts/release-license-inventory.mjs
+++ b/scripts/release-license-inventory.mjs
@@ -15,6 +15,35 @@ const workspaceRoot = path.resolve(scriptDir, "..");
 const LV_CHORDIA_CHECKPOINT_BYTES = 28_730_939;
 const LV_CHORDIA_SOURCE_REVISION = "9d7de7bbf45efa6731ec8dc62d35280f141c0702";
 const flatpakGeneratedRoot = path.join(workspaceRoot, "packaging", "flatpak", "generated");
+const ffmpegSourceLockPath = path.join(workspaceRoot, "packaging", "ffmpeg", "sources.lock.json");
+
+function buildOwnedCodecPolicy() {
+  const sourceLock = JSON.parse(readFileSync(ffmpegSourceLockPath, "utf8"));
+  const sourceArchiveName =
+    `TuneForge_${sourceLock.runtimeVersion}_corresponding-sources.tar`;
+  return {
+    runtimeVersion: sourceLock.runtimeVersion,
+    ownedTargets: Object.keys(sourceLock.targets),
+    sources: Object.fromEntries(Object.entries(sourceLock.sources).map(([name, source]) => [
+      name,
+      {
+        version: source.version,
+        license: source.license,
+        url: source.url,
+        sha256: source.sha256,
+        verification: source.verification ??
+          `Detached signature verified with ${source.signingFingerprint}.`,
+      },
+    ])),
+    developmentResolution: "Host FFmpeg remains the default outside packaged applications.",
+    flatpakResolution:
+      "Flatpak ships zero owned FFmpeg/LAME payload; use only the audited GNOME runtime/extension tools.",
+    sourceLock: "packaging/ffmpeg/sources.lock.json",
+    correspondingSources: `packaging/ffmpeg/generated/${sourceArchiveName}`,
+    buildCommand: "pnpm ffmpeg:build",
+    sourceCommand: "pnpm ffmpeg:sources",
+  };
+}
 
 export const REVIEWED_FLATPAK_PYTHON_LICENSES = Object.freeze({
   alembic: "MIT", "annotated-doc": "MIT", "annotated-types": "MIT", anyio: "MIT",
@@ -293,6 +322,7 @@ export function buildReleaseLicenseInventory({
       })),
     })),
     toolStatuses,
+    ownedCodecPolicy: buildOwnedCodecPolicy(),
     modelPolicy: {
       defaultPackageOptions: {
         lvChordia: defaultOptions.lvChordia,
@@ -358,7 +388,8 @@ export function buildReleaseLicenseInventory({
       "Default release package commands must not pass --model-bundle.",
       "Advanced Chords packages must include only the exact pinned Crema ONNX model and runtime-state files.",
       "Demucs pretrained-weight redistribution is unclear/restricted upstream.",
-      "FFmpeg and ffprobe are host-installed and are not bundled.",
+      "Owned FFmpeg/LAME release payloads require matching source companion, notice, provenance, architecture, and linkage validation.",
+      "Development remains host-resolved; Flatpak ships zero owned FFmpeg/LAME payload.",
       "Python package license metadata can be incomplete; review missing fields manually.",
       "Do not commit redirected inventory reports or generated package resources.",
       "NVIDIA extension wheels require their bundled NVIDIA component license metadata review.",
@@ -421,6 +452,23 @@ export function formatReleaseLicenseInventory(checklist) {
     lines.push(`  tools: ${formatToolList(item.tools, checklist.toolStatuses)}`);
     lines.push(`  note: ${item.note}`);
   }
+
+  lines.push("");
+  lines.push("Owned codec policy:");
+  lines.push(`- runtime: ${checklist.ownedCodecPolicy.runtimeVersion}`);
+  lines.push(`- owned targets: ${checklist.ownedCodecPolicy.ownedTargets.join(", ")}`);
+  for (const [name, source] of Object.entries(checklist.ownedCodecPolicy.sources)) {
+    lines.push(
+      `- ${name} ${source.version}: ${source.license}, ${source.url}, SHA-256 ${source.sha256}`,
+    );
+    lines.push(`  verification: ${source.verification}`);
+  }
+  lines.push(`- development: ${checklist.ownedCodecPolicy.developmentResolution}`);
+  lines.push(`- Flatpak: ${checklist.ownedCodecPolicy.flatpakResolution}`);
+  lines.push(`- source lock: ${checklist.ownedCodecPolicy.sourceLock}`);
+  lines.push(`- corresponding sources: ${checklist.ownedCodecPolicy.correspondingSources}`);
+  lines.push(`- build: ${checklist.ownedCodecPolicy.buildCommand}`);
+  lines.push(`- source companion: ${checklist.ownedCodecPolicy.sourceCommand}`);
 
   lines.push("");
   lines.push("Model-weight policy:");

--- a/scripts/release-license-inventory.test.mjs
+++ b/scripts/release-license-inventory.test.mjs
@@ -57,6 +57,36 @@ test("model policy documents default no-bundle packaging and explicit bundle com
   });
 });
 
+test("owned codec policy records audited payloads and platform ownership", () => {
+  const checklist = buildReleaseLicenseInventory();
+
+  assert.equal(checklist.ownedCodecPolicy.runtimeVersion, "ffmpeg-9.0.1-lame-4.0-1");
+  assert.deepEqual(checklist.ownedCodecPolicy.ownedTargets, [
+    "macos-arm64",
+    "android-arm64-v8a",
+  ]);
+  assert.deepEqual(
+    Object.fromEntries(Object.entries(checklist.ownedCodecPolicy.sources).map(
+      ([name, source]) => [name, source.license],
+    )),
+    { ffmpeg: "LGPL-2.1-or-later", lame: "LGPL-2.0-or-later" },
+  );
+  assert.match(checklist.ownedCodecPolicy.sources.ffmpeg.verification, /FCF986EA/);
+  assert.match(checklist.ownedCodecPolicy.sources.lame.verification, /no detached signature/);
+  assert.match(checklist.ownedCodecPolicy.developmentResolution, /Host FFmpeg/);
+  assert.match(checklist.ownedCodecPolicy.flatpakResolution, /zero owned/);
+  assert.equal(
+    checklist.ownedCodecPolicy.correspondingSources,
+    "packaging/ffmpeg/generated/" +
+      "TuneForge_ffmpeg-9.0.1-lame-4.0-1_corresponding-sources.tar",
+  );
+
+  const rendered = formatReleaseLicenseInventory(checklist);
+  assert.match(rendered, /Owned codec policy:/);
+  assert.match(rendered, /FFmpeg\/LAME release payloads require matching source companion/);
+  assert.doesNotMatch(rendered, /FFmpeg and ffprobe are host-installed and are not bundled/);
+});
+
 test("model policy output is stable when lyrics model env is overridden", () => {
   const baseline = withLyricsModelEnv(undefined, () => buildReleaseLicenseInventory().modelPolicy);
   const overridden = withLyricsModelEnv("tiny", () => buildReleaseLicenseInventory().modelPolicy);

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -59,6 +59,15 @@ release_license_start=${SECONDS}
 release_license_elapsed=$((SECONDS - release_license_start))
 printf '\n[tests] Release license inventory tests finished in %ss\n' "${release_license_elapsed}"
 
+printf '\n[tests] Starting release media catalog tests\n\n'
+release_media_start=${SECONDS}
+(
+  cd "${repo_root}"
+  node --test scripts/capture-release-media.test.mjs
+)
+release_media_elapsed=$((SECONDS - release_media_start))
+printf '\n[tests] Release media catalog tests finished in %ss\n' "${release_media_elapsed}"
+
 printf '\n[tests] Starting Android packaging helper tests\n\n'
 android_package_start=${SECONDS}
 (

--- a/scripts/test-ffmpeg-shim.mjs
+++ b/scripts/test-ffmpeg-shim.mjs
@@ -1,0 +1,341 @@
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { spawn, spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const workspaceRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const runtime = path.resolve(
+  process.env.TUNEFORGE_FFMPEG_RUNTIME_DIR
+    ?? path.join(workspaceRoot, "packaging", "ffmpeg", "generated", "macos-arm64"),
+);
+const libraryRoot = path.join(runtime, "lib");
+const ownedFfmpeg = path.join(runtime, "bin", "ffmpeg");
+const ownedFfprobe = path.join(runtime, "bin", "ffprobe");
+const fixtureFfmpeg = process.env.TUNEFORGE_FIXTURE_FFMPEG ?? "ffmpeg";
+const sanitizerFlags = process.env.TUNEFORGE_FFMPEG_SHIM_SANITIZERS === "1"
+  ? ["-fsanitize=address,undefined", "-fno-omit-frame-pointer"]
+  : [];
+const work = mkdtempSync(path.join(tmpdir(), "tuneforge-ffmpeg-shim-test-"));
+const runtimeEnv = {
+  ...process.env,
+  DYLD_LIBRARY_PATH: [libraryRoot, process.env.DYLD_LIBRARY_PATH].filter(Boolean).join(":"),
+};
+
+function fail(message) {
+  throw new Error(message);
+}
+
+function run(command, args, { allowFailure = false, env = process.env } = {}) {
+  const result = spawnSync(command, args, { encoding: "utf8", env });
+  if (result.error) throw result.error;
+  if (!allowFailure && result.status !== 0) {
+    fail(`${command} exited ${result.status}: ${(result.stderr ?? "").trim()}`);
+  }
+  return result;
+}
+
+function runAsync(command, args, { env = process.env } = {}) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, { env, stdio: ["ignore", "ignore", "pipe"] });
+    let stderr = "";
+    child.stderr.setEncoding("utf8");
+    child.stderr.on("data", (chunk) => { stderr += chunk; });
+    child.once("error", reject);
+    child.once("close", (status) => status === 0
+      ? resolve({ status, stderr })
+      : reject(new Error(`${command} exited ${status}: ${stderr.trim()}`)));
+  });
+}
+
+function wav(file, {
+  rate = 44_100, channels = 1, frequencies = [440], seconds = 2, amplitude = 16_000,
+} = {}) {
+  const frames = Math.round(rate * seconds);
+  const data = Buffer.alloc(frames * channels * 2);
+  for (let frame = 0; frame < frames; frame += 1) {
+    for (let channel = 0; channel < channels; channel += 1) {
+      const frequency = frequencies[channel] ?? frequencies[0];
+      const sample = Math.round(Math.sin(2 * Math.PI * frequency * frame / rate) * amplitude);
+      data.writeInt16LE(sample, (frame * channels + channel) * 2);
+    }
+  }
+  const header = Buffer.alloc(44);
+  header.write("RIFF", 0); header.writeUInt32LE(36 + data.length, 4); header.write("WAVE", 8);
+  header.write("fmt ", 12); header.writeUInt32LE(16, 16); header.writeUInt16LE(1, 20);
+  header.writeUInt16LE(channels, 22); header.writeUInt32LE(rate, 24);
+  header.writeUInt32LE(rate * channels * 2, 28); header.writeUInt16LE(channels * 2, 32);
+  header.writeUInt16LE(16, 34); header.write("data", 36); header.writeUInt32LE(data.length, 40);
+  writeFileSync(file, Buffer.concat([header, data]));
+}
+
+function probe(file) {
+  const result = run(ownedFfprobe, [
+    "-v", "error", "-select_streams", "a:0", "-show_entries",
+    "stream=codec_name,profile,sample_rate,channels,bit_rate,duration", "-of", "json", file,
+  ], { env: runtimeEnv });
+  const stream = JSON.parse(result.stdout).streams?.[0];
+  if (!stream) fail(`No audio stream in ${file}`);
+  return stream;
+}
+
+function decodedPcm(file) {
+  const decoded = path.join(work, `${path.basename(file)}-decoded.wav`);
+  run(ownedFfmpeg, ["-v", "error", "-y", "-i", file, "-map", "0:a:0", "-c:a", "pcm_s16le", decoded], {
+    env: runtimeEnv,
+  });
+  const bytes = readFileSync(decoded);
+  let offset = 12;
+  let rate = 0;
+  let channels = 0;
+  let data = null;
+  while (offset + 8 <= bytes.length) {
+    const id = bytes.toString("ascii", offset, offset + 4);
+    const size = bytes.readUInt32LE(offset + 4);
+    if (id === "fmt ") {
+      channels = bytes.readUInt16LE(offset + 10);
+      rate = bytes.readUInt32LE(offset + 12);
+    } else if (id === "data") {
+      data = bytes.subarray(offset + 8, offset + 8 + size);
+      break;
+    }
+    offset += 8 + size + (size % 2);
+  }
+  if (!data || !rate || !channels) fail(`Invalid decoded WAV: ${decoded}`);
+  const samples = [];
+  for (let index = 0; index + channels * 2 <= data.length; index += channels * 2) {
+    samples.push(data.readInt16LE(index) / 32768);
+  }
+  return { samples, rate, channels, duration: samples.length / rate };
+}
+
+function frequency(audio) {
+  const samples = audio.samples.slice(0, 16_384);
+  let bestFrequency = 0;
+  let bestPower = -1;
+  for (let candidate = 380; candidate <= 920; candidate += 1) {
+    const coefficient = 2 * Math.cos(2 * Math.PI * candidate / audio.rate);
+    let q1 = 0;
+    let q2 = 0;
+    for (let index = 0; index < samples.length; index += 1) {
+      const window = 0.5 - 0.5 * Math.cos(2 * Math.PI * index / (samples.length - 1));
+      const q0 = coefficient * q1 - q2 + samples[index] * window;
+      q2 = q1;
+      q1 = q0;
+    }
+    const power = q1 * q1 + q2 * q2 - coefficient * q1 * q2;
+    if (power > bestPower) {
+      bestPower = power;
+      bestFrequency = candidate;
+    }
+  }
+  return bestFrequency;
+}
+
+function peak(audio) {
+  return audio.samples.reduce((maximum, sample) => Math.max(maximum, Math.abs(sample)), 0);
+}
+
+function assertNear(actual, expected, tolerance, label) {
+  if (Math.abs(actual - expected) > tolerance) {
+    fail(`${label}: expected ${expected} ± ${tolerance}, got ${actual}`);
+  }
+}
+
+function render(harness, input, output, format, cents = 0, cancelMode = "never") {
+  return run(harness, [input, output, format, String(cents), cancelMode], {
+    allowFailure: cancelMode !== "never",
+    env: runtimeEnv,
+  });
+}
+
+try {
+  const harness = path.join(work, "bridge-test");
+  run("clang", [
+    "-std=c11", "-Wall", "-Wextra", "-Werror",
+    ...sanitizerFlags,
+    `-I${path.join(runtime, "include")}`,
+    path.join(workspaceRoot, "apps", "desktop", "src-tauri", "src", "mobile_ffmpeg", "bridge.c"),
+    path.join(workspaceRoot, "apps", "desktop", "src-tauri", "src", "mobile_ffmpeg", "bridge_test.c"),
+    `-L${libraryRoot}`, `-Wl,-rpath,${libraryRoot}`,
+    "-lavfilter", "-lavformat", "-lavcodec", "-lswresample", "-lavutil", "-lmp3lame",
+    "-o", harness,
+  ]);
+
+  const mono = path.join(work, "mono-44100.wav");
+  const stereo = path.join(work, "stereo-48000.wav");
+  const mono32 = path.join(work, "mono-32000.wav");
+  const stereo44 = path.join(work, "stereo-44100.wav");
+  const stereo96 = path.join(work, "stereo-96000.wav");
+  const surround = path.join(work, "surround-48000.wav");
+  const second = path.join(work, "second.wav");
+  wav(mono);
+  wav(stereo, { rate: 48_000, channels: 2, frequencies: [440, 660] });
+  wav(mono32, { rate: 32_000 });
+  wav(stereo44, { channels: 2, frequencies: [440, 660] });
+  wav(stereo96, { rate: 96_000, channels: 2, frequencies: [440, 660] });
+  wav(surround, { rate: 48_000, channels: 6, frequencies: [220, 330, 440, 550, 660, 770] });
+  wav(second, { frequencies: [880] });
+
+  const fixtureSpecs = [
+    ["flac", ["-c:a", "flac"], "flac"],
+    ["mp3", ["-c:a", "libmp3lame", "-b:a", "192k"], "mp3"],
+    ["m4a", ["-c:a", "aac", "-b:a", "192k"], "m4a"],
+    ["aac", ["-c:a", "aac", "-b:a", "192k", "-f", "adts"], "aac"],
+    ["ogg", ["-ac", "2", "-c:a", "vorbis", "-strict", "experimental"], "ogg"],
+    ["mp4", ["-c:a", "aac", "-b:a", "192k"], "mp4"],
+    ["alac", ["-c:a", "alac"], "m4a"],
+    ["pcm24", ["-c:a", "pcm_s24le"], "wav"],
+    ["pcmf32", ["-c:a", "pcm_f32le"], "wav"],
+  ];
+  const inputs = [mono];
+  for (const [name, options, extension] of fixtureSpecs) {
+    const output = path.join(work, `${name}.${extension}`);
+    run(fixtureFfmpeg, ["-v", "error", "-y", "-i", mono, ...options, output]);
+    inputs.push(output);
+  }
+  const webm = path.join(work, "audio.webm");
+  run(fixtureFfmpeg, ["-v", "error", "-y", "-i", mono, "-c:a", "libopus", webm]);
+  inputs.push(webm);
+  const mixedWebm = path.join(work, "mixed-av.webm");
+  run(fixtureFfmpeg, [
+    "-v", "error", "-y", "-f", "lavfi", "-i", "color=c=black:s=16x16:r=1:d=2",
+    "-i", mono, "-shortest", "-c:v", "libvpx-vp9", "-c:a", "libopus", mixedWebm,
+  ]);
+  inputs.push(mixedWebm);
+  const mixedVorbisWebm = path.join(work, "mixed-av-vorbis.webm");
+  run(fixtureFfmpeg, [
+    "-v", "error", "-y", "-f", "lavfi", "-i", "color=c=black:s=16x16:r=1:d=2",
+    "-i", mono, "-map", "0:v:0", "-map", "1:a:0", "-shortest", "-c:v", "libvpx-vp9",
+    "-ac", "2", "-c:a", "vorbis", "-strict",
+    "experimental", mixedVorbisWebm,
+  ]);
+  inputs.push(mixedVorbisWebm);
+  const multiple = path.join(work, "multiple.mka");
+  run(fixtureFfmpeg, [
+    "-v", "error", "-y", "-i", mono, "-i", second, "-map", "0:a:0", "-map", "1:a:0",
+    "-c:a", "flac", multiple,
+  ]);
+  inputs.push(multiple);
+
+  for (const [index, input] of inputs.entries()) {
+    const output = path.join(work, `input-${index}.wav`);
+    const result = render(harness, input, output, "wav");
+    if (!result.stderr.includes("progress=100")) fail(`Progress did not complete for ${input}`);
+    const audio = decodedPcm(output);
+    assertNear(audio.duration, 2, 0.08, `duration for ${path.basename(input)}`);
+    assertNear(frequency(audio), 440, 4, `first audio stream for ${path.basename(input)}`);
+  }
+
+  const outputProfiles = { wav: "pcm_s16le", flac: "flac", mp3: "mp3", m4a: "aac" };
+  for (const [format, codec] of Object.entries(outputProfiles)) {
+    const output = path.join(work, `profile.${format}`);
+    render(harness, stereo, output, format);
+    const stream = probe(output);
+    if (stream.codec_name !== codec) fail(`${format} used ${stream.codec_name}, expected ${codec}`);
+    if (Number(stream.sample_rate) !== 48_000 || stream.channels !== 2) {
+      fail(`${format} did not preserve 48 kHz stereo`);
+    }
+    const audio = decodedPcm(output);
+    assertNear(audio.duration, 2, format === "wav" || format === "flac" ? 0.03 : 0.15, `${format} duration`);
+  }
+
+  for (const source of [mono32, stereo44]) {
+    const expected = decodedPcm(source);
+    for (const format of Object.keys(outputProfiles)) {
+      const output = path.join(work, `${path.basename(source)}.${format}`);
+      render(harness, source, output, format);
+      const stream = probe(output);
+      if (Number(stream.sample_rate) !== expected.rate || stream.channels !== expected.channels) {
+        fail(`${format} did not preserve ${expected.rate} Hz/${expected.channels} ch`);
+      }
+    }
+  }
+
+  for (const [source, label] of [[stereo96, "96 kHz"], [surround, "5.1"]]) {
+    const output = path.join(work, `${path.basename(source)}.mp3`);
+    render(harness, source, output, "mp3");
+    const stream = probe(output);
+    if (Number(stream.sample_rate) !== 48_000 || stream.channels !== 2) {
+      fail(`${label} MP3 negotiation produced ${stream.sample_rate} Hz/${stream.channels} ch`);
+    }
+  }
+
+  for (const name of ["m4a.m4a", "audio.webm"]) {
+    const source = path.join(work, name);
+    const decoded = decodedPcm(source);
+    assertNear(decoded.duration, 2, 0.08, `${name} decoded priming/duration`);
+    assertNear(frequency(decoded), 440, 4, `${name} decoded pitch`);
+  }
+
+  const headroom = path.join(work, "headroom.wav");
+  wav(headroom, { amplitude: 29_000 });
+  for (const format of Object.keys(outputProfiles)) {
+    const output = path.join(work, `headroom.${format}`);
+    render(harness, headroom, output, format);
+    const outputPeak = peak(decodedPcm(output));
+    if (outputPeak < 0.75 || outputPeak > 0.99999) {
+      fail(`${format} peak/headroom out of bounds: ${outputPeak}`);
+    }
+  }
+
+  const pitched = path.join(work, "pitched.wav");
+  render(harness, mono, pitched, "wav", 1200);
+  const pitchedAudio = decodedPcm(pitched);
+  assertNear(pitchedAudio.duration, 2, 0.08, "pitch-shift duration compensation");
+  assertNear(frequency(pitchedAudio), 880, 8, "pitch-shift frequency");
+
+  const cancelled = path.join(work, "cancelled.wav");
+  const cancelResult = render(harness, mono, cancelled, "wav", 0, "immediate");
+  if (cancelResult.status === 0 || !cancelResult.stderr.includes("cancelled")) {
+    fail("Immediate cancellation did not stop the shim");
+  }
+  if (existsSync(cancelled)) fail("Immediate cancellation left a partial output");
+  const longInput = path.join(work, "long.wav");
+  wav(longInput, { seconds: 30, channels: 2 });
+  const cancelledMidway = path.join(work, "cancelled-midway.flac");
+  const midwayResult = render(harness, longInput, cancelledMidway, "flac", 0, "35");
+  if (midwayResult.status === 0 || !midwayResult.stderr.includes("cancelled")) {
+    fail("Mid-operation cancellation did not stop the shim");
+  }
+  if (existsSync(cancelledMidway)) fail("Mid-operation cancellation left a partial output");
+  const malformed = path.join(work, "malformed.mp3");
+  writeFileSync(malformed, Buffer.from("not audio"));
+  const malformedResult = run(harness, [malformed, path.join(work, "bad.wav"), "wav", "0", "never"], {
+    allowFailure: true,
+    env: runtimeEnv,
+  });
+  if (malformedResult.status === 0 || !malformedResult.stderr.includes("open input")) {
+    fail(`Malformed input did not fail at the native boundary: ${malformedResult.stderr.trim()}`);
+  }
+
+  const truncated = path.join(work, "truncated.m4a");
+  const m4aBytes = readFileSync(path.join(work, "m4a.m4a"));
+  writeFileSync(truncated, m4aBytes.subarray(0, Math.max(32, Math.floor(m4aBytes.length / 2))));
+  const truncatedResult = run(harness, [
+    truncated, path.join(work, "truncated.wav"), "wav", "0", "never",
+  ], { allowFailure: true, env: runtimeEnv });
+  if (truncatedResult.status === 0) fail("Truncated input unexpectedly completed");
+  if (existsSync(path.join(work, "truncated.wav"))) fail("Truncated input left a partial output");
+
+  const concurrentA = path.join(work, "concurrent-a.flac");
+  const concurrentB = path.join(work, "concurrent-b.m4a");
+  await Promise.all([
+    runAsync(harness, [stereo, concurrentA, "flac", "0", "never"], { env: runtimeEnv }),
+    runAsync(harness, [mono32, concurrentB, "m4a", "0", "never"], { env: runtimeEnv }),
+  ]);
+  assertNear(decodedPcm(concurrentA).duration, 2, 0.03, "concurrent FLAC duration");
+  assertNear(decodedPcm(concurrentB).duration, 2, 0.15, "concurrent M4A duration");
+
+  process.stdout.write(`${JSON.stringify({
+    inputs: inputs.length,
+    outputs: 4,
+    rateChannelProfiles: 8,
+    negotiatedMp3Profiles: 2,
+    cancellation: ["immediate", "mid-operation"],
+    concurrency: 2,
+    pitch: true,
+  })}\n`);
+} finally {
+  rmSync(work, { recursive: true, force: true });
+}

--- a/scripts/validate-android-release-jni.mjs
+++ b/scripts/validate-android-release-jni.mjs
@@ -60,10 +60,10 @@ export function selectAndroidTools(sdkRoot) {
   const versions = readdirSync(buildTools).sort(compareVersions).reverse();
   for (const version of versions) {
     const root = path.join(buildTools, version);
-    const tools = Object.fromEntries(["aapt2", "apksigner", "dexdump"].map((name) => [name, path.join(root, name)]));
+    const tools = Object.fromEntries(["aapt2", "apksigner", "dexdump", "zipalign"].map((name) => [name, path.join(root, name)]));
     if (Object.values(tools).every(existsSync)) return { ...tools, version };
   }
-  throw new Error("No Android build-tools version contains aapt2, apksigner, and dexdump.");
+  throw new Error("No Android build-tools version contains aapt2, apksigner, dexdump, and zipalign.");
 }
 
 export function assertDexMethods(xmlDocuments, methods) {
@@ -142,14 +142,55 @@ export function validateReleaseJni({ root = workspaceRoot, run = runCommand, apk
     throw new Error("Release APK must be non-debuggable and contain arm64-v8a native code.");
   }
   run(tools.apksigner, ["verify", "--verbose", artifact]);
+  run(tools.zipalign, ["-c", "-P", "16", "4", artifact]);
   let tempDir;
   try {
-    const dexFiles = run("unzip", ["-Z1", artifact]).split("\n").filter((file) => /^classes\d*\.dex$/.test(file)).sort(compareDexNames);
+    const entries = run("unzip", ["-Z1", artifact]).split("\n").filter(Boolean);
+    const dexFiles = entries.filter((file) => /^classes\d*\.dex$/.test(file)).sort(compareDexNames);
     if (!dexFiles.length) throw new Error("Release APK contains no classes*.dex files.");
+    const requiredLibraries = [
+      "libavcodec.so", "libavfilter.so", "libavformat.so", "libavutil.so",
+      "libswresample.so", "libmp3lame.so",
+    ];
+    const nativeEntries = entries.filter((file) => file.startsWith("lib/"));
+    if (nativeEntries.some((file) => !file.startsWith("lib/arm64-v8a/"))) {
+      throw new Error("Release APK contains a native ABI other than arm64-v8a.");
+    }
+    for (const library of requiredLibraries) {
+      if (!nativeEntries.includes(`lib/arm64-v8a/${library}`)) {
+        throw new Error(`Release APK is missing owned codec library ${library}.`);
+      }
+    }
+    if (!entries.includes("assets/ffmpeg/provenance.json") ||
+        !entries.includes("assets/ffmpeg/licenses/FFmpeg-COPYING.LGPLv2.1.txt") ||
+        !entries.includes("assets/ffmpeg/licenses/LAME-COPYING.LGPL-2.0.txt")) {
+      throw new Error("Release APK is missing owned codec provenance or LGPL notices.");
+    }
     tempDir = mkdtempSync(path.join(os.tmpdir(), "tuneforge-jni-dex-"));
-    run("unzip", ["-qq", artifact, ...dexFiles, "-d", tempDir]);
+    run("unzip", ["-qq", artifact, ...dexFiles, ...nativeEntries, "-d", tempDir]);
     const xmlDocuments = dexFiles.map((file) => run(tools.dexdump, ["-l", "xml", path.join(tempDir, file)]));
     assertDexMethods(xmlDocuments, rules);
+    const readelf = env.LLVM_READELF;
+    if (!readelf || !existsSync(readelf)) {
+      throw new Error("LLVM_READELF from the pinned Android NDK is required for native payload validation.");
+    }
+    const ownedNames = new Set(requiredLibraries);
+    for (const entry of nativeEntries) {
+      const file = path.join(tempDir, entry);
+      const elf = run(readelf, ["-h", "-l", "-d", file]);
+      if (!/Machine:\s+AArch64/.test(elf)) throw new Error(`APK native library is not AArch64: ${entry}`);
+      const alignments = [...elf.matchAll(/LOAD\s+[^\n]*\s0x([0-9a-f]+)\s*$/gim)]
+        .map((match) => Number.parseInt(match[1], 16));
+      if (!alignments.length || alignments.some((alignment) => alignment < 0x4000)) {
+        throw new Error(`APK native library lacks 16 KB LOAD alignment: ${entry}`);
+      }
+      for (const match of elf.matchAll(/Shared library: \[([^\]]+)\]/g)) {
+        const dependency = match[1];
+        if (/^(?:libav|libswresample|libmp3lame)/.test(dependency) && !ownedNames.has(dependency)) {
+          throw new Error(`APK native dependency is outside owned codec closure: ${dependency}`);
+        }
+      }
+    }
   } finally {
     if (tempDir) rmSync(tempDir, { recursive: true, force: true });
   }

--- a/scripts/validate-android-release-jni.test.mjs
+++ b/scripts/validate-android-release-jni.test.mjs
@@ -45,21 +45,41 @@ test("validates an explicit APK, falls through empty SDK values, and rejects inv
   mkdirSync(path.dirname(rulesPath), { recursive: true }); writeFileSync(rulesPath, rules);
   const apk = path.join(root, "staged.apk"); writeFileSync(apk, "apk");
   const sdkRoot = path.join(root, "sdk");
-  for (const tool of ["aapt2", "apksigner", "dexdump"]) {
+  for (const tool of ["aapt2", "apksigner", "dexdump", "zipalign"]) {
     const candidate = path.join(sdkRoot, "build-tools/36.0.0", tool);
     mkdirSync(path.dirname(candidate), { recursive: true }); writeFileSync(candidate, "");
   }
+  const readelf = path.join(root, "llvm-readelf"); writeFileSync(readelf, "");
+  const archiveEntries = [
+    "classes.dex", "lib/arm64-v8a/libtuneforge.so",
+    ...["libavcodec.so", "libavfilter.so", "libavformat.so", "libavutil.so",
+      "libswresample.so", "libmp3lame.so"].map((name) => `lib/arm64-v8a/${name}`),
+    "assets/ffmpeg/provenance.json",
+    "assets/ffmpeg/licenses/FFmpeg-COPYING.LGPLv2.1.txt",
+    "assets/ffmpeg/licenses/LAME-COPYING.LGPL-2.0.txt",
+  ];
   const calls = [];
-  validateReleaseJni({ root, apk, sdkRoot: "", env: { ANDROID_HOME: "", ANDROID_SDK_ROOT: sdkRoot },
+  validateReleaseJni({ root, apk, sdkRoot: "", env: {
+    ANDROID_HOME: "", ANDROID_SDK_ROOT: sdkRoot, LLVM_READELF: readelf,
+  },
     run: (command, args) => {
       calls.push([command, args]);
       if (command.endsWith("aapt2")) return "native-code: 'arm64-v8a'";
-      if (command === "unzip" && args[0] === "-Z1") return "classes.dex";
+      if (command === "unzip" && args[0] === "-Z1") return archiveEntries.join("\n");
+      if (command === "unzip" && args[0] === "-qq") {
+        const destination = args.at(-1);
+        for (const entry of args.slice(2, -2)) {
+          const candidate = path.join(destination, entry);
+          mkdirSync(path.dirname(candidate), { recursive: true }); writeFileSync(candidate, "fixture");
+        }
+        return "";
+      }
       if (command.endsWith("dexdump")) return dexXml(parseJniRules(rules));
+      if (command === readelf) return "Machine: AArch64\nLOAD 0x000000 0x000000 0x000000 0x1000 0x1000 R E 0x4000\nShared library: [libc.so]";
       return "";
     },
   });
-  assert.equal(calls.filter(([, args]) => args.includes(apk)).length, 4);
+  assert.equal(calls.filter(([, args]) => args.includes(apk)).length, 5);
   assert.deepEqual(parseCli(["--apk", apk]), { apk });
   for (const argv of [["--apk"], ["--other", apk], ["--apk", apk, "extra"]]) assert.throws(() => parseCli(argv), /Usage/);
   assert.throws(() => validateReleaseJni({ root, apk: path.join(root, "missing.apk"), sdkRoot }), /missing/);
@@ -70,7 +90,7 @@ test("selects highest complete Android build-tools version", () => {
   for (const version of ["35.0.0", "36.0.0"]) {
     const dir = path.join(root, "build-tools", version);
     mkdirSync(dir, { recursive: true });
-    for (const tool of ["aapt2", "apksigner", "dexdump"]) writeFileSync(path.join(dir, tool), "");
+    for (const tool of ["aapt2", "apksigner", "dexdump", "zipalign"]) writeFileSync(path.join(dir, tool), "");
   }
   assert.equal(selectAndroidTools(root).version, "36.0.0");
 });

--- a/scripts/validate-packaged-ffmpeg.mjs
+++ b/scripts/validate-packaged-ffmpeg.mjs
@@ -1,0 +1,179 @@
+import { createHash } from "node:crypto";
+import { existsSync, lstatSync, readFileSync, readdirSync, realpathSync, statSync } from "node:fs";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const scriptPath = fileURLToPath(import.meta.url);
+const workspaceRoot = path.resolve(path.dirname(scriptPath), "..");
+const lock = JSON.parse(readFileSync(path.join(workspaceRoot, "packaging", "ffmpeg", "sources.lock.json"), "utf8"));
+
+function fail(message) {
+  throw new Error(message);
+}
+
+function sha256(filePath) {
+  return createHash("sha256").update(readFileSync(filePath)).digest("hex");
+}
+
+function run(command, args) {
+  const result = spawnSync(command, args, { encoding: "utf8", stdio: "pipe" });
+  if (result.error) throw result.error;
+  if (result.status !== 0) fail(`${command} exited ${result.status}: ${(result.stderr ?? "").trim()}`);
+  return result.stdout ?? "";
+}
+
+function filesUnder(root) {
+  const visit = (directory) => readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+    const filePath = path.join(directory, entry.name);
+    if (entry.isSymbolicLink()) fail(`Owned FFmpeg payload must not contain symlinks: ${filePath}`);
+    return entry.isDirectory() ? visit(filePath) : [filePath];
+  });
+  return visit(root);
+}
+
+function baseLibraryName(fileName) {
+  const match = /^(lib(?:avcodec|avfilter|avformat|avutil|swresample|mp3lame))(?:\.[0-9]+)*\.(?:dylib|so)(?:\.[0-9]+)*$/.exec(fileName);
+  return match?.[1] ?? null;
+}
+
+export function validateProvenance(root, target, { requireCorrespondingSources = true } = {}) {
+  const provenancePath = path.join(root, "provenance.json");
+  if (!existsSync(provenancePath)) fail(`Owned FFmpeg provenance missing: ${provenancePath}`);
+  const provenance = JSON.parse(readFileSync(provenancePath, "utf8"));
+  if (provenance.runtimeVersion !== lock.runtimeVersion || provenance.target !== target) {
+    fail("Owned FFmpeg provenance version or target does not match the source lock");
+  }
+  if (requireCorrespondingSources) {
+    const source = provenance.correspondingSources;
+    if (typeof source?.fileName !== "string" || path.basename(source.fileName) !== source.fileName ||
+        typeof source.sha256 !== "string" || typeof source.size !== "number") {
+      fail("Owned FFmpeg corresponding-source metadata is missing or invalid");
+    }
+    const sourcePath = path.join(path.dirname(root), source.fileName);
+    if (!existsSync(sourcePath) || statSync(sourcePath).size !== source.size ||
+        sha256(sourcePath) !== source.sha256) {
+      fail("Owned FFmpeg corresponding-source bundle does not match provenance");
+    }
+  }
+  const configure = provenance.configure?.ffmpeg;
+  if (!Array.isArray(configure)) fail("Owned FFmpeg configure arguments missing");
+  for (const required of [...lock.policy.licenseFlagsRequired, ...lock.policy.networkFlagsRequired]) {
+    if (!configure.includes(required)) fail(`Owned FFmpeg configure is missing ${required}`);
+  }
+  for (const forbidden of ["--enable-gpl", "--enable-nonfree", "--enable-version3", "--enable-network"]) {
+    if (configure.includes(forbidden)) fail(`Owned FFmpeg configure contains forbidden flag ${forbidden}`);
+  }
+  const recorded = new Set();
+  for (const entry of provenance.files ?? []) {
+    if (typeof entry.path !== "string" || recorded.has(entry.path)) {
+      fail(`Owned FFmpeg provenance has an invalid or duplicate path: ${entry.path}`);
+    }
+    recorded.add(entry.path);
+    const filePath = path.resolve(root, entry.path);
+    if (!filePath.startsWith(`${realpathSync(root)}${path.sep}`)) fail(`Provenance path escapes payload: ${entry.path}`);
+    if (!existsSync(filePath) || statSync(filePath).size !== entry.size || sha256(filePath) !== entry.sha256) {
+      fail(`Owned FFmpeg file does not match provenance: ${entry.path}`);
+    }
+  }
+  const actual = filesUnder(root)
+    .map((file) => path.relative(root, file).split(path.sep).join("/"))
+    .filter((file) => file !== "provenance.json");
+  for (const file of actual) if (!recorded.has(file)) fail(`Owned FFmpeg file is absent from provenance: ${file}`);
+  for (const file of recorded) if (!actual.includes(file)) fail(`Owned FFmpeg provenance records an absent file: ${file}`);
+  return provenance;
+}
+
+function validateLibrarySet(root, target) {
+  const libraryRoot = path.join(root, "lib");
+  if (!existsSync(libraryRoot)) fail(`Owned FFmpeg library directory missing: ${libraryRoot}`);
+  const actual = new Set(
+    filesUnder(libraryRoot)
+      .map((file) => baseLibraryName(path.basename(file)))
+      .filter(Boolean),
+  );
+  const expected = new Set(lock.targets[target].libraries);
+  for (const name of expected) if (!actual.has(name)) fail(`Owned FFmpeg library missing: ${name}`);
+  for (const name of actual) if (!expected.has(name)) fail(`Unexpected owned FFmpeg library: ${name}`);
+  for (const forbidden of lock.policy.forbiddenLibraries) {
+    if (filesUnder(libraryRoot).some((file) => path.basename(file).startsWith(forbidden))) {
+      fail(`Forbidden owned FFmpeg library: ${forbidden}`);
+    }
+  }
+  return filesUnder(libraryRoot).filter((file) => baseLibraryName(path.basename(file)));
+}
+
+function validateMac(root, libraries) {
+  const programs = lock.targets["macos-arm64"].programs.map((name) => path.join(root, "bin", name));
+  for (const executable of programs) {
+    if (!existsSync(executable)) fail(`Owned FFmpeg executable missing: ${executable}`);
+  }
+  const ownedNames = new Set(libraries.map((file) => path.basename(file)));
+  for (const file of [...libraries, ...programs]) {
+    const info = run("file", [file]);
+    if (!info.includes("arm64")) fail(`Owned macOS FFmpeg file is not arm64: ${file}`);
+    const linkage = run("otool", ["-L", file]);
+    if (/\/(?:opt\/homebrew|usr\/local|opt\/local)\//.test(linkage)) {
+      fail(`Owned macOS FFmpeg links to Homebrew or MacPorts: ${file}`);
+    }
+    const invalid = linkage.split("\n").slice(1).map((line) => line.trim().split(" ")[0]).filter(Boolean)
+      .find((dependency) => dependency.startsWith("/") && !dependency.startsWith("/usr/lib/") && !dependency.startsWith("/System/Library/"));
+    if (invalid) fail(`Owned macOS FFmpeg has external absolute dependency ${invalid}`);
+    const missingOwned = linkage.split("\n").slice(1).map((line) => line.trim().split(" ")[0]).filter(Boolean)
+      .find((dependency) => dependency.startsWith("@rpath/") && !ownedNames.has(path.basename(dependency)));
+    if (missingOwned) fail(`Owned macOS FFmpeg dependency is outside the payload: ${missingOwned}`);
+  }
+}
+
+function validateAndroid(libraries) {
+  const ownedNames = new Set(libraries.map((file) => path.basename(file)));
+  const systemNames = new Set(["libc.so", "libdl.so", "libm.so"]);
+  for (const file of libraries) {
+    if (!path.basename(file).endsWith(".so")) continue;
+    const header = run(process.env.LLVM_READELF || "llvm-readelf", ["-h", "-l", "-d", file]);
+    if (!/Machine:\s+AArch64/.test(header)) fail(`Owned Android FFmpeg file is not AArch64: ${file}`);
+    const loads = [...header.matchAll(/LOAD\s+[^\n]*\s0x([0-9a-f]+)\s*$/gim)];
+    if (!loads.length || loads.some((match) => Number.parseInt(match[1], 16) < 0x4000)) {
+      fail(`Owned Android FFmpeg file lacks 16 KB LOAD alignment: ${file}`);
+    }
+    if (/NEEDED[^\n]*(?:libavdevice|libpostproc|libswscale|libGPL)/i.test(header)) {
+      fail(`Owned Android FFmpeg has forbidden DT_NEEDED dependency: ${file}`);
+    }
+    for (const match of header.matchAll(/Shared library: \[([^\]]+)\]/g)) {
+      if (!ownedNames.has(match[1]) && !systemNames.has(match[1])) {
+        fail(`Owned Android FFmpeg dependency is outside audited closure: ${match[1]}`);
+      }
+    }
+  }
+}
+
+export function validateOwnedFfmpeg({ root, target, requireCorrespondingSources = true }) {
+  if (!Object.hasOwn(lock.targets, target)) fail(`Unknown FFmpeg target: ${target}`);
+  if (!existsSync(root) || !lstatSync(root).isDirectory()) fail(`Owned FFmpeg payload missing: ${root}`);
+  validateProvenance(root, target, { requireCorrespondingSources });
+  const libraries = validateLibrarySet(root, target);
+  for (const license of ["FFmpeg-COPYING.LGPLv2.1.txt", "LAME-COPYING.LGPL-2.0.txt", "LAME-LICENSE.txt"]) {
+    if (!existsSync(path.join(root, "licenses", license))) fail(`Owned FFmpeg license missing: ${license}`);
+  }
+  if (target === "macos-arm64") validateMac(root, libraries);
+  else validateAndroid(libraries);
+  return { target, files: filesUnder(root).length, bytes: filesUnder(root).reduce((sum, file) => sum + statSync(file).size, 0) };
+}
+
+function main(argv) {
+  const args = argv[0] === "--" ? argv.slice(1) : argv;
+  const targetIndex = args.indexOf("--target");
+  const rootIndex = args.indexOf("--root");
+  if (targetIndex < 0 || rootIndex < 0) fail("Usage: validate-packaged-ffmpeg --target <target> --root <payload>");
+  const result = validateOwnedFfmpeg({ target: args[targetIndex + 1], root: path.resolve(args[rootIndex + 1]) });
+  process.stdout.write(`${JSON.stringify(result)}\n`);
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === scriptPath) {
+  try {
+    main(process.argv.slice(2));
+  } catch (error) {
+    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+    process.exitCode = 1;
+  }
+}


### PR DESCRIPTION
## Summary

- Package a pinned, audited LGPL FFmpeg runtime for macOS arm64 and Android arm64-v8a, with reproducible source builds, provenance, notices, linkage checks, and replacement instructions.
- Add the Android FFmpeg bridge and integrate durable import, preview, retune, transpose, and saved-artifact export for WAV, FLAC, MP3, and AAC-LC M4A. Conversion jobs use staged outputs, validation, cancellation, atomic promotion, and restart cleanup.
- Persist rendered duration during Android import so native playback exposes the correct total and seek range. Add Android MIME aliases so system providers allow M4A and AAC selection.
- Preserve the shared realtime playback path and saved-artifact export semantics. Export does not apply current playback tuning or tempo; tempo-altered durable mixes remain scoped to #529.

Closes #528
Refs #529

## Testing

- Baseline gates: `rtk pnpm lint`, `rtk proxy pnpm typecheck`, and `rtk pnpm test`. Passed 49 frontend files / 894 tests, 430 Rust tests, 824 backend tests, and script suites.
- Backend confirmation: `cd apps/backend && rtk uv run --python 3.14 ruff check . && rtk uv run --python 3.14 mypy app && rtk uv run --python 3.14 pytest`. Ruff, mypy across 87 files, and 824 pytest tests passed.
- Native validation: `rtk cargo check --manifest-path apps/desktop/src-tauri/Cargo.toml` checked 439 crates without warnings. `scripts/test-ffmpeg-shim.mjs` ran with `TUNEFORGE_FFMPEG_SHIM_SANITIZERS=1`; ASan and UBSan covered 14 inputs across four outputs, eight sample-rate/channel profiles, errors, cancellation, and concurrency. Package-validation and license-inventory scripts audited 216 owned macOS files and 198 Android files; Android APK zip alignment and JNI dependency closure passed.
- Release media: `rtk node scripts/capture-release-media.mjs --run`. All 10 generated items passed and were inspected.
- Android packaging and focused checks: `rtk pnpm package:android`, `rtk pnpm package:android:debug`, `rtk cargo test --manifest-path apps/desktop/src-tauri/Cargo.toml mobile_import_conversion_reports_audio_duration`, `rtk proxy env TUNEFORGE_ANDROID_FFMPEG_ROOT=packaging/ffmpeg/generated/android-arm64-v8a LLVM_READELF="$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/darwin-x86_64/bin/llvm-readelf" bash scripts/android-arm64-env.sh cargo check --manifest-path apps/desktop/src-tauri/Cargo.toml --target aarch64-linux-android`, `rtk cargo fmt --manifest-path apps/desktop/src-tauri/Cargo.toml --check`, `rtk pnpm --filter @tuneforge/desktop exec vitest run src/App.library.test.tsx -t 'uses the selected durable format for Android imports' --reporter=verbose`, `rtk pnpm --filter @tuneforge/desktop lint`, `rtk pnpm -C apps/desktop typecheck`, and `rtk git diff --check`.
- Package identity: the baseline optimized APK came from `cad2d4ba`; fixed debug APKs were built from working-tree fixes subsequently amended into `23d03941`.
- On a fresh isolated API 36 arm64 emulator with synthetic audio, imported WAV, MP3, FLAC, OGG, AAC, M4A/ALAC, mixed-audio/video WebM, and a 600-second WAV through Android SAF. A malformed WAV was rejected without creating a project or artifact.
- Verified native playback total, pause, seek, resume, and stop after importing a 24-second WAV. Retune measured 431.9988 Hz from a 440 Hz source; transpose by one semitone measured 466.1537 Hz.
- Exported WAV, FLAC, MP3, and AAC-LC M4A through SAF; provider readback size and SHA-256 matched, and decoded output measured approximately 432 Hz over 24 seconds. Changing playback capo tuning left an existing-artifact WAV export byte-identical.
- Verified long-job cancellation and forced-restart recovery: no partial output remained, interrupted work failed with a retry message, and completed projects and artifacts were retained.
- Reviewed the final six-file emulator-fix diff with no actionable findings.

Manual limits: the emulator used 4 KB pages, so this does not claim 16 KB runtime-device coverage. Physical listening, thermal/battery behavior, and other SAF providers were not tested. With CDP attached, some picker results waited until another native app action; three consecutive native-only M4A, AAC, and ALAC imports completed without post-selection app interaction. Android `mobile-cpu-v1` analysis intentionally leaves BPM and timing empty. Playback-tempo export regression was not exercised because local Android analysis does not populate BPM.

Remaining release-acceptance gaps: audit the exact GNOME 50 Flatpak runtime/extension contract, validate alignment of an installable APK generated from the AAB, and test signed macOS relocation, notarization, and offline clean-host behavior. This PR remains a draft until those checks are complete.
