### PR TITLE
build: bootstrap the iOS simulator runtime

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[env]
+BINDGEN_EXTRA_CLANG_ARGS_aarch64_apple_ios_sim = "--target=arm64-apple-ios-simulator"

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -174,19 +174,19 @@ This file is the source of truth for dependency and model-weight distribution po
 
 - **License:** Apache-2.0 / MIT (dual)
 - **Source:** <https://github.com/RustAudio/cpal>
-- **Notes:** Used by the desktop shell for local microphone device enumeration and tuner input capture, and by macOS, Linux, and Android project playback. Android playback uses CPAL's AAudio backend and requires API 26 or newer.
+- **Notes:** Used by the desktop shell for local microphone device enumeration and tuner input capture, and by macOS, Linux, and Android project playback. Android playback uses CPAL's AAudio backend and requires API 26 or newer. The iOS simulator foundation initializes CPAL's CoreAudio output backend during its debug startup smoke; product playback remains unavailable there.
 
 ### signalsmith-stretch
 
 - **License:** MIT
 - **Source:** <https://github.com/colinmarc/signalsmith-stretch-rs>
-- **Notes:** Used by the native macOS, Linux, and Android playback engine for tempo changes with pitch preservation. Its resolved Rust transitive stack is permissively licensed.
+- **Notes:** Used by the native macOS, Linux, and Android playback engine for tempo changes with pitch preservation. The iOS simulator foundation constructs and processes a synthetic buffer during its debug startup smoke. Its resolved Rust transitive stack is permissively licensed.
 
 ### Symphonia
 
 - **License:** MPL-2.0
 - **Source:** <https://github.com/pdeljanov/Symphonia>
-- **Notes:** Used by the native macOS, Linux, and Android playback engine and by Android durable-artifact validation. FFmpeg conversion remains separate from realtime playback.
+- **Notes:** Used by the native macOS, Linux, and Android playback engine and by Android durable-artifact validation. The iOS simulator foundation decodes a generated WAV during its debug startup smoke. FFmpeg conversion remains separate from realtime playback and is not included on iOS.
 
 ### ndk-context
 
@@ -198,7 +198,13 @@ This file is the source of truth for dependency and model-weight distribution po
 
 - **License:** MIT for rusqlite; SQLite is public domain
 - **Source:** <https://github.com/rusqlite/rusqlite> and <https://sqlite.org/>
-- **Notes:** Used by the embedded Android backend. Desktop persistence remains in the Python backend.
+- **Notes:** Used by the embedded Android backend. The iOS simulator foundation exercises an in-memory database during debug startup; durable iOS persistence is not yet available. Desktop persistence remains in the Python backend.
+
+### rustls
+
+- **License:** Apache-2.0 OR ISC OR MIT
+- **Source:** <https://github.com/rustls/rustls>
+- **Notes:** The iOS target explicitly installs the already-resolved ring crypto provider before Tauri initializes its existing Rustls-based networking stack. This keeps startup deterministic and does not add an iOS transport feature.
 
 ### android_system_properties
 

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -7,6 +7,8 @@
     "build": "tsc && vite build",
     "android:prepare": "node ../../scripts/package-android.mjs --prepare",
     "android:icons": "tauri icon --output src-tauri/target/android-icons src-tauri/icons/icon.png",
+    "ios:prepare": "node ../../scripts/prepare-ios.mjs",
+    "ios:build:debug": "node ../../scripts/prepare-ios.mjs --build-debug",
     "android:build": "node ../../scripts/package-android.mjs",
     "android:build:debug": "node ../../scripts/package-android.mjs --debug",
     "android:build:release": "node ../../scripts/package-android.mjs --publishable",

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -7134,6 +7134,7 @@ dependencies = [
  "objc2-foundation",
  "rand",
  "rusqlite",
+ "rustls",
  "serde",
  "serde_json",
  "sha2 0.11.0",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -36,13 +36,16 @@ sha2 = "0.11.0"
 snow = "0.10.0"
 tokio = { version = "1.53.1", features = ["time"] }
 
-[target.'cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))'.dependencies]
+[target.'cfg(any(target_os = "android", target_os = "ios", target_os = "linux", target_os = "macos"))'.dependencies]
 cpal = "0.18.2"
 signalsmith-stretch = "0.1.3"
 symphonia = { version = "0.6.1", default-features = false, features = ["all"] }
 
-[target.'cfg(any(target_os = "linux", target_os = "macos"))'.dependencies]
+[target.'cfg(any(target_os = "ios", target_os = "linux", target_os = "macos"))'.dependencies]
 rusqlite = { version = "0.40.2", features = ["bundled"] }
+
+[target.'cfg(target_os = "ios")'.dependencies]
+rustls = { version = "0.23.43", default-features = false, features = ["ring", "std"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 dbus = "0.9.12"

--- a/apps/desktop/src-tauri/src/ios_dependency_smoke.rs
+++ b/apps/desktop/src-tauri/src/ios_dependency_smoke.rs
@@ -1,0 +1,150 @@
+use std::{
+    fs,
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc, Mutex,
+    },
+    thread,
+    time::{Duration, Instant},
+};
+
+use cpal::{
+    traits::{DeviceTrait, HostTrait, StreamTrait},
+    FromSample, Sample, SampleFormat, SizedSample,
+};
+use rusqlite::Connection;
+use tauri::{AppHandle, Manager};
+
+use crate::native_audio::decode::{probe_mobile_durable_audio, write_mono_pcm_wav, DecodedAudio};
+
+pub fn run(app: &AppHandle) -> Result<(), Box<dyn std::error::Error>> {
+    smoke_sqlite()?;
+    smoke_decode(app)?;
+    smoke_signalsmith();
+    smoke_output()?;
+    eprintln!("TuneForge iOS dependency smoke passed.");
+    Ok(())
+}
+
+fn smoke_sqlite() -> Result<(), String> {
+    let connection = Connection::open_in_memory().map_err(|error| error.to_string())?;
+    connection
+        .execute_batch(
+            "CREATE TABLE dependency_gate (value INTEGER NOT NULL);\
+             INSERT INTO dependency_gate (value) VALUES (1);",
+        )
+        .map_err(|error| error.to_string())?;
+    let value: i64 = connection
+        .query_row("SELECT value FROM dependency_gate", [], |row| row.get(0))
+        .map_err(|error| error.to_string())?;
+    (value == 1)
+        .then_some(())
+        .ok_or_else(|| "SQLite dependency smoke returned unexpected data.".to_string())
+}
+
+fn smoke_decode(app: &AppHandle) -> Result<(), String> {
+    let root = app
+        .path()
+        .app_cache_dir()
+        .map_err(|error| error.to_string())?;
+    fs::create_dir_all(&root).map_err(|error| error.to_string())?;
+    let path = root.join("ios-dependency-smoke.wav");
+    let audio = DecodedAudio {
+        samples: vec![0.0; 512],
+        sample_rate: 48_000,
+        channels: 1,
+    };
+    write_mono_pcm_wav(&path, &audio)?;
+    let result = probe_mobile_durable_audio(&path, "wav");
+    let _ = fs::remove_file(path);
+    result
+}
+
+fn smoke_signalsmith() {
+    let mut stretch = signalsmith_stretch::Stretch::preset_default(1, 48_000);
+    let input = [0.0_f32; 512];
+    let mut output = [0.0_f32; 512];
+    stretch.process(input, &mut output);
+}
+
+fn smoke_output() -> Result<(), String> {
+    let host = cpal::default_host();
+    let device = host
+        .default_output_device()
+        .ok_or_else(|| "iOS dependency smoke found no output device.".to_string())?;
+    let supported = device
+        .default_output_config()
+        .map_err(|error| format!("iOS dependency smoke could not read output config: {error}"))?;
+    let sample_format = supported.sample_format();
+    let config = supported.into();
+    let callback_seen = Arc::new(AtomicBool::new(false));
+    let stream_error = Arc::new(Mutex::new(None));
+    let stream = match sample_format {
+        SampleFormat::F32 => build_silent_stream::<f32>(
+            &device,
+            &config,
+            callback_seen.clone(),
+            stream_error.clone(),
+        ),
+        SampleFormat::I16 => build_silent_stream::<i16>(
+            &device,
+            &config,
+            callback_seen.clone(),
+            stream_error.clone(),
+        ),
+        SampleFormat::U16 => build_silent_stream::<u16>(
+            &device,
+            &config,
+            callback_seen.clone(),
+            stream_error.clone(),
+        ),
+        other => Err(format!(
+            "iOS dependency smoke found unsupported output format {other:?}."
+        )),
+    }?;
+    stream
+        .play()
+        .map_err(|error| format!("iOS dependency smoke could not start output: {error}"))?;
+    let deadline = Instant::now() + Duration::from_secs(2);
+    while !callback_seen.load(Ordering::Acquire) && Instant::now() < deadline {
+        thread::sleep(Duration::from_millis(20));
+    }
+    if let Some(error) = stream_error
+        .lock()
+        .map_err(|_| "iOS dependency smoke output error lock failed.".to_string())?
+        .take()
+    {
+        return Err(error);
+    }
+    callback_seen
+        .load(Ordering::Acquire)
+        .then_some(())
+        .ok_or_else(|| "iOS dependency smoke output callback timed out.".to_string())
+}
+
+fn build_silent_stream<T>(
+    device: &cpal::Device,
+    config: &cpal::StreamConfig,
+    callback_seen: Arc<AtomicBool>,
+    stream_error: Arc<Mutex<Option<String>>>,
+) -> Result<cpal::Stream, String>
+where
+    T: Sample + SizedSample + FromSample<f32>,
+{
+    device
+        .build_output_stream(
+            *config,
+            move |output: &mut [T], _| {
+                let silent = T::from_sample(0.0);
+                output.fill(silent);
+                callback_seen.store(true, Ordering::Release);
+            },
+            move |error| {
+                if let Ok(mut slot) = stream_error.lock() {
+                    *slot = Some(format!("iOS dependency smoke output failed: {error}"));
+                }
+            },
+            None,
+        )
+        .map_err(|error| format!("iOS dependency smoke could not build output: {error}"))
+}

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -1,6 +1,6 @@
 use std::{process::Child, sync::Mutex};
 
-#[cfg(not(target_os = "android"))]
+#[cfg(not(any(target_os = "android", target_os = "ios")))]
 use std::{
     collections::HashMap,
     env,
@@ -16,10 +16,12 @@ use std::{
 
 use tauri::{AppHandle, Manager, State};
 
-#[cfg(not(target_os = "android"))]
+#[cfg(not(any(target_os = "android", target_os = "ios")))]
 use serde::{Deserialize, Serialize};
 
 mod file_dialog_scope;
+#[cfg(all(target_os = "ios", debug_assertions))]
+mod ios_dependency_smoke;
 mod mobile_backend;
 #[cfg(target_os = "android")]
 mod mobile_ffmpeg;
@@ -107,13 +109,13 @@ where
         .map_err(|_| "Sync evidence export worker stopped unexpectedly.".to_string())?
 }
 
-#[cfg(not(target_os = "android"))]
+#[cfg(not(any(target_os = "android", target_os = "ios")))]
 fn allocate_port() -> Result<u16, Box<dyn std::error::Error>> {
     let listener = TcpListener::bind(("127.0.0.1", 0))?;
     Ok(listener.local_addr()?.port())
 }
 
-#[cfg(not(target_os = "android"))]
+#[cfg(not(any(target_os = "android", target_os = "ios")))]
 fn try_health_check(port: u16) -> bool {
     let mut stream = match TcpStream::connect(("127.0.0.1", port)) {
         Ok(stream) => stream,
@@ -138,7 +140,7 @@ fn try_health_check(port: u16) -> bool {
     response.starts_with("HTTP/1.1 200") || response.starts_with("HTTP/1.0 200")
 }
 
-#[cfg(not(target_os = "android"))]
+#[cfg(not(any(target_os = "android", target_os = "ios")))]
 fn wait_for_backend(port: u16, timeout: Duration) -> Result<(), Box<dyn std::error::Error>> {
     let deadline = Instant::now() + timeout;
     while Instant::now() < deadline {
@@ -151,12 +153,12 @@ fn wait_for_backend(port: u16, timeout: Duration) -> Result<(), Box<dyn std::err
     Err(format!("Timed out waiting for bundled backend on port {port}").into())
 }
 
-#[cfg(not(target_os = "android"))]
+#[cfg(not(any(target_os = "android", target_os = "ios")))]
 fn python_executable(python_root: &Path) -> PathBuf {
     python_root.join("bin").join("python3.14")
 }
 
-#[cfg(not(target_os = "android"))]
+#[cfg(not(any(target_os = "android", target_os = "ios")))]
 #[derive(Debug, Deserialize, PartialEq, Serialize)]
 #[serde(deny_unknown_fields)]
 struct TorchExtensionProfile {
@@ -173,7 +175,7 @@ struct TorchExtensionProfile {
     pair_id: String,
 }
 
-#[cfg(not(target_os = "android"))]
+#[cfg(not(any(target_os = "android", target_os = "ios")))]
 const TORCH_EXTENSION_POLICY_JSON: &str = r#"{
   "schema_version": 2,
   "contract": "profile-pair-v1",
@@ -198,7 +200,7 @@ const TORCH_EXTENSION_POLICY_JSON: &str = r#"{
   }
 }"#;
 
-#[cfg(not(target_os = "android"))]
+#[cfg(not(any(target_os = "android", target_os = "ios")))]
 #[derive(Deserialize)]
 struct TorchExtensionPolicy {
     schema_version: u8,
@@ -207,7 +209,7 @@ struct TorchExtensionPolicy {
     profiles: HashMap<String, TorchExtensionPolicyProfile>,
 }
 
-#[cfg(not(target_os = "android"))]
+#[cfg(not(any(target_os = "android", target_os = "ios")))]
 #[derive(Deserialize)]
 struct TorchExtensionPolicyProfile {
     ref_prefix: String,
@@ -218,7 +220,7 @@ struct TorchExtensionPolicyProfile {
     pair_id: String,
 }
 
-#[cfg(not(target_os = "android"))]
+#[cfg(not(any(target_os = "android", target_os = "ios")))]
 fn expected_torch_extension_profile(name: &str, role: &str) -> TorchExtensionProfile {
     let policy = serde_json::from_str::<TorchExtensionPolicy>(TORCH_EXTENSION_POLICY_JSON)
         .expect("valid embedded Torch extension policy");
@@ -246,7 +248,7 @@ fn expected_torch_extension_profile(name: &str, role: &str) -> TorchExtensionPro
     }
 }
 
-#[cfg(not(target_os = "android"))]
+#[cfg(not(any(target_os = "android", target_os = "ios")))]
 fn valid_torch_extension_site_packages(root: &Path, name: &str) -> Option<PathBuf> {
     let site_packages = root.join("site-packages");
     let core = root.join("Core");
@@ -270,19 +272,19 @@ fn valid_torch_extension_site_packages(root: &Path, name: &str) -> Option<PathBu
     .then_some(site_packages)
 }
 
-#[cfg(not(target_os = "android"))]
+#[cfg(not(any(target_os = "android", target_os = "ios")))]
 fn select_torch_extension_site_packages(nvidia_root: &Path, legacy_root: &Path) -> Option<PathBuf> {
     valid_torch_extension_site_packages(nvidia_root, "Nvidia")
         .or_else(|| valid_torch_extension_site_packages(legacy_root, "LegacyNvidia"))
 }
 
-#[cfg(not(target_os = "android"))]
+#[cfg(not(any(target_os = "android", target_os = "ios")))]
 fn mounted_torch_extension_site_packages() -> Option<PathBuf> {
     let root = Path::new("/app/lib/tuneforge/backend/torch-extensions");
     select_torch_extension_site_packages(&root.join("Nvidia"), &root.join("LegacyNvidia"))
 }
 
-#[cfg(not(target_os = "android"))]
+#[cfg(not(any(target_os = "android", target_os = "ios")))]
 fn build_python_path(backend_root: &Path) -> Result<String, Box<dyn std::error::Error>> {
     let site_packages = backend_root.join("site-packages");
     let backend_source = backend_root.join("src");
@@ -297,7 +299,7 @@ fn build_python_path(backend_root: &Path) -> Result<String, Box<dyn std::error::
     Ok(joined.to_string_lossy().into_owned())
 }
 
-#[cfg(not(target_os = "android"))]
+#[cfg(not(any(target_os = "android", target_os = "ios")))]
 fn build_backend_library_path(
     python_root: &Path,
     mut prefixes: Vec<PathBuf>,
@@ -309,7 +311,7 @@ fn build_backend_library_path(
     env::join_paths(append_unique_paths(prefixes, current_paths))
 }
 
-#[cfg(not(target_os = "android"))]
+#[cfg(not(any(target_os = "android", target_os = "ios")))]
 fn resolve_bundled_backend_root(app: &AppHandle) -> Result<PathBuf, Box<dyn std::error::Error>> {
     if let Some(root) = env::var_os("TUNEFORGE_BUNDLED_BACKEND_ROOT") {
         return Ok(PathBuf::from(root));
@@ -319,7 +321,10 @@ fn resolve_bundled_backend_root(app: &AppHandle) -> Result<PathBuf, Box<dyn std:
     Ok(resources_root.join("resources").join("backend"))
 }
 
-#[cfg(all(not(target_os = "android"), target_os = "macos"))]
+#[cfg(all(
+    not(any(target_os = "android", target_os = "ios")),
+    target_os = "macos"
+))]
 fn host_tool_fallback_dirs() -> Vec<PathBuf> {
     [
         "/opt/homebrew/bin",
@@ -338,12 +343,15 @@ fn host_tool_fallback_dirs() -> Vec<PathBuf> {
     .collect()
 }
 
-#[cfg(all(not(target_os = "android"), not(target_os = "macos")))]
+#[cfg(all(
+    not(any(target_os = "android", target_os = "ios")),
+    not(target_os = "macos")
+))]
 fn host_tool_fallback_dirs() -> Vec<PathBuf> {
     Vec::new()
 }
 
-#[cfg(not(target_os = "android"))]
+#[cfg(not(any(target_os = "android", target_os = "ios")))]
 fn append_unique_paths(
     mut paths: Vec<PathBuf>,
     extras: impl IntoIterator<Item = PathBuf>,
@@ -356,7 +364,7 @@ fn append_unique_paths(
     paths
 }
 
-#[cfg(not(target_os = "android"))]
+#[cfg(not(any(target_os = "android", target_os = "ios")))]
 fn build_backend_search_path(mut prefixes: Vec<PathBuf>) -> Result<OsString, env::JoinPathsError> {
     let current_paths: Vec<PathBuf> = env::var_os("PATH")
         .map(|path| env::split_paths(&path).collect())
@@ -365,7 +373,11 @@ fn build_backend_search_path(mut prefixes: Vec<PathBuf>) -> Result<OsString, env
     env::join_paths(append_unique_paths(prefixes, host_tool_fallback_dirs()))
 }
 
-#[cfg(all(not(target_os = "android"), any(not(target_os = "macos"), test), unix))]
+#[cfg(all(
+    not(any(target_os = "android", target_os = "ios")),
+    any(not(target_os = "macos"), test),
+    unix
+))]
 fn is_executable_file(path: &Path) -> bool {
     use std::os::unix::fs::PermissionsExt;
 
@@ -375,7 +387,7 @@ fn is_executable_file(path: &Path) -> bool {
 }
 
 #[cfg(all(
-    not(target_os = "android"),
+    not(any(target_os = "android", target_os = "ios")),
     any(not(target_os = "macos"), test),
     not(unix)
 ))]
@@ -383,14 +395,17 @@ fn is_executable_file(path: &Path) -> bool {
     path.is_file()
 }
 
-#[cfg(all(not(target_os = "android"), any(not(target_os = "macos"), test)))]
+#[cfg(all(
+    not(any(target_os = "android", target_os = "ios")),
+    any(not(target_os = "macos"), test)
+))]
 fn find_executable_in_path(binary_name: &str, search_path: &OsString) -> Option<PathBuf> {
     env::split_paths(search_path)
         .map(|directory| directory.join(binary_name))
         .find(|candidate| is_executable_file(candidate))
 }
 
-#[cfg(not(target_os = "android"))]
+#[cfg(not(any(target_os = "android", target_os = "ios")))]
 fn spawn_packaged_backend(app: &AppHandle) -> Result<BackendRuntime, Box<dyn std::error::Error>> {
     let bundled_backend_root = resolve_bundled_backend_root(app)?;
     let bundled_python_root = bundled_backend_root.join("python");
@@ -489,7 +504,7 @@ fn spawn_packaged_backend(app: &AppHandle) -> Result<BackendRuntime, Box<dyn std
     Ok(BackendRuntime::new(base_url, Some(child)))
 }
 
-#[cfg(not(target_os = "android"))]
+#[cfg(not(any(target_os = "android", target_os = "ios")))]
 fn development_backend() -> BackendRuntime {
     let base_url = env::var("TUNEFORGE_DEV_API_BASE_URL")
         .unwrap_or_else(|_| "http://127.0.0.1:8765".to_string());
@@ -538,6 +553,8 @@ fn install_linux_media_permission_handler(
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
+    #[cfg(target_os = "ios")]
+    let _ = rustls::crypto::ring::default_provider().install_default();
     let builder = tauri::Builder::default();
     #[cfg(target_os = "android")]
     let builder = builder.plugin(tauri_plugin_barcode_scanner::init());
@@ -547,14 +564,16 @@ pub fn run() {
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_fs::init())
         .setup(|app| {
-            #[cfg(target_os = "android")]
+            #[cfg(any(target_os = "android", target_os = "ios"))]
             let runtime = BackendRuntime::new("mobile://embedded".to_string(), None);
-            #[cfg(not(target_os = "android"))]
+            #[cfg(not(any(target_os = "android", target_os = "ios")))]
             let runtime = if cfg!(debug_assertions) {
                 development_backend()
             } else {
                 spawn_packaged_backend(app.handle())?
             };
+            #[cfg(all(target_os = "ios", debug_assertions))]
+            ios_dependency_smoke::run(app.handle())?;
             let power_inhibition = power_inhibition::PowerInhibitionState::new();
             let mobile_media =
                 mobile_media_transport::MobileMediaTransportState::new(app.handle().clone())?;
@@ -684,7 +703,7 @@ pub fn run() {
     });
 }
 
-#[cfg(all(test, not(target_os = "android")))]
+#[cfg(all(test, not(any(target_os = "android", target_os = "ios"))))]
 mod tests {
     use super::*;
 

--- a/apps/desktop/src-tauri/src/mobile_backend/stubs.rs
+++ b/apps/desktop/src-tauri/src/mobile_backend/stubs.rs
@@ -2,11 +2,35 @@ use super::*;
 use serde_json::Value;
 use tauri::AppHandle;
 
-#[cfg(not(target_os = "android"))]
+#[cfg(target_os = "ios")]
+#[tauri::command]
+pub fn mobile_capabilities() -> Result<MobileCapabilities, String> {
+    Ok(MobileCapabilities {
+        platform: "ios",
+        media_backend: "cpal_coreaudio",
+        is_emulator: cfg!(target_abi = "sim"),
+        gpu_backend: None,
+        analysis_available: false,
+        basic_chords_available: false,
+        whisper_available: false,
+        stem_separation_available: false,
+        generation_testing_available: false,
+        max_recommended_model: None,
+        cpu_fallback_allowed: false,
+    })
+}
+
+#[cfg(not(any(target_os = "android", target_os = "ios")))]
 #[tauri::command]
 pub fn mobile_capabilities() -> Result<MobileCapabilities, String> {
     Err(MOBILE_UNAVAILABLE.to_string())
 }
+
+#[cfg(target_os = "ios")]
+const MOBILE_STUB_UNAVAILABLE: &str =
+    "This operation is unavailable in the iOS runtime foundation.";
+#[cfg(not(target_os = "ios"))]
+const MOBILE_STUB_UNAVAILABLE: &str = MOBILE_UNAVAILABLE;
 
 #[cfg(not(target_os = "android"))]
 macro_rules! mobile_stub {
@@ -14,7 +38,7 @@ macro_rules! mobile_stub {
         #[tauri::command]
         pub fn $name($($arg: $ty,)*) -> Result<$ret, String> {
             $(let _ = $arg;)*
-            Err(MOBILE_UNAVAILABLE.to_string())
+            Err(MOBILE_STUB_UNAVAILABLE.to_string())
         }
     };
 }

--- a/apps/desktop/src-tauri/src/native_audio/capture.rs
+++ b/apps/desktop/src-tauri/src/native_audio/capture.rs
@@ -3,6 +3,8 @@ use std::sync::{mpsc, Arc, Mutex};
 use std::thread::{self, JoinHandle};
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use tauri::AppHandle;
+#[cfg(target_os = "ios")]
+use tauri::Emitter;
 
 #[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
 use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};

--- a/apps/desktop/src-tauri/src/native_audio/decode.rs
+++ b/apps/desktop/src-tauri/src/native_audio/decode.rs
@@ -2,9 +2,19 @@
 
 use std::{fs, path::Path};
 
-#[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
+#[cfg(any(
+    target_os = "android",
+    target_os = "ios",
+    target_os = "linux",
+    target_os = "macos"
+))]
 use std::{fs::File, io::Read};
-#[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
+#[cfg(any(
+    target_os = "android",
+    target_os = "ios",
+    target_os = "linux",
+    target_os = "macos"
+))]
 use symphonia::core::{
     codecs::audio::{
         well_known::{
@@ -35,14 +45,34 @@ pub struct DecodedInterleavedAudio {
     pub channels: u32,
 }
 
-#[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
+#[cfg(any(
+    target_os = "android",
+    target_os = "ios",
+    target_os = "linux",
+    target_os = "macos"
+))]
 const DURABLE_PROBE_PACKET_LIMIT: usize = 32;
-#[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
+#[cfg(any(
+    target_os = "android",
+    target_os = "ios",
+    target_os = "linux",
+    target_os = "macos"
+))]
 const DURABLE_PROBE_PACKET_BYTES: usize = 4 * 1024 * 1024;
-#[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
+#[cfg(any(
+    target_os = "android",
+    target_os = "ios",
+    target_os = "linux",
+    target_os = "macos"
+))]
 const DURABLE_PROBE_HEADER_BYTES: usize = 64;
 
-#[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
+#[cfg(any(
+    target_os = "android",
+    target_os = "ios",
+    target_os = "linux",
+    target_os = "macos"
+))]
 fn durable_container_matches(format: &str, header: &[u8]) -> bool {
     match format {
         "wav" => header.starts_with(b"RIFF") && header.get(8..12) == Some(b"WAVE"),
@@ -60,7 +90,12 @@ fn durable_container_matches(format: &str, header: &[u8]) -> bool {
 }
 
 pub fn probe_mobile_durable_audio(path: &Path, expected_format: &str) -> Result<(), String> {
-    #[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
+    #[cfg(any(
+        target_os = "android",
+        target_os = "ios",
+        target_os = "linux",
+        target_os = "macos"
+    ))]
     {
         let expected_format = expected_format.trim().to_ascii_lowercase();
         let expected_suffix = format!(".{expected_format}");
@@ -162,7 +197,12 @@ pub fn probe_mobile_durable_audio(path: &Path, expected_format: &str) -> Result<
         );
     }
 
-    #[cfg(not(any(target_os = "android", target_os = "linux", target_os = "macos")))]
+    #[cfg(not(any(
+        target_os = "android",
+        target_os = "ios",
+        target_os = "linux",
+        target_os = "macos"
+    )))]
     {
         let _ = (path, expected_format);
         Err("Durable audio probing is unavailable on this platform.".to_string())

--- a/apps/desktop/src-tauri/src/native_audio/mod.rs
+++ b/apps/desktop/src-tauri/src/native_audio/mod.rs
@@ -9,7 +9,12 @@ pub mod diagnostics;
 pub mod mixer;
 pub mod platform;
 pub mod session;
-#[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
+#[cfg(any(
+    target_os = "android",
+    target_os = "ios",
+    target_os = "linux",
+    target_os = "macos"
+))]
 mod source_scope;
 pub mod system_input;
 pub mod timeline;

--- a/apps/desktop/src-tauri/src/native_audio/source_scope.rs
+++ b/apps/desktop/src-tauri/src/native_audio/source_scope.rs
@@ -9,14 +9,14 @@ use std::{env, ffi::OsStr};
 
 use rusqlite::{params, Connection, Error as SqliteError, OpenFlags, OptionalExtension};
 use serde_json::Value;
-#[cfg(not(target_os = "android"))]
+#[cfg(not(any(target_os = "android", target_os = "ios")))]
 use tauri::AppHandle;
-#[cfg(target_os = "android")]
+#[cfg(any(target_os = "android", target_os = "ios"))]
 use tauri::{AppHandle, Manager};
 
 #[cfg(any(target_os = "linux", target_os = "macos", test))]
 const BACKEND_DATABASE_NAME: &str = "app.sqlite";
-#[cfg(target_os = "android")]
+#[cfg(any(target_os = "android", target_os = "ios"))]
 const MOBILE_DATABASE_NAME: &str = "mobile.sqlite3";
 const BACKEND_PROJECTS_DIR: &str = "projects";
 const PLAYBACK_SOURCE_MISSING_MESSAGE: &str = "Native playback source is missing or unavailable.";
@@ -33,7 +33,7 @@ pub(super) struct PlaybackSourceScope {
 
 impl PlaybackSourceScope {
     pub(super) fn from_app(app: &AppHandle) -> Result<Self, String> {
-        #[cfg(target_os = "android")]
+        #[cfg(any(target_os = "android", target_os = "ios"))]
         {
             let data_root = app
                 .path()
@@ -43,14 +43,14 @@ impl PlaybackSourceScope {
                 .map_err(|error| error.message().to_string());
         }
 
-        #[cfg(not(target_os = "android"))]
+        #[cfg(not(any(target_os = "android", target_os = "ios")))]
         {
             let _ = app;
             Self::from_backend_config()
         }
     }
 
-    #[cfg(not(target_os = "android"))]
+    #[cfg(not(any(target_os = "android", target_os = "ios")))]
     pub(super) fn from_backend_config() -> Result<Self, String> {
         let data_root = backend_data_root()?;
         Self::from_backend_data_root(&data_root).map_err(|error| error.message().to_string())

--- a/apps/desktop/src-tauri/src/native_audio/transport.rs
+++ b/apps/desktop/src-tauri/src/native_audio/transport.rs
@@ -7,7 +7,7 @@ use std::sync::{
 use std::time::{Duration, Instant};
 use tauri::AppHandle;
 
-#[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
+#[cfg(any(mobile, target_os = "linux", target_os = "macos"))]
 use std::{
     fs::File,
     io::{Read, Seek, SeekFrom},
@@ -16,11 +16,11 @@ use std::{
     thread::{self, JoinHandle},
 };
 
-#[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
+#[cfg(any(mobile, target_os = "linux", target_os = "macos"))]
 use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
-#[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
+#[cfg(any(mobile, target_os = "linux", target_os = "macos"))]
 use cpal::{ErrorKind, FromSample, Sample, SampleFormat, SizedSample};
-#[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
+#[cfg(any(mobile, target_os = "linux", target_os = "macos"))]
 use symphonia::core::{
     codecs::audio::{AudioDecoder, AudioDecoderOptions},
     errors::Error as SymphoniaError,
@@ -29,7 +29,7 @@ use symphonia::core::{
     meta::MetadataOptions,
     units::Time,
 };
-#[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
+#[cfg(any(mobile, target_os = "linux", target_os = "macos"))]
 use tauri::Emitter;
 
 use super::{
@@ -44,7 +44,7 @@ use super::{
     AudioCapabilities,
 };
 
-#[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
+#[cfg(any(mobile, target_os = "linux", target_os = "macos"))]
 use super::{
     decode::{
         convert_interleaved_channels, decode_wav_sample, read_u16_le, read_u32_le,
@@ -66,15 +66,15 @@ const CLICK_ACCENT_FREQUENCY_HZ: f64 = 1760.0;
 const PRECOUNT_FREQUENCY_HZ: f64 = 760.0;
 const PRECOUNT_ATTACK_SECONDS: f64 = 0.002;
 const PRECOUNT_DURATION_SECONDS: f64 = 0.045;
-#[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
+#[cfg(any(mobile, target_os = "linux", target_os = "macos"))]
 const STREAM_CHUNK_FRAMES: usize = 2048;
-#[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
+#[cfg(any(mobile, target_os = "linux", target_os = "macos"))]
 const RING_BUFFER_SECONDS: usize = 8;
-#[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
+#[cfg(any(mobile, target_os = "linux", target_os = "macos"))]
 const PREBUFFER_TARGET_SECONDS: f64 = 0.12;
-#[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
+#[cfg(any(mobile, target_os = "linux", target_os = "macos"))]
 const PREBUFFER_TIMEOUT: Duration = Duration::from_millis(1500);
-#[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
+#[cfg(any(mobile, target_os = "linux", target_os = "macos"))]
 const PREBUFFER_POLL_INTERVAL: Duration = Duration::from_millis(5);
 const SUSTAINED_UNDERRUN_ERROR_SECONDS: f64 = 0.5;
 const AUDIBLE_GAIN_FLOOR: f32 = 0.0001;
@@ -365,7 +365,7 @@ impl RingReadStatus {
     }
 }
 
-#[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
+#[cfg(any(mobile, target_os = "linux", target_os = "macos"))]
 enum WorkerControl {
     SetPlaybackRate {
         playback_rate: f64,
@@ -379,7 +379,7 @@ enum WorkerControl {
     Stop,
 }
 
-#[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
+#[cfg(any(mobile, target_os = "linux", target_os = "macos"))]
 struct WorkerError {
     lane_id: String,
     message: String,
@@ -472,7 +472,7 @@ struct PlaybackShared {
     diagnostics_gain_first_change_recorded: bool,
     timeline: Arc<Mutex<Timeline>>,
     generation: u64,
-    #[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
+    #[cfg(any(mobile, target_os = "linux", target_os = "macos"))]
     report_sender: mpsc::SyncSender<RuntimeReport>,
     pending_cues: VecDeque<timeline::CueEvent>,
     terminal_reported: bool,
@@ -515,7 +515,7 @@ impl PlaybackShared {
         }
     }
 
-    #[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
+    #[cfg(any(mobile, target_os = "linux", target_os = "macos"))]
     fn prebuffer_ready(&self) -> bool {
         if self.duration_seconds > 0.0 && self.position_seconds >= self.duration_seconds {
             return true;
@@ -545,7 +545,7 @@ impl PlaybackShared {
     }
 }
 
-#[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
+#[cfg(any(mobile, target_os = "linux", target_os = "macos"))]
 fn mark_terminal_runtime_error(
     shared: &mut PlaybackShared,
     code: NativeAudioErrorCode,
@@ -560,7 +560,7 @@ fn mark_terminal_runtime_error(
     diagnostics::record_callback_safe_code(shared.diagnostics_generation, diagnostic_code);
 }
 
-#[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
+#[cfg(any(mobile, target_os = "linux", target_os = "macos"))]
 fn output_stream_error_code(error: &cpal::Error) -> NativeAudioErrorCode {
     match error.kind() {
         ErrorKind::DeviceChanged => NativeAudioErrorCode::DeviceChanged,
@@ -570,7 +570,7 @@ fn output_stream_error_code(error: &cpal::Error) -> NativeAudioErrorCode {
     }
 }
 
-#[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
+#[cfg(any(mobile, target_os = "linux", target_os = "macos"))]
 fn diagnostic_output_stream_error_kind(error: &cpal::Error) -> DiagnosticOutputStreamErrorKind {
     match error.kind() {
         ErrorKind::DeviceBusy => DiagnosticOutputStreamErrorKind::DeviceBusy,
@@ -591,7 +591,7 @@ fn diagnostic_output_stream_error_kind(error: &cpal::Error) -> DiagnosticOutputS
     }
 }
 
-#[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
+#[cfg(any(mobile, target_os = "linux", target_os = "macos"))]
 fn handle_output_stream_error_with_policy(
     shared: &mut PlaybackShared,
     error: &cpal::Error,
@@ -612,12 +612,12 @@ fn handle_output_stream_error_with_policy(
     }
 }
 
-#[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
+#[cfg(any(mobile, target_os = "linux", target_os = "macos"))]
 fn handle_output_stream_error(shared: &mut PlaybackShared, error: &cpal::Error) {
     handle_output_stream_error_with_policy(shared, error, cfg!(target_os = "linux"));
 }
 
-#[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
+#[cfg(any(mobile, target_os = "linux", target_os = "macos"))]
 fn diagnostic_code_for_output_stream_error(code: NativeAudioErrorCode) -> DiagnosticSafeCode {
     match code {
         NativeAudioErrorCode::DeviceChanged => DiagnosticSafeCode::DeviceChanged,
@@ -628,7 +628,7 @@ fn diagnostic_code_for_output_stream_error(code: NativeAudioErrorCode) -> Diagno
     }
 }
 
-#[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
+#[cfg(any(mobile, target_os = "linux", target_os = "macos"))]
 fn mark_device_changed(shared: &mut PlaybackShared) {
     if shared.terminal_error.is_some()
         || shared.terminal_cause.is_some()
@@ -643,7 +643,7 @@ fn mark_device_changed(shared: &mut PlaybackShared) {
     );
 }
 
-#[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
+#[cfg(any(mobile, target_os = "linux", target_os = "macos"))]
 fn prebuffer_target_samples(sample_rate: u32, channels: usize) -> usize {
     let target_frames = (sample_rate as f64 * PREBUFFER_TARGET_SECONDS).ceil() as usize;
     target_frames
@@ -651,7 +651,7 @@ fn prebuffer_target_samples(sample_rate: u32, channels: usize) -> usize {
         .max(STREAM_CHUNK_FRAMES.saturating_mul(channels))
 }
 
-#[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
+#[cfg(any(mobile, target_os = "linux", target_os = "macos"))]
 struct PlaybackRuntime {
     shared: Arc<Mutex<PlaybackShared>>,
     audio_stop_sender: mpsc::Sender<RuntimeControl>,
@@ -663,7 +663,7 @@ struct PlaybackRuntime {
     auxiliary_only: bool,
 }
 
-#[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
+#[cfg(any(mobile, target_os = "linux", target_os = "macos"))]
 enum RuntimeControl {
     Stop,
 }
@@ -684,11 +684,11 @@ pub struct TransportState {
     diagnostics_generation: u64,
     timeline: Option<Arc<Mutex<Timeline>>>,
     generation: u64,
-    #[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
+    #[cfg(any(mobile, target_os = "linux", target_os = "macos"))]
     report_sender: Option<mpsc::SyncSender<RuntimeReport>>,
-    #[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
+    #[cfg(any(mobile, target_os = "linux", target_os = "macos"))]
     app: Option<AppHandle>,
-    #[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
+    #[cfg(any(mobile, target_os = "linux", target_os = "macos"))]
     runtime: Option<PlaybackRuntime>,
     #[cfg(test)]
     fail_next_runtime_start: bool,
@@ -714,11 +714,11 @@ impl Default for TransportState {
             diagnostics_generation: 0,
             timeline: None,
             generation: 0,
-            #[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
+            #[cfg(any(mobile, target_os = "linux", target_os = "macos"))]
             report_sender: None,
-            #[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
+            #[cfg(any(mobile, target_os = "linux", target_os = "macos"))]
             app: None,
-            #[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
+            #[cfg(any(mobile, target_os = "linux", target_os = "macos"))]
             runtime: None,
             #[cfg(test)]
             fail_next_runtime_start: false,
@@ -733,12 +733,12 @@ impl TransportState {
         &mut self,
         generation: u64,
         timeline: Arc<Mutex<Timeline>>,
-        #[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
+        #[cfg(any(mobile, target_os = "linux", target_os = "macos"))]
         report_sender: mpsc::SyncSender<RuntimeReport>,
     ) {
         self.generation = generation;
         self.timeline = Some(timeline);
-        #[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
+        #[cfg(any(mobile, target_os = "linux", target_os = "macos"))]
         {
             self.report_sender = Some(report_sender);
         }
@@ -749,33 +749,30 @@ impl TransportState {
     }
 
     pub fn has_runtime(&self) -> bool {
-        #[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
+        #[cfg(any(mobile, target_os = "linux", target_os = "macos"))]
         {
             self.runtime.is_some()
         }
-        #[cfg(not(any(target_os = "android", target_os = "linux", target_os = "macos")))]
+        #[cfg(not(any(mobile, target_os = "linux", target_os = "macos")))]
         {
             false
         }
     }
 
     pub fn has_auxiliary_runtime(&self) -> bool {
-        #[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
+        #[cfg(any(mobile, target_os = "linux", target_os = "macos"))]
         {
             self.runtime
                 .as_ref()
                 .is_some_and(|runtime| runtime.auxiliary_only)
         }
-        #[cfg(not(any(target_os = "android", target_os = "linux", target_os = "macos")))]
+        #[cfg(not(any(mobile, target_os = "linux", target_os = "macos")))]
         {
             false
         }
     }
 
-    #[cfg(all(
-        test,
-        any(target_os = "android", target_os = "linux", target_os = "macos")
-    ))]
+    #[cfg(all(test, any(mobile, target_os = "linux", target_os = "macos")))]
     pub(crate) fn install_test_auxiliary_runtime(&mut self) {
         let timeline = self
             .timeline
@@ -829,7 +826,7 @@ impl TransportState {
     }
 
     pub fn begin_explicit_attempt(&mut self, capabilities: AudioCapabilities) {
-        #[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
+        #[cfg(any(mobile, target_os = "linux", target_os = "macos"))]
         if self.runtime.as_ref().is_some_and(|runtime| {
             runtime.shared.lock().ok().is_some_and(|shared| {
                 shared.terminal_error.is_some() || shared.terminal_cause.is_some()
@@ -853,7 +850,7 @@ impl TransportState {
                 timeline.stop();
             }
         }
-        #[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
+        #[cfg(any(mobile, target_os = "linux", target_os = "macos"))]
         if let Some(runtime) = &self.runtime {
             for sender in &runtime.worker_control_senders {
                 let _ = sender.send(WorkerControl::Stop);
@@ -874,7 +871,7 @@ impl TransportState {
 
     pub fn set_diagnostics_generation(&mut self, generation: u64) {
         self.diagnostics_generation = generation;
-        #[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
+        #[cfg(any(mobile, target_os = "linux", target_os = "macos"))]
         if let Some(runtime) = &self.runtime {
             if let Ok(mut shared) = runtime.shared.lock() {
                 shared.diagnostics_generation = generation;
@@ -913,18 +910,12 @@ impl TransportState {
             .expect("session acquisition is validated before prepare");
         let duration_seconds = request.duration_seconds.unwrap_or(0.0).max(0.0);
         let playback_rate = normalize_playback_rate(request.playback_rate);
-        #[cfg(all(
-            not(test),
-            any(target_os = "android", target_os = "linux", target_os = "macos")
-        ))]
+        #[cfg(all(not(test), any(mobile, target_os = "linux", target_os = "macos")))]
         let runtime_unavailable_reason = (capabilities.native_playback_supported && app.is_none())
             .then(|| "Native audio runtime is unavailable.".to_string());
-        #[cfg(all(
-            test,
-            any(target_os = "android", target_os = "linux", target_os = "macos")
-        ))]
+        #[cfg(all(test, any(mobile, target_os = "linux", target_os = "macos")))]
         let runtime_unavailable_reason: Option<String> = None;
-        #[cfg(not(any(target_os = "android", target_os = "linux", target_os = "macos")))]
+        #[cfg(not(any(mobile, target_os = "linux", target_os = "macos")))]
         let runtime_unavailable_reason = capabilities
             .native_playback_supported
             .then(|| "Native playback is unsupported on this platform.".to_string());
@@ -932,13 +923,13 @@ impl TransportState {
             capabilities.native_playback_supported && runtime_unavailable_reason.is_none();
         let availability_reason = runtime_unavailable_reason
             .or_else(|| capabilities.availability_reason.map(str::to_string));
-        #[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
+        #[cfg(any(mobile, target_os = "linux", target_os = "macos"))]
         let preserve_standalone_runtime = self.click.enabled && self.runtime.is_some();
-        #[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
+        #[cfg(any(mobile, target_os = "linux", target_os = "macos"))]
         if !preserve_standalone_runtime {
             self.stop_runtime();
         }
-        #[cfg(not(any(target_os = "android", target_os = "linux", target_os = "macos")))]
+        #[cfg(not(any(mobile, target_os = "linux", target_os = "macos")))]
         self.stop_runtime();
 
         self.session_id = Some(request.session_id.clone());
@@ -951,7 +942,7 @@ impl TransportState {
         self.lanes = lanes.clone();
         self.native_playback_supported = native_playback_supported;
         self.availability_reason = availability_reason;
-        #[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
+        #[cfg(any(mobile, target_os = "linux", target_os = "macos"))]
         {
             self.app = app;
             if preserve_standalone_runtime {
@@ -1010,7 +1001,7 @@ impl TransportState {
                 next_playback_rate = Some(rate);
             }
         }
-        #[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
+        #[cfg(any(mobile, target_os = "linux", target_os = "macos"))]
         if let Some(runtime) = &self.runtime {
             let mut should_prebuffer = false;
             if let Ok(mut shared) = runtime.shared.lock() {
@@ -1052,13 +1043,13 @@ impl TransportState {
     pub fn bind_auxiliary_runtime(
         &mut self,
         timeline: Arc<Mutex<Timeline>>,
-        #[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
+        #[cfg(any(mobile, target_os = "linux", target_os = "macos"))]
         report_sender: mpsc::SyncSender<RuntimeReport>,
     ) {
         if self.timeline.is_none() {
             self.timeline = Some(timeline);
         }
-        #[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
+        #[cfg(any(mobile, target_os = "linux", target_os = "macos"))]
         if self.report_sender.is_none() {
             self.report_sender = Some(report_sender);
         }
@@ -1100,7 +1091,7 @@ impl TransportState {
                 .validate_acquisition()
                 .map_err(str::to_string)?;
         }
-        #[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
+        #[cfg(any(mobile, target_os = "linux", target_os = "macos"))]
         if acquisition && request.enabled && self.runtime_requires_replacement(false) {
             self.stop_runtime();
             self.click.enabled = false;
@@ -1121,10 +1112,10 @@ impl TransportState {
         let previous_status = self.status;
         let previous_position_seconds = self.position_seconds;
         let previous_started_at = self.started_at;
-        #[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
+        #[cfg(any(mobile, target_os = "linux", target_os = "macos"))]
         let previous_app = self.app.clone();
         let state = self.apply_standalone_metronome(&request)?;
-        #[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
+        #[cfg(any(mobile, target_os = "linux", target_os = "macos"))]
         let lifecycle_result = (|| {
             if let Some(app) = app {
                 self.app = Some(app);
@@ -1151,7 +1142,7 @@ impl TransportState {
             }
             Ok::<(), String>(())
         })();
-        #[cfg(not(any(target_os = "android", target_os = "linux", target_os = "macos")))]
+        #[cfg(not(any(mobile, target_os = "linux", target_os = "macos")))]
         let lifecycle_result = Ok::<(), String>(());
         if let Err(error) = lifecycle_result {
             self.click = previous_click;
@@ -1163,11 +1154,11 @@ impl TransportState {
             self.status = previous_status;
             self.position_seconds = previous_position_seconds;
             self.started_at = previous_started_at;
-            #[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
+            #[cfg(any(mobile, target_os = "linux", target_os = "macos"))]
             {
                 self.app = previous_app;
             }
-            #[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
+            #[cfg(any(mobile, target_os = "linux", target_os = "macos"))]
             if let Some(runtime) = &self.runtime {
                 if let Ok(mut shared) = runtime.shared.lock() {
                     shared.click = self.click.clone();
@@ -1277,9 +1268,9 @@ impl TransportState {
             self.position_seconds = self.clamp_position(start_time_seconds);
         }
         let _ = request.scheduled_start_time_seconds;
-        #[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
+        #[cfg(any(mobile, target_os = "linux", target_os = "macos"))]
         let runtime_started = self.ensure_runtime(true)?;
-        #[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
+        #[cfg(any(mobile, target_os = "linux", target_os = "macos"))]
         let terminal_runtime = self.runtime.as_ref().and_then(|runtime| {
             let shared = runtime.shared.lock().ok()?;
             let reason = shared
@@ -1292,7 +1283,7 @@ impl TransportState {
                 })?;
             Some((shared.position_seconds, reason))
         });
-        #[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
+        #[cfg(any(mobile, target_os = "linux", target_os = "macos"))]
         if let Some((position_seconds, reason)) = terminal_runtime {
             self.position_seconds = position_seconds;
             self.status = TransportStatus::Paused;
@@ -1302,7 +1293,7 @@ impl TransportState {
             self.stop_runtime();
             return Err(reason);
         }
-        #[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
+        #[cfg(any(mobile, target_os = "linux", target_os = "macos"))]
         if let Some(runtime) = &self.runtime {
             if runtime_started || request.start_time_seconds.is_some() {
                 seek_runtime_workers(runtime, self.position_seconds, self.diagnostics_generation);
@@ -1351,7 +1342,7 @@ impl TransportState {
         self.status = TransportStatus::Paused;
         self.started_at = None;
 
-        #[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
+        #[cfg(any(mobile, target_os = "linux", target_os = "macos"))]
         if let Some(runtime) = &self.runtime {
             if let Ok(mut shared) = runtime.shared.lock() {
                 self.position_seconds = shared.position_seconds;
@@ -1375,18 +1366,18 @@ impl TransportState {
                 }
             }
         }
-        #[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
+        #[cfg(any(mobile, target_os = "linux", target_os = "macos"))]
         if !self.click.enabled || !self.native_playback_supported {
             self.stop_runtime();
         }
-        #[cfg(not(any(target_os = "android", target_os = "linux", target_os = "macos")))]
+        #[cfg(not(any(mobile, target_os = "linux", target_os = "macos")))]
         self.stop_runtime();
 
         self.snapshot()
     }
 
     pub fn stop(&mut self) -> AudioSnapshot {
-        #[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
+        #[cfg(any(mobile, target_os = "linux", target_os = "macos"))]
         let failed_runtime = self.runtime.as_ref().and_then(|runtime| {
             let shared = runtime.shared.lock().ok()?;
             let reason = shared
@@ -1399,7 +1390,7 @@ impl TransportState {
                 })?;
             Some((shared.position_seconds, reason))
         });
-        #[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
+        #[cfg(any(mobile, target_os = "linux", target_os = "macos"))]
         if let Some((position_seconds, reason)) = failed_runtime {
             self.position_seconds = position_seconds;
             self.status = TransportStatus::Paused;
@@ -1413,7 +1404,7 @@ impl TransportState {
         self.position_seconds = 0.0;
         self.status = TransportStatus::Stopped;
         self.started_at = None;
-        #[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
+        #[cfg(any(mobile, target_os = "linux", target_os = "macos"))]
         if self.click.enabled {
             if let Some(runtime) = &self.runtime {
                 seek_runtime_workers(runtime, 0.0, self.diagnostics_generation);
@@ -1428,7 +1419,7 @@ impl TransportState {
         } else {
             self.stop_runtime();
         }
-        #[cfg(not(any(target_os = "android", target_os = "linux", target_os = "macos")))]
+        #[cfg(not(any(mobile, target_os = "linux", target_os = "macos")))]
         self.stop_runtime();
 
         self.snapshot()
@@ -1440,7 +1431,7 @@ impl TransportState {
             self.started_at = Some(Instant::now());
         }
 
-        #[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
+        #[cfg(any(mobile, target_os = "linux", target_os = "macos"))]
         if let Some(runtime) = &self.runtime {
             let was_playing = self.status == TransportStatus::Playing;
             if was_playing {
@@ -1476,7 +1467,7 @@ impl TransportState {
     }
 
     pub fn snapshot(&self) -> AudioSnapshot {
-        #[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
+        #[cfg(any(mobile, target_os = "linux", target_os = "macos"))]
         if let Some(runtime) = &self.runtime {
             if let Ok(shared) = runtime.shared.lock() {
                 return shared.snapshot();
@@ -1520,7 +1511,7 @@ impl TransportState {
         clamp_position(value, self.duration_seconds)
     }
 
-    #[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
+    #[cfg(any(mobile, target_os = "linux", target_os = "macos"))]
     fn ensure_runtime(&mut self, require_project_runtime: bool) -> Result<bool, String> {
         #[cfg(test)]
         if std::mem::take(&mut self.fail_next_runtime_start) {
@@ -1596,7 +1587,7 @@ impl TransportState {
         }
     }
 
-    #[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
+    #[cfg(any(mobile, target_os = "linux", target_os = "macos"))]
     fn runtime_requires_replacement(&self, require_project_runtime: bool) -> bool {
         self.runtime.as_ref().is_some_and(|runtime| {
             let terminal = runtime.shared.lock().ok().is_some_and(|shared| {
@@ -1617,7 +1608,7 @@ impl TransportState {
     }
 
     fn stop_runtime(&mut self) {
-        #[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
+        #[cfg(any(mobile, target_os = "linux", target_os = "macos"))]
         if let Some(mut runtime) = self.runtime.take() {
             for sender in &runtime.worker_control_senders {
                 let _ = sender.send(WorkerControl::Stop);
@@ -1637,7 +1628,7 @@ impl TransportState {
     }
 }
 
-#[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
+#[cfg(any(mobile, target_os = "linux", target_os = "macos"))]
 fn runtime_threads_finished(runtime: &PlaybackRuntime) -> bool {
     runtime
         .audio_thread
@@ -1650,7 +1641,7 @@ fn runtime_threads_finished(runtime: &PlaybackRuntime) -> bool {
         && runtime.worker_threads.iter().all(JoinHandle::is_finished)
 }
 
-#[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
+#[cfg(any(mobile, target_os = "linux", target_os = "macos"))]
 fn seek_runtime_workers(
     runtime: &PlaybackRuntime,
     position_seconds: f64,
@@ -1670,7 +1661,7 @@ fn seek_runtime_workers(
     }
 }
 
-#[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
+#[cfg(any(mobile, target_os = "linux", target_os = "macos"))]
 fn wait_for_runtime_prebuffer(
     runtime: &PlaybackRuntime,
 ) -> Result<(), NativePlaybackTerminalCause> {
@@ -1693,7 +1684,7 @@ fn wait_for_runtime_prebuffer(
     }
 }
 
-#[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
+#[cfg(any(mobile, target_os = "linux", target_os = "macos"))]
 fn mark_runtime_terminal(runtime: &PlaybackRuntime, cause: NativePlaybackTerminalCause) {
     if let Ok(mut shared) = runtime.shared.lock() {
         shared.status = TransportStatus::Paused;
@@ -2214,7 +2205,7 @@ fn render_shared_output(shared: &mut PlaybackShared, output: &mut [f32]) {
     }
 }
 
-#[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
+#[cfg(any(mobile, target_os = "linux", target_os = "macos"))]
 fn render_shared_output_typed<T>(shared: &mut PlaybackShared, output: &mut [T])
 where
     T: Sample + FromSample<f32> + Copy,
@@ -2286,7 +2277,7 @@ where
     }
 }
 
-#[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
+#[cfg(any(mobile, target_os = "linux", target_os = "macos"))]
 fn start_native_runtime(
     app: AppHandle,
     session_id: &str,
@@ -2439,7 +2430,7 @@ fn start_native_runtime(
     })
 }
 
-#[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
+#[cfg(any(mobile, target_os = "linux", target_os = "macos"))]
 fn start_output_stream_thread(
     config: cpal::StreamConfig,
     sample_format: SampleFormat,
@@ -2486,7 +2477,7 @@ fn start_output_stream_thread(
     drop(stream);
 }
 
-#[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
+#[cfg(any(mobile, target_os = "linux", target_os = "macos"))]
 fn build_output_stream(
     device: &cpal::Device,
     config: &cpal::StreamConfig,
@@ -2503,7 +2494,7 @@ fn build_output_stream(
     }
 }
 
-#[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
+#[cfg(any(mobile, target_os = "linux", target_os = "macos"))]
 fn build_typed_output_stream<T>(
     device: &cpal::Device,
     config: &cpal::StreamConfig,
@@ -2543,7 +2534,7 @@ where
     Ok((stream, callback_receiver))
 }
 
-#[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
+#[cfg(any(mobile, target_os = "linux", target_os = "macos"))]
 fn emit_runtime_events(app: &AppHandle, shared: &Arc<Mutex<PlaybackShared>>) -> bool {
     let (snapshot, ended, error, terminal, cues, reporter, metronome_enabled) = {
         let mut shared = match shared.lock() {
@@ -2657,30 +2648,30 @@ fn emit_runtime_events(app: &AppHandle, shared: &Arc<Mutex<PlaybackShared>>) -> 
     should_stop_runtime_after_report(ended, terminal.is_some(), metronome_enabled)
 }
 
-#[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
+#[cfg(any(mobile, target_os = "linux", target_os = "macos"))]
 fn should_emit_ended(ended_pending: bool, requires_error_handling: bool) -> bool {
     ended_pending && !requires_error_handling
 }
 
-#[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
+#[cfg(any(mobile, target_os = "linux", target_os = "macos"))]
 fn should_stop_runtime_after_report(ended: bool, terminal: bool, metronome_enabled: bool) -> bool {
     terminal || (ended && !metronome_enabled)
 }
 
-#[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
+#[cfg(any(mobile, target_os = "linux", target_os = "macos"))]
 struct LoadedPlaybackLanes {
     lanes: Vec<PlaybackLane>,
     workers: DecoderWorkers,
 }
 
-#[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
+#[cfg(any(mobile, target_os = "linux", target_os = "macos"))]
 #[derive(Default)]
 struct DecoderWorkers {
     control_senders: Vec<mpsc::Sender<WorkerControl>>,
     threads: Vec<JoinHandle<()>>,
 }
 
-#[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
+#[cfg(any(mobile, target_os = "linux", target_os = "macos"))]
 fn sourced_playback_lanes(
     raw_lanes: &[AudioLaneRequest],
 ) -> impl Iterator<Item = (usize, &AudioLaneRequest)> {
@@ -2690,7 +2681,7 @@ fn sourced_playback_lanes(
         .enumerate()
 }
 
-#[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
+#[cfg(any(mobile, target_os = "linux", target_os = "macos"))]
 impl DecoderWorkers {
     fn into_parts(mut self) -> (Vec<mpsc::Sender<WorkerControl>>, Vec<JoinHandle<()>>) {
         (
@@ -2700,7 +2691,7 @@ impl DecoderWorkers {
     }
 }
 
-#[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
+#[cfg(any(mobile, target_os = "linux", target_os = "macos"))]
 impl Drop for DecoderWorkers {
     fn drop(&mut self) {
         for sender in &self.control_senders {
@@ -2712,7 +2703,7 @@ impl Drop for DecoderWorkers {
     }
 }
 
-#[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
+#[cfg(any(mobile, target_os = "linux", target_os = "macos"))]
 fn load_playback_lanes(
     app: &AppHandle,
     raw_lanes: &[AudioLaneRequest],
@@ -2803,7 +2794,7 @@ fn load_playback_lanes(
     Ok(LoadedPlaybackLanes { lanes, workers })
 }
 
-#[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
+#[cfg(any(mobile, target_os = "linux", target_os = "macos"))]
 fn spawn_decoder_worker(
     lane_id: String,
     lane_ordinal: usize,
@@ -2974,7 +2965,7 @@ fn spawn_decoder_worker(
     Ok((sender, worker_thread))
 }
 
-#[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
+#[cfg(any(mobile, target_os = "linux", target_os = "macos"))]
 fn push_or_defer_worker_samples(
     ring: &Arc<Mutex<RingBuffer>>,
     pending_samples: &mut Option<Vec<f32>>,
@@ -2989,18 +2980,18 @@ fn push_or_defer_worker_samples(
     }
 }
 
-#[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
+#[cfg(any(mobile, target_os = "linux", target_os = "macos"))]
 enum StreamingDecoder {
     Wav(WavStreamDecoder),
     Symphonia(SymphoniaStreamDecoder),
 }
 
-#[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
+#[cfg(any(mobile, target_os = "linux", target_os = "macos"))]
 trait WorkerDiagnosticsGenerationTarget {
     fn set_worker_diagnostics_generation(&mut self, generation: u64, lane_ordinal: usize);
 }
 
-#[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
+#[cfg(any(mobile, target_os = "linux", target_os = "macos"))]
 fn apply_worker_control_diagnostics_generation<T: WorkerDiagnosticsGenerationTarget>(
     control: &WorkerControl,
     current_generation: &mut u64,
@@ -3024,7 +3015,7 @@ fn apply_worker_control_diagnostics_generation<T: WorkerDiagnosticsGenerationTar
     }
 }
 
-#[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
+#[cfg(any(mobile, target_os = "linux", target_os = "macos"))]
 impl StreamingDecoder {
     fn open_with_diagnostics(
         path: PathBuf,
@@ -3129,19 +3120,19 @@ impl StreamingDecoder {
     }
 }
 
-#[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
+#[cfg(any(mobile, target_os = "linux", target_os = "macos"))]
 impl WorkerDiagnosticsGenerationTarget for StreamingDecoder {
     fn set_worker_diagnostics_generation(&mut self, generation: u64, lane_ordinal: usize) {
         self.set_diagnostics_generation(generation, lane_ordinal);
     }
 }
 
-#[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
+#[cfg(any(mobile, target_os = "linux", target_os = "macos"))]
 fn decoder_diagnostics_context(generation: u64, lane_ordinal: usize) -> Option<(u64, usize)> {
     (generation != 0).then_some((generation, lane_ordinal))
 }
 
-#[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
+#[cfg(any(mobile, target_os = "linux", target_os = "macos"))]
 fn set_decoder_diagnostics_context(
     context: &mut Option<(u64, usize)>,
     generation: u64,
@@ -3150,7 +3141,7 @@ fn set_decoder_diagnostics_context(
     *context = decoder_diagnostics_context(generation, lane_ordinal);
 }
 
-#[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
+#[cfg(any(mobile, target_os = "linux", target_os = "macos"))]
 struct WavStreamDecoder {
     file: File,
     audio_format: u16,
@@ -3167,7 +3158,7 @@ struct WavStreamDecoder {
     stretch: signalsmith_stretch::Stretch,
 }
 
-#[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
+#[cfg(any(mobile, target_os = "linux", target_os = "macos"))]
 impl WavStreamDecoder {
     fn open(
         path: &Path,
@@ -3346,7 +3337,7 @@ impl WavStreamDecoder {
     }
 }
 
-#[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
+#[cfg(any(mobile, target_os = "linux", target_os = "macos"))]
 struct SymphoniaStreamDecoder {
     format: Box<dyn FormatReader>,
     decoder: Box<dyn AudioDecoder>,
@@ -3359,7 +3350,7 @@ struct SymphoniaStreamDecoder {
     diagnostics_context: Option<(u64, usize)>,
 }
 
-#[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
+#[cfg(any(mobile, target_os = "linux", target_os = "macos"))]
 impl SymphoniaStreamDecoder {
     fn open(
         path: PathBuf,
@@ -3525,7 +3516,7 @@ impl SymphoniaStreamDecoder {
     }
 }
 
-#[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
+#[cfg(any(mobile, target_os = "linux", target_os = "macos"))]
 fn prepare_stream_chunk(
     samples: &[f32],
     source_channels: u32,
@@ -3563,7 +3554,7 @@ fn prepare_stream_chunk(
 #[cfg(test)]
 mod tests {
     use super::*;
-    #[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
+    #[cfg(any(mobile, target_os = "linux", target_os = "macos"))]
     use std::fs;
 
     fn capabilities() -> AudioCapabilities {
@@ -3743,7 +3734,7 @@ mod tests {
         render(true);
     }
 
-    #[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
+    #[cfg(any(mobile, target_os = "linux", target_os = "macos"))]
     fn stoppable_runtime(shared: PlaybackShared) -> (PlaybackRuntime, Vec<mpsc::Receiver<()>>) {
         let (audio_stop_sender, audio_stop_receiver) = mpsc::channel();
         let (audio_exited_sender, audio_exited_receiver) = mpsc::channel();
@@ -3794,7 +3785,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
+    #[cfg(any(mobile, target_os = "linux", target_os = "macos"))]
     fn classifies_cpal_output_errors_without_exposing_backend_details() {
         let classified = [
             (
@@ -3880,7 +3871,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
+    #[cfg(any(mobile, target_os = "linux", target_os = "macos"))]
     fn linux_xrun_policy_preserves_playing_runtime_until_a_fatal_output_error() {
         let mut shared =
             shared_with_lane(Arc::new(Mutex::new(RingBuffer::new(1_000))), 1_000, 1, 1.0);
@@ -3957,7 +3948,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
+    #[cfg(any(mobile, target_os = "linux", target_os = "macos"))]
     fn terminal_error_precedes_recoverable_and_device_changed_events() {
         let mut device_changed_first =
             shared_with_lane(Arc::new(Mutex::new(RingBuffer::new(1_000))), 1_000, 1, 1.0);
@@ -4003,7 +3994,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
+    #[cfg(any(mobile, target_os = "linux", target_os = "macos"))]
     fn terminal_error_suppresses_ended_notification_for_the_same_snapshot() {
         let mut shared =
             shared_with_lane(Arc::new(Mutex::new(RingBuffer::new(1_000))), 1_000, 1, 1.0);
@@ -4024,7 +4015,7 @@ mod tests {
         assert!(should_emit_ended(true, false));
     }
 
-    #[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
+    #[cfg(any(mobile, target_os = "linux", target_os = "macos"))]
     fn assert_sample_close(actual: f32, expected: f32) {
         assert!(
             (actual - expected).abs() < 0.000_1,
@@ -4032,7 +4023,7 @@ mod tests {
         );
     }
 
-    #[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
+    #[cfg(any(mobile, target_os = "linux", target_os = "macos"))]
     fn write_mono_i16_wav(path: &std::path::Path, sample_rate: u32, samples: &[i16]) {
         let data_size = samples.len().checked_mul(2).expect("wav data size");
         let chunk_size = 36usize.checked_add(data_size).expect("wav chunk size") as u32;
@@ -4117,7 +4108,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
+    #[cfg(any(mobile, target_os = "linux", target_os = "macos"))]
     fn play_rejects_a_retained_terminal_runtime_error() {
         let shared = Arc::new(Mutex::new(shared_with_lane(
             Arc::new(Mutex::new(RingBuffer::new(1_000))),
@@ -4168,7 +4159,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
+    #[cfg(any(mobile, target_os = "linux", target_os = "macos"))]
     fn runtime_start_failure_cleanup_stops_decoder_workers() {
         let (control_sender, control_receiver) = mpsc::channel();
         let (exited_sender, exited_receiver) = mpsc::channel();
@@ -4191,7 +4182,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
+    #[cfg(any(mobile, target_os = "linux", target_os = "macos"))]
     fn stop_releases_failed_runtime_and_preserves_terminal_handoff_state() {
         let mut shared =
             shared_with_lane(Arc::new(Mutex::new(RingBuffer::new(1_000))), 1_000, 1, 1.0);
@@ -4228,7 +4219,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
+    #[cfg(any(mobile, target_os = "linux", target_os = "macos"))]
     fn decoder_worker_exits_when_its_startup_owner_disconnects() {
         let path = std::env::temp_dir().join(format!(
             "tuneforge-decoder-worker-disconnect-test-{}.wav",
@@ -4257,7 +4248,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
+    #[cfg(any(mobile, target_os = "linux", target_os = "macos"))]
     fn sourced_lanes_receive_loaded_ordinals_when_raw_lanes_are_sparse() {
         let lane = |id: &str, source_path: Option<&str>| AudioLaneRequest {
             id: id.to_string(),
@@ -4371,7 +4362,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
+    #[cfg(any(mobile, target_os = "linux", target_os = "macos"))]
     fn pause_releases_runtime_workers_and_preserves_confirmed_position() {
         let mut shared =
             shared_with_lane(Arc::new(Mutex::new(RingBuffer::new(1_000))), 1_000, 1, 1.0);
@@ -4395,7 +4386,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
+    #[cfg(any(mobile, target_os = "linux", target_os = "macos"))]
     fn stop_releases_runtime_workers_and_resets_position() {
         let mut shared =
             shared_with_lane(Arc::new(Mutex::new(RingBuffer::new(1_000))), 1_000, 1, 1.0);
@@ -4723,7 +4714,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
+    #[cfg(any(mobile, target_os = "linux", target_os = "macos"))]
     fn offline_render_seek_starts_from_requested_wav_offset() {
         let sample_rate = 1_000;
         let path = std::env::temp_dir().join(format!(
@@ -4746,7 +4737,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
+    #[cfg(any(mobile, target_os = "linux", target_os = "macos"))]
     fn tempo_and_seek_controls_attribute_skipped_events_to_active_generation() {
         assert_eq!(decoder_diagnostics_context(0, 3), None);
         let mut disabled_context = Some((9, 3));
@@ -5004,7 +4995,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
+    #[cfg(any(mobile, target_os = "linux", target_os = "macos"))]
     fn standalone_enable_rolls_back_control_when_runtime_start_fails() {
         let mut transport = TransportState::default();
         transport.fail_next_runtime_start = true;
@@ -5031,7 +5022,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
+    #[cfg(any(mobile, target_os = "linux", target_os = "macos"))]
     fn standalone_enable_preserves_paused_project_generation() {
         let mut transport = TransportState::default();
         transport.session_id = Some("project-session".into());
@@ -5051,7 +5042,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
+    #[cfg(any(mobile, target_os = "linux", target_os = "macos"))]
     fn standalone_rejects_acquisition_while_active() {
         let mut transport = TransportState::default();
         let started = transport
@@ -5080,7 +5071,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
+    #[cfg(any(mobile, target_os = "linux", target_os = "macos"))]
     fn standalone_terminal_retry_reaps_runtime_and_advances_generation() {
         let mut transport = TransportState::default();
         let started = transport
@@ -5116,7 +5107,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
+    #[cfg(any(mobile, target_os = "linux", target_os = "macos"))]
     fn standalone_stop_rejects_delayed_acquisition_without_restarting_audio() {
         let mut transport = TransportState::default();
         let started = transport
@@ -5174,7 +5165,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
+    #[cfg(any(mobile, target_os = "linux", target_os = "macos"))]
     fn standalone_disable_rolls_back_control_when_release_fails() {
         let mut transport = TransportState::default();
         let started = transport
@@ -5216,7 +5207,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
+    #[cfg(any(mobile, target_os = "linux", target_os = "macos"))]
     fn pause_and_stop_keep_enabled_standalone_runtime_free_running() {
         let mut shared =
             shared_with_lane(Arc::new(Mutex::new(RingBuffer::new(1_000))), 1_000, 1, 1.0);
@@ -5252,7 +5243,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
+    #[cfg(any(mobile, target_os = "linux", target_os = "macos"))]
     fn reporter_keeps_output_alive_after_end_only_for_enabled_metronome() {
         assert!(!should_stop_runtime_after_report(true, false, true));
         assert!(should_stop_runtime_after_report(true, false, false));
@@ -5260,7 +5251,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
+    #[cfg(any(mobile, target_os = "linux", target_os = "macos"))]
     fn unavailable_playback_prepare_preserves_existing_standalone_runtime() {
         let ring = Arc::new(Mutex::new(RingBuffer::new(1_000)));
         let mut shared = shared_with_lane(ring, 1_000, 1, 1.0);
@@ -5377,7 +5368,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
+    #[cfg(any(mobile, target_os = "linux", target_os = "macos"))]
     fn wav_stream_decoder_preserves_stereo_channels() {
         let path = std::env::temp_dir().join(format!(
             "tuneforge-transport-stereo-stream-test-{}.wav",

--- a/apps/desktop/src-tauri/tauri.ios.conf.json
+++ b/apps/desktop/src-tauri/tauri.ios.conf.json
@@ -1,0 +1,13 @@
+{
+  "identifier": "com.tuneforge.simulator",
+  "build": {
+    "beforeBuildCommand": "pnpm --filter @tuneforge/desktop build"
+  },
+  "bundle": {
+    "resources": [],
+    "iOS": {
+      "frameworks": ["SystemConfiguration"],
+      "minimumSystemVersion": "14.0"
+    }
+  }
+}

--- a/apps/desktop/src/App.activity.test.tsx
+++ b/apps/desktop/src/App.activity.test.tsx
@@ -469,6 +469,18 @@ describe("Desktop app activity", () => {
     expect(mockListJobs.mock.calls.some(([params]) => params === undefined)).toBe(false);
   });
 
+  it("disables bulk job actions when the activity queue is unavailable", async () => {
+    mockListJobs
+      .mockRejectedValueOnce(new Error("Jobs unavailable"))
+      .mockRejectedValueOnce(new Error("Jobs unavailable"));
+    renderApp(["/activity"]);
+
+    expect(await screen.findByText("Could not load the activity queue.")).toBeInTheDocument();
+    screen.getAllByRole("group", { name: "Bulk job actions" }).forEach((group) => {
+      within(group).getAllByRole("button").forEach((button) => expect(button).toBeDisabled());
+    });
+  });
+
   it("searches activity jobs by project name", async () => {
     setProjects([
       project({ id: "proj_choir", display_name: "Choir Practice" }),
@@ -878,6 +890,20 @@ describe("Desktop app activity", () => {
 
     await waitFor(() => expect(mockStopSyncListener).toHaveBeenCalled());
     expect(await screen.findByText("Stopped")).toBeInTheDocument();
+  });
+
+  it("keeps sync actions unavailable when prerequisite queries fail", async () => {
+    const user = userEvent.setup();
+    mockGetSyncIdentity.mockRejectedValueOnce(new Error("Identity unavailable"));
+    mockGetSyncTransportStatus.mockRejectedValueOnce(new Error("Listener unavailable"));
+    mockListSyncTrustedPeers.mockRejectedValueOnce(new Error("Peers unavailable"));
+    await openSyncTab(user);
+
+    expect(await screen.findByText("Native sync transport is unavailable.")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Start Listener" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Answer Offer" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Trust Response" })).toBeDisabled();
+    expect(screen.queryByText("No nearby devices.")).not.toBeInTheDocument();
   });
 
   it("shows active sync progress and polls listener status while listening", async () => {

--- a/apps/desktop/src/App.library.test.tsx
+++ b/apps/desktop/src/App.library.test.tsx
@@ -252,6 +252,8 @@ describe("Desktop app library", () => {
 
     const alert = await screen.findByRole("alert");
     expect(within(alert).getByText("Could not load projects.")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Import Track(s)" })).toBeDisabled();
+    expect(screen.queryByText("0 projects ready")).not.toBeInTheDocument();
     expect(screen.queryByRole("heading", { name: "No projects yet" })).not.toBeInTheDocument();
   });
 

--- a/apps/desktop/src/features/activity/ActivitySyncPanel.tsx
+++ b/apps/desktop/src/features/activity/ActivitySyncPanel.tsx
@@ -2251,6 +2251,7 @@ export function ActivitySyncPanel() {
   }, [pairingInputValue]);
 	  const qrScanSupported = mobileCapabilitiesQuery.data?.platform === "android";
 	  const isAndroidRuntime = mobileCapabilitiesQuery.data?.platform === "android";
+    const pairingPrerequisitesUnavailable = identityQuery.isError || peersQuery.isError;
 
   const refreshSyncQueries = useCallback(async () => {
     await Promise.all([
@@ -2857,7 +2858,7 @@ export function ActivitySyncPanel() {
         </div>
         <button
           className="button button--ghost button--small"
-          disabled={listenerMutationPending}
+          disabled={listenerQuery.isError || listenerMutationPending}
           onClick={handleListenerToggle}
           type="button"
         >
@@ -3123,7 +3124,12 @@ export function ActivitySyncPanel() {
           <div className="activity-sync-actions">
             <button
               className="button button--primary button--small"
-              disabled={!pairingInputValue || pairingInputInvalid || pairingPayloadPending}
+              disabled={
+                pairingPrerequisitesUnavailable ||
+                !pairingInputValue ||
+                pairingInputInvalid ||
+                pairingPayloadPending
+              }
               onClick={handleAnswerPairingOffer}
               type="button"
             >
@@ -3131,7 +3137,12 @@ export function ActivitySyncPanel() {
             </button>
             <button
               className="button button--ghost button--small"
-              disabled={!pairingInputValue || pairingInputInvalid || pairingPayloadPending}
+              disabled={
+                pairingPrerequisitesUnavailable ||
+                !pairingInputValue ||
+                pairingInputInvalid ||
+                pairingPayloadPending
+              }
               onClick={handleTrustPeer}
               type="button"
             >
@@ -3263,7 +3274,7 @@ export function ActivitySyncPanel() {
           <span className="metric-label">{nearbyPeers.length} nearby</span>
         </div>
 
-        {!nearbyPeers.length ? (
+        {listenerQuery.isSuccess && !nearbyPeers.length ? (
           <p className="activity-sync-empty">No nearby devices.</p>
         ) : null}
         {nearbyPeers.length ? (

--- a/apps/desktop/src/features/activity/ActivityView.tsx
+++ b/apps/desktop/src/features/activity/ActivityView.tsx
@@ -696,7 +696,7 @@ export function ActivityView() {
               return (
                 <button
                   className="button button--ghost button--small activity-bulk-actions__button"
-                  disabled={bulkJobsMutation.isPending || conversionActive}
+                  disabled={isError || bulkJobsMutation.isPending || conversionActive}
                   key={action.jobType}
                   onClick={() => {
                     void handleBulkJobAction(action);

--- a/apps/desktop/src/features/projects/LibraryView.tsx
+++ b/apps/desktop/src/features/projects/LibraryView.tsx
@@ -467,7 +467,7 @@ export function LibraryView() {
           <button
             className="button button--primary"
             onClick={() => importMutation.mutate()}
-            disabled={importMutation.isPending}
+            disabled={importMutation.isPending || isProjectsLoading || isProjectsError}
           >
             {pendingImportCopy ? pendingImportCopy.buttonLabel : "Import Track(s)"}
             <Upload aria-hidden="true" className="button__icon" />
@@ -516,26 +516,28 @@ export function LibraryView() {
             }}
           />
         </label>
-        <div className="library-toolbar__summary" aria-live="polite">
-          {deferredSearch ? (
-            totalProjectCount ? (
+        {!showInitialError ? (
+          <div className="library-toolbar__summary" aria-live="polite">
+            {deferredSearch ? (
+              totalProjectCount ? (
+                <span>
+                  {hasLoadedAllProjects
+                    ? `${totalProjectCount} match${totalProjectCount === 1 ? "" : "es"}`
+                    : `${loadedProjectCount} of ${totalProjectCount} matches loaded`}{" "}
+                  for "{deferredSearch}"
+                </span>
+              ) : (
+                <span>No matches for "{deferredSearch}"</span>
+              )
+            ) : (
               <span>
                 {hasLoadedAllProjects
-                  ? `${totalProjectCount} match${totalProjectCount === 1 ? "" : "es"}`
-                  : `${loadedProjectCount} of ${totalProjectCount} matches loaded`}{" "}
-                for "{deferredSearch}"
+                  ? `${totalProjectCount} project${totalProjectCount === 1 ? "" : "s"} ready`
+                  : `${loadedProjectCount} of ${totalProjectCount} projects loaded`}
               </span>
-            ) : (
-              <span>No matches for "{deferredSearch}"</span>
-            )
-          ) : (
-            <span>
-              {hasLoadedAllProjects
-                ? `${totalProjectCount} project${totalProjectCount === 1 ? "" : "s"} ready`
-                : `${loadedProjectCount} of ${totalProjectCount} projects loaded`}
-            </span>
-          )}
-        </div>
+            )}
+          </div>
+        ) : null}
       </div>
 
       {showInitialLoading ? (

--- a/apps/desktop/src/lib/api.mobile-sync.test.ts
+++ b/apps/desktop/src/lib/api.mobile-sync.test.ts
@@ -129,6 +129,42 @@ describe("mobile sync API adapter", () => {
     });
   });
 
+  it("routes iOS through mobile IPC without an HTTP fallback", async () => {
+    mockInvoke.mockResolvedValueOnce({
+      ...mobileCapabilities,
+      platform: "ios",
+      mediaBackend: "cpal_coreaudio",
+      analysisAvailable: false,
+      basicChordsAvailable: false,
+    });
+    const apiModule = await import("./api");
+    await expect(apiModule.initializeApi()).resolves.toBe("mobile://embedded");
+    mockInvoke.mockClear();
+
+    await apiModule.api.getHealth();
+
+    expect(mockInvoke).toHaveBeenCalledWith("mobile_get_health", undefined);
+  });
+
+  it("fails closed when an embedded mobile runtime cannot report capabilities", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    mockInvoke.mockImplementation(async (command: string) => {
+      if (command === "mobile_capabilities") {
+        throw new Error("capabilities unavailable");
+      }
+      if (command === "backend_base_url") {
+        return "mobile://embedded";
+      }
+      return {};
+    });
+    const apiModule = await import("./api");
+
+    await expect(apiModule.initializeApi()).rejects.toThrow("could not report its capabilities");
+    expect(apiModule.getApiBaseUrl()).toBe("mobile://embedded");
+    expect(fetchSpy).not.toHaveBeenCalled();
+    fetchSpy.mockRestore();
+  });
+
   it("routes latest jobs query params to the mobile jobs command", async () => {
     const api = await loadMobileApi();
     const params: ListJobsParams = {

--- a/apps/desktop/src/lib/api.ts
+++ b/apps/desktop/src/lib/api.ts
@@ -4,6 +4,7 @@ import type { components, MobileCapabilities, paths } from "@tuneforge/shared-ty
 import { normalizeApiDateTime } from "./datetime";
 
 const DEFAULT_API_BASE_URL = import.meta.env.VITE_API_BASE_URL ?? "http://127.0.0.1:8765";
+const EMBEDDED_MOBILE_API_BASE_URL = "mobile://embedded";
 let apiBaseUrl = DEFAULT_API_BASE_URL;
 let runtimeInitPromise: Promise<string> | null = null;
 
@@ -2504,8 +2505,12 @@ function createMobileTuneForgeClient(capabilities: MobileCapabilities): TuneForg
     getMobileCapabilities: async () => capabilities,
     ensureWebMediaTransport,
     getHealth: () => invokeMobile("mobile_get_health"),
-    getExportCapabilities: async () => ({
-      capabilities: {
+    getExportCapabilities: async () => {
+      if (capabilities.platform === "ios") {
+        throw unsupportedRuntimeError("Export");
+      }
+      return {
+        capabilities: {
         platform: "android",
         formats: [
           { id: "wav", available: true, reason: null },
@@ -2527,8 +2532,9 @@ function createMobileTuneForgeClient(capabilities: MobileCapabilities): TuneForg
           },
         ],
         max_artifact_count: 1,
-      },
-    }),
+        },
+      };
+    },
     listProjects: (params?: ListProjectsParams) =>
       invokeMobile("mobile_list_projects", { params: params ?? null }),
     importProject: async (body: ProjectImportRequest) => {
@@ -2634,23 +2640,29 @@ export async function initializeApi() {
 
       try {
         const capabilities = await invoke<MobileCapabilities>("mobile_capabilities");
-        apiBaseUrl = "mobile://embedded";
+        apiBaseUrl = EMBEDDED_MOBILE_API_BASE_URL;
         activeClient = createMobileTuneForgeClient(capabilities);
         return apiBaseUrl;
       } catch {
         activeClient = createHttpTuneForgeClient();
       }
 
+      let resolved: string;
       try {
-        const resolved = await invoke<string>("backend_base_url");
-        apiBaseUrl = resolved;
-        client = createClient<paths>({ baseUrl: apiBaseUrl });
-        activeClient = createHttpTuneForgeClient();
+        resolved = await invoke<string>("backend_base_url");
       } catch {
         apiBaseUrl = DEFAULT_API_BASE_URL;
         client = createClient<paths>({ baseUrl: apiBaseUrl });
         activeClient = createHttpTuneForgeClient();
+        return apiBaseUrl;
       }
+      if (resolved === EMBEDDED_MOBILE_API_BASE_URL) {
+        apiBaseUrl = resolved;
+        throw new Error("The embedded mobile API bridge could not report its capabilities.");
+      }
+      apiBaseUrl = resolved;
+      client = createClient<paths>({ baseUrl: apiBaseUrl });
+      activeClient = createHttpTuneForgeClient();
 
       return apiBaseUrl;
     })();

--- a/apps/desktop/src/styles/utilities-responsive.css
+++ b/apps/desktop/src/styles/utilities-responsive.css
@@ -50,6 +50,7 @@
     align-items: center;
     justify-content: space-between;
     flex-wrap: wrap;
+    padding-block-start: calc(1.2rem + var(--safe-area-top));
   }
 
   .nav {
@@ -152,7 +153,7 @@
 @media (max-width: 720px) {
   .sidebar {
     gap: 0.75rem;
-    padding: 0.75rem;
+    padding: calc(0.75rem + var(--safe-area-top)) 0.75rem 0.75rem;
   }
 
   .brand__copy,

--- a/docs/MOBILE.md
+++ b/docs/MOBILE.md
@@ -1,13 +1,13 @@
 # TuneForge Mobile Architecture
 
-TuneForge mobile is Android-first and keeps the local-only product rule: no account, no cloud backend, no telemetry, and no remote processing.
+TuneForge mobile keeps the local-only product rule: no account, no cloud backend, no telemetry, and no remote processing.
 
 ## Backend Shape
 
-The mobile app includes its backend inside the Tauri app. It does not run the desktop Python/FastAPI backend on Android.
+The mobile app includes its backend inside the Tauri app. It does not run the desktop Python/FastAPI backend on Android or iOS.
 
 - Desktop: React -> Tauri -> FastAPI -> Python engines -> platform FFmpeg runtime -> SQLite/filesystem.
-- Mobile: React -> Tauri commands -> embedded Rust/Kotlin backend -> owned FFmpeg conversion plus Android media APIs -> SQLite/filesystem.
+- Mobile: React -> Tauri commands -> embedded Rust backend -> platform services -> SQLite/filesystem. Android alone adds Kotlin, owned FFmpeg conversion, and Android media APIs.
 
 The frontend talks through a `TuneForgeClient` boundary. Desktop uses the existing generated OpenAPI HTTP client. Mobile uses Tauri commands that return the same project, job, artifact, lyrics, chord, and analysis response shapes where possible.
 
@@ -155,6 +155,39 @@ transfer, recovery, or conflict states rather than where the data originated.
 | Edits | Project updates plus lyrics, chord, section, and tab-apply edits persisted as project documents or entity revisions. | Persist mobile edits locally and sync as revisions. Desktop-synced edits stay editable documents, not flattened files. | Healthy editable local data has no badge. Local edits use normal unsynced or conflicted states, not generation failure states. |
 | Sync revisions | `entity_revisions` with revision identity, entity type, source artifact, content hash, state, author device, payload, metadata, and timestamps. | Reconcile by identity and content hash. Apply tombstones before accepting older revisions. | Healthy accepted revisions have no badge. `Missing` if referenced payload is absent. `Unreadable` if hash or schema validation fails. Conflicts use sync conflict state. |
 | Tombstones | `delete_tombstones` for deleted projects, artifacts, and entity revisions, with author, target, group/project context, and prior metadata. | Persist delete markers and suppress resurrected records from offline peers. | Deleted records stay deleted or hidden, not `Missing`. Invalid tombstones are `Unreadable`; accepted tombstones have no status badge. |
+
+## iOS Simulator Foundation
+
+The iOS target currently provides a simulator-only runtime foundation. It bundles the normal React
+frontend, reports iOS capabilities through Tauri IPC, and fails closed when the embedded API is not
+available. It never falls back to the desktop HTTP backend at `127.0.0.1:8765`. Project persistence,
+LAN sync, and playback are not available in this foundation.
+
+The debug startup smoke verifies an in-memory SQLite query, synthetic WAV decode, Signalsmith
+construction and processing, and CPAL/CoreAudio output initialization. The app uses the isolated
+debug identifier `com.tuneforge.simulator`; no Apple signing team is required for a simulator build.
+Desktop Python, model, and FFmpeg resources are excluded from the iOS bundle.
+
+Install CocoaPods and the simulator Rust target once, then prepare or build from the repository root
+with Xcode selected per command and pnpm 11.22.0 pinned for that invocation:
+
+```sh
+pod --version
+rustup target add aarch64-apple-ios-sim --toolchain stable
+DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer \
+  npm exec --yes --package=pnpm@11.22.0 -- \
+  pnpm --filter @tuneforge/desktop ios:prepare
+DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer \
+  npm exec --yes --package=pnpm@11.22.0 -- \
+  pnpm --filter @tuneforge/desktop ios:build:debug
+```
+
+Preparation uses `tauri ios init --skip-targets-install`, preserves any existing ignored scaffold
+under `apps/desktop/src-tauri/target/`, and regenerates the ignored AppIcon catalog from the existing
+TuneForge source icon. The build script creates ignored command shims so Xcode child processes keep
+the selected developer directory and stable Rust toolchain without changing global configuration.
+The unsigned simulator app is written below
+`apps/desktop/src-tauri/gen/apple/build/arm64-sim/TuneForge.app`.
 
 ## Android Setup
 

--- a/packages/shared-types/src/mobile.ts
+++ b/packages/shared-types/src/mobile.ts
@@ -1,6 +1,6 @@
 export type MobileCapabilities = {
   platform: "android" | "ios";
-  mediaBackend: "android_media_codec" | "avfoundation";
+  mediaBackend: "android_media_codec" | "avfoundation" | "cpal_coreaudio";
   isEmulator: boolean;
   gpuBackend: "vulkan" | "nnapi" | "qnn" | "coreml" | null;
   analysisAvailable: boolean;

--- a/scripts/prepare-ios.mjs
+++ b/scripts/prepare-ios.mjs
@@ -1,0 +1,115 @@
+import { chmod, cp, mkdir, rename, stat, writeFile } from "node:fs/promises";
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const desktop = path.join(root, "apps", "desktop");
+const tauriRoot = path.join(desktop, "src-tauri");
+const appleRoot = path.join(tauriRoot, "gen", "apple");
+const targetRoot = path.join(tauriRoot, "target");
+const iconRoot = path.join(targetRoot, "ios-icons");
+const toolchainBin = path.join(targetRoot, "ios-toolchain-bin");
+const buildDebug = process.argv.slice(2).includes("--build-debug");
+
+async function exists(value) {
+  try {
+    await stat(value);
+    return true;
+  } catch (error) {
+    if (error?.code === "ENOENT") return false;
+    throw error;
+  }
+}
+
+function run(command, args, options = {}) {
+  const result = spawnSync(command, args, {
+    cwd: desktop,
+    env: options.env ?? process.env,
+    encoding: options.capture ? "utf8" : undefined,
+    stdio: options.capture ? "pipe" : "inherit",
+  });
+  if (result.status !== 0) process.exit(result.status ?? 1);
+  return options.capture ? result.stdout.trim() : undefined;
+}
+
+function shellQuote(value) {
+  return `'${value.replaceAll("'", `'\\''`)}'`;
+}
+
+async function prepareToolchainEnvironment() {
+  const developerDir = process.env.DEVELOPER_DIR;
+  if (!developerDir) {
+    throw new Error("Set DEVELOPER_DIR to the selected Xcode developer directory.");
+  }
+
+  const rustc = run("rustup", ["which", "rustc", "--toolchain", "stable"], {
+    capture: true,
+  });
+  const cargo = run("rustup", ["which", "cargo", "--toolchain", "stable"], {
+    capture: true,
+  });
+  await mkdir(toolchainBin, { recursive: true });
+  const scripts = {
+    "xcode-select": `#!/bin/sh\nif [ "$#" -eq 1 ] && [ "$1" = "-p" ]; then\n  printf '%s\\n' ${shellQuote(developerDir)}\n  exit 0\nfi\nexec /usr/bin/xcode-select "$@"\n`,
+    xcodebuild: `#!/bin/sh\nDEVELOPER_DIR=${shellQuote(developerDir)} exec /usr/bin/xcodebuild "$@"\n`,
+    cargo: `#!/bin/sh\nRUSTC=${shellQuote(rustc)} exec ${shellQuote(cargo)} "$@"\n`,
+  };
+  await Promise.all(
+    Object.entries(scripts).map(async ([name, contents]) => {
+      const destination = path.join(toolchainBin, name);
+      await writeFile(destination, contents);
+      await chmod(destination, 0o755);
+    }),
+  );
+  return {
+    ...process.env,
+    PATH: `${toolchainBin}${path.delimiter}${process.env.PATH ?? ""}`,
+    RUSTC: rustc,
+  };
+}
+
+function runTauri(args, env) {
+  run("pnpm", ["exec", "tauri", ...args], { env });
+}
+
+const toolchainEnv = await prepareToolchainEnvironment();
+
+await mkdir(targetRoot, { recursive: true });
+if (await exists(appleRoot)) {
+  const backup = path.join(targetRoot, `ios-scaffold-${Date.now()}`);
+  await rename(appleRoot, backup);
+  console.log(`Preserved previous iOS scaffold at ${path.relative(root, backup)}.`);
+}
+
+runTauri([
+  "ios",
+  "init",
+  "--ci",
+  "--skip-targets-install",
+  "--config",
+  "src-tauri/tauri.ios.conf.json",
+], toolchainEnv);
+runTauri(["icon", "src-tauri/icons/icon.png", "--output", iconRoot], toolchainEnv);
+
+const generatedIcons = path.join(iconRoot, "ios");
+const appIconSet = path.join(appleRoot, "Assets.xcassets", "AppIcon.appiconset");
+await cp(generatedIcons, appIconSet, { recursive: true });
+console.log("Generated the iOS scaffold and TuneForge app icons.");
+
+if (buildDebug) {
+  runTauri(
+    [
+      "ios",
+      "build",
+      "--debug",
+      "--target",
+      "aarch64-sim",
+      "--ci",
+      "--no-sign",
+      "--config",
+      "src-tauri/tauri.ios.conf.json",
+    ],
+    toolchainEnv,
+  );
+}


### PR DESCRIPTION
## Summary

Bootstrap the iOS simulator with a bundled frontend, TuneForge icons, and the pinned native runtime dependencies. iOS requests use Tauri IPC and fail explicitly while persistence, sync, and product playback remain unavailable.

## Motivation

Refs #531. Depends on #532. Follows the [reviewed #401 evidence](https://github.com/grazzolini/tuneforge/issues/401#issuecomment-5620176932).

This is layer 2 of four planned layers: shared mobile wiring; iOS runtime foundation; shared persistence/manual TCP sync; native WAV playback and session lifecycle. The later layers require a revised aggregate file budget before implementation.

## Changes

- Add reproducible unsigned simulator preparation/build commands using per-command Xcode selection, stable Rust, and pinned pnpm. Generate ignored Xcode scaffolding and icons from existing TuneForge artwork.
- Compile the existing native runtime on iOS; debug startup exercises rusqlite 0.40.2, Symphonia 0.6.1, Signalsmith 0.1.3, and CPAL 0.18.2.
- Initialize the existing Rustls provider and declare the required Apple framework. Exclude desktop Python, FFmpeg, models, and inherited resource bundles.
- Add the handwritten `cpal_coreaudio` capability value, fail closed on embedded capability errors, and keep unavailable actions disabled. Fix mobile safe-area spacing and avoid reporting a project count after a failed query.
- Update mobile setup and dependency notices. No HTTP/OpenAPI or sync-wire changes; no duplicated storage or sync implementation.

Production diff: +615/-223 across 19 files. Tests/docs: +110/-7. Cargo.lock: +1 generated line. No generated icons or Xcode project files are tracked.

## Testing

- `npm exec --yes --package=pnpm@11.22.0 -- pnpm lint` and `npm exec --yes --package=pnpm@11.22.0 -- pnpm typecheck`: passed.
- `npm exec --yes --package=pnpm@11.22.0 -- pnpm test`: frontend 898 tests, Rust 431 tests, and tooling suites passed. The first backend run had one import-response failure (823/824); the focused test and a full fresh-isolated `uv run --python 3.14 pytest` rerun in `apps/backend` passed (824/824). No backend edits.
- Focused API/Activity/Library checks passed, including the final Library error-state assertion.
- `cargo check --manifest-path apps/desktop/src-tauri/Cargo.toml`: passed.
- `TUNEFORGE_ANDROID_FFMPEG_ROOT="$PWD/packaging/ffmpeg/generated/android-arm64-v8a" bash scripts/android-arm64-env.sh cargo check --manifest-path apps/desktop/src-tauri/Cargo.toml --target aarch64-linux-android`: passed with the audited Android FFmpeg runtime and NDK 29 configured.
- `cargo fmt --manifest-path apps/desktop/src-tauri/Cargo.toml --check`, `node --check scripts/prepare-ios.mjs`, and `git diff --check`: passed.
- `npm exec --yes --package=pnpm@11.22.0 -- pnpm --filter @tuneforge/desktop ios:build:debug`: passed with per-command DEVELOPER_DIR as documented in docs/MOBILE.md, using Xcode 26.6 and the iOS 26.5 simulator runtime. Installed and launched the unsigned debug app on a dedicated fresh simulator with an isolated app identifier; the runtime smoke passed all four dependency checks.
- Inspected the built bundle: no Python, FFmpeg, models, or inherited resources. Visual checks confirmed the TuneForge icon, bundled Library, safe-area spacing, and truthful unavailable state. Correctness, contract, and focused visual reviews passed.

Simulator evidence covers this runtime foundation only. Live sync, persistence, product playback, physical devices, and release/distribution validation belong to later work.

## Checklist

- [x] Conventional Commit title; one signed layer commit.
- [x] Applicable checks and bounded reviews completed; initial backend failure and reruns disclosed above.
- [x] Mobile documentation and dependency notices updated.
- [x] No generated package artifacts, model weights, secrets, or copyrighted audio added.
- [x] No backend route/schema change; contract regeneration not required.
- [x] No MVP or release claim; changelog entry deferred to the product functionality.
