### PR TITLE
feat: Add iOS project sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ download, installation, verification, signature, and publication instructions.
 
 ### Added
 
+- Added simulator-only iOS project persistence and manual TCP sync with trusted desktop peers,
+  including synced project metadata in Library.
 - Added owned, offline LGPL FFmpeg conversion for macOS arm64 and Android arm64, API 26+, with
   durable WAV, FLAC, MP3, and M4A import, preview, retune, transpose, and Android export support.
 

--- a/apps/desktop/src-tauri/Info.ios.plist
+++ b/apps/desktop/src-tauri/Info.ios.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>NSLocalNetworkUsageDescription</key>
+  <string>TuneForge connects to a desktop you pair with to sync projects over your local network.</string>
+</dict>
+</plist>

--- a/apps/desktop/src-tauri/src/mobile_backend/constants.rs
+++ b/apps/desktop/src-tauri/src/mobile_backend/constants.rs
@@ -9,11 +9,11 @@ const PROJECT_ID_PREFIX: &str = "proj_sha256_";
 const SYNC_PROJECT_MANIFEST_SCHEMA_VERSION: &str = "1";
 #[cfg_attr(not(target_os = "android"), allow(dead_code))]
 const SYNC_PAIRING_PROTOCOL_VERSION: &str = "tuneforge-sync-v1";
-#[cfg(any(test, target_os = "android"))]
+#[cfg(any(test, mobile))]
 const TRANSPORT_HANDSHAKE_CHALLENGE_TYPE: &str = "transport_handshake";
-#[cfg(any(test, target_os = "android"))]
+#[cfg(any(test, mobile))]
 const TRANSPORT_HANDSHAKE_MAX_TTL_SECONDS: i64 = 300;
-#[cfg(any(test, target_os = "android"))]
+#[cfg(any(test, mobile))]
 const TRANSPORT_HANDSHAKE_CLOCK_SKEW_SECONDS: i64 = 30;
 #[cfg(not(target_os = "android"))]
 const MOBILE_UNAVAILABLE: &str = "Mobile embedded backend is only available in Android builds.";

--- a/apps/desktop/src-tauri/src/mobile_backend/embedded.rs
+++ b/apps/desktop/src-tauri/src/mobile_backend/embedded.rs
@@ -60,11 +60,13 @@ pub use manifests::{
 pub use reconciliation::{mobile_apply_sync_reconciliation, mobile_plan_sync_reconciliation};
 pub use storage::{
     mobile_cancel_job, mobile_delete_artifact, mobile_delete_project, mobile_get_health,
-    mobile_get_job, mobile_get_project, mobile_get_sync_staged_artifact, mobile_import_project,
-    mobile_list_artifacts, mobile_list_jobs, mobile_list_projects,
+    mobile_get_job, mobile_get_project, mobile_get_sync_staged_artifact, mobile_list_artifacts,
+    mobile_list_jobs, mobile_list_projects,
     mobile_register_sync_staged_reference, mobile_stage_sync_artifact,
     mobile_sync_transport_artifact_file, mobile_update_project,
 };
+#[cfg(target_os = "android")]
+pub use storage::mobile_import_project;
 pub use transport_bridge::{
     mobile_sync_transport_create_pairing_offer_value, mobile_sync_transport_local_identity_value,
     mobile_sync_transport_metadata_value, mobile_sync_transport_project_manifest_value,

--- a/apps/desktop/src-tauri/src/mobile_backend/helpers.rs
+++ b/apps/desktop/src-tauri/src/mobile_backend/helpers.rs
@@ -934,7 +934,7 @@ fn validate_remote_tombstone_identity(
     Err("Remote delete tombstone author_device_id is not an active trusted peer.".to_string())
 }
 
-#[cfg(any(test, target_os = "android"))]
+#[cfg(any(test, mobile))]
 fn validate_transport_trusted_peer(
     trusted_peer: Option<&SyncTrustedPeerSchema>,
     local_sync_group_id: &str,
@@ -950,7 +950,7 @@ fn validate_transport_trusted_peer(
     Ok(())
 }
 
-#[cfg(any(test, target_os = "android"))]
+#[cfg(any(test, mobile))]
 fn canonical_transport_handshake_challenge(
     challenge: &Value,
     local_device_id: &str,
@@ -1027,14 +1027,14 @@ fn canonical_transport_handshake_challenge(
     Ok(canonical)
 }
 
-#[cfg(any(test, target_os = "android"))]
+#[cfg(any(test, mobile))]
 fn transport_handshake_challenge_json(
     challenge: &std::collections::BTreeMap<String, Value>,
 ) -> Result<String, String> {
     serde_json::to_string(challenge).map_err(|error| error.to_string())
 }
 
-#[cfg(any(test, target_os = "android"))]
+#[cfg(any(test, mobile))]
 fn transport_handshake_proof_value(
     local_device_id: &str,
     peer_device_id: &str,
@@ -1057,7 +1057,7 @@ fn transport_handshake_proof_value(
     })
 }
 
-#[cfg(any(test, target_os = "android"))]
+#[cfg(any(test, mobile))]
 fn transport_challenge_string<'a>(
     challenge: &'a Value,
     field: &str,
@@ -1077,7 +1077,7 @@ fn transport_challenge_string<'a>(
     Ok(value)
 }
 
-#[cfg(any(test, target_os = "android"))]
+#[cfg(any(test, mobile))]
 fn transport_challenge_datetime(
     challenge: &Value,
     field: &str,
@@ -1091,7 +1091,7 @@ fn transport_challenge_datetime(
         .map_err(|_| format!("Transport handshake {field} must be an ISO-8601 timestamp."))
 }
 
-#[cfg(any(test, target_os = "android"))]
+#[cfg(any(test, mobile))]
 fn validate_transport_challenge_window(
     issued_at: chrono::DateTime<chrono::Utc>,
     expires_at: chrono::DateTime<chrono::Utc>,
@@ -1112,7 +1112,7 @@ fn validate_transport_challenge_window(
     Ok(())
 }
 
-#[cfg(any(test, target_os = "android"))]
+#[cfg(any(test, mobile))]
 fn transport_handshake_iso(value: chrono::DateTime<chrono::Utc>) -> String {
     let micros = value.timestamp_subsec_micros();
     if micros == 0 {
@@ -2118,6 +2118,304 @@ mod mobile_backend_tests {
                 ],
             )
             .unwrap();
+    }
+
+    #[cfg(not(target_os = "android"))]
+    fn insert_mobile_relocation_artifact(
+        connection: &Connection,
+        project_id: &str,
+        artifact_id: &str,
+        path: &std::path::Path,
+        bytes: &[u8],
+    ) -> (String, i64) {
+        let (sha256, size_bytes) = write_mobile_contract_file(path, bytes);
+        insert_mobile_contract_artifact(
+            connection,
+            MobileContractArtifact {
+                artifact_id,
+                project_id,
+                artifact_type: "source_audio",
+                format: "wav",
+                path,
+                content_sha256: &sha256,
+                size_bytes,
+                generated_by: "sync",
+                can_delete: false,
+                can_regenerate: false,
+                cache_key: None,
+                metadata: json!({"fixture": true}),
+            },
+        );
+        (sha256, size_bytes)
+    }
+
+    #[cfg(not(target_os = "android"))]
+    #[test]
+    fn mobile_ios_container_relocation_preserves_registered_state() {
+        let old_root = mobile_storage_contract_root("ios-relocation-old");
+        let connection = storage::db_at_root(&old_root).unwrap();
+        let bytes = b"verified iOS relocation bytes";
+        let source_sha256 = storage::hex_digest(&Sha256::digest(bytes));
+        let project_id = source_hash_to_project_id(&source_sha256).unwrap();
+        let old_path = storage::project_root_path(&old_root, &project_id)
+            .unwrap()
+            .join("source/source.wav");
+        insert_mobile_contract_project(&connection, &project_id, &source_sha256, &old_path);
+        insert_mobile_relocation_artifact(
+            &connection,
+            &project_id,
+            "art_ios_relocation",
+            &old_path,
+            bytes,
+        );
+        let mut project_before =
+            serde_json::to_value(storage::get_project_schema(&connection, &project_id).unwrap())
+                .unwrap();
+        project_before.as_object_mut().unwrap().remove("source_path");
+        project_before.as_object_mut().unwrap().remove("imported_path");
+        drop(connection);
+
+        let new_root = mobile_storage_contract_root("ios-relocation-new");
+        std::fs::remove_dir_all(&new_root).unwrap();
+        std::fs::rename(&old_root, &new_root).unwrap();
+        let connection = Connection::open(new_root.join("mobile.sqlite3")).unwrap();
+        storage::relocate_ios_paths(&connection, &new_root).unwrap();
+
+        let artifact = connection
+            .query_row(
+                &format!("SELECT {ARTIFACT_COLUMNS} FROM artifacts WHERE id = 'art_ios_relocation'"),
+                [],
+                storage::row_artifact,
+            )
+            .unwrap();
+        let expected_path = storage::project_root_path(&new_root, &project_id)
+            .unwrap()
+            .join("source/source.wav");
+        assert_eq!(artifact.path, expected_path.to_string_lossy());
+        assert_eq!(std::fs::read(&artifact.path).unwrap(), bytes);
+        let mut project_after =
+            serde_json::to_value(storage::get_project_schema(&connection, &project_id).unwrap())
+                .unwrap();
+        assert_eq!(project_after["source_path"], artifact.path);
+        assert_eq!(project_after["imported_path"], artifact.path);
+        project_after.as_object_mut().unwrap().remove("source_path");
+        project_after.as_object_mut().unwrap().remove("imported_path");
+        assert_eq!(project_after, project_before);
+        drop(connection);
+        let _ = std::fs::remove_dir_all(new_root);
+    }
+
+    #[cfg(not(target_os = "android"))]
+    #[test]
+    fn mobile_ios_container_relocation_is_fail_closed_and_transactional() {
+        let old_root = mobile_storage_contract_root("ios-relocation-rollback-old");
+        let connection = storage::db_at_root(&old_root).unwrap();
+        let source_bytes = b"source bytes";
+        let source_sha256 = storage::hex_digest(&Sha256::digest(source_bytes));
+        let project_id = source_hash_to_project_id(&source_sha256).unwrap();
+        let project_root = storage::project_root_path(&old_root, &project_id).unwrap();
+        let source_path = project_root.join("source/source.wav");
+        let corrupt_path = project_root.join("stems/corrupt.wav");
+        insert_mobile_contract_project(&connection, &project_id, &source_sha256, &source_path);
+        insert_mobile_relocation_artifact(
+            &connection,
+            &project_id,
+            "art_ios_source",
+            &source_path,
+            source_bytes,
+        );
+        insert_mobile_relocation_artifact(
+            &connection,
+            &project_id,
+            "art_ios_corrupt",
+            &corrupt_path,
+            b"expected stem bytes",
+        );
+        drop(connection);
+
+        let new_root = mobile_storage_contract_root("ios-relocation-rollback-new");
+        std::fs::remove_dir_all(&new_root).unwrap();
+        std::fs::rename(&old_root, &new_root).unwrap();
+        std::fs::write(
+            storage::project_root_path(&new_root, &project_id)
+                .unwrap()
+                .join("stems/corrupt.wav"),
+            b"corrupt",
+        )
+        .unwrap();
+        let connection = Connection::open(new_root.join("mobile.sqlite3")).unwrap();
+        assert!(storage::relocate_ios_paths(&connection, &new_root).is_err());
+        let paths = connection
+            .prepare("SELECT path FROM artifacts ORDER BY id")
+            .unwrap()
+            .query_map([], |row| row.get::<_, String>(0))
+            .unwrap()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
+        assert_eq!(paths, vec![corrupt_path.to_string_lossy(), source_path.to_string_lossy()]);
+        drop(connection);
+        let _ = std::fs::remove_dir_all(new_root);
+    }
+
+    #[cfg(all(not(target_os = "android"), unix))]
+    #[test]
+    fn mobile_ios_container_relocation_rejects_off_root_symlink_without_side_effects() {
+        let old_root = mobile_storage_contract_root("ios-relocation-symlink-old");
+        let connection = storage::db_at_root(&old_root).unwrap();
+        let bytes = b"registered artifact bytes";
+        let source_sha256 = storage::hex_digest(&Sha256::digest(bytes));
+        let project_id = source_hash_to_project_id(&source_sha256).unwrap();
+        let old_path = storage::project_root_path(&old_root, &project_id)
+            .unwrap()
+            .join("source/source.wav");
+        insert_mobile_contract_project(&connection, &project_id, &source_sha256, &old_path);
+        insert_mobile_relocation_artifact(
+            &connection,
+            &project_id,
+            "art_ios_symlink",
+            &old_path,
+            bytes,
+        );
+        drop(connection);
+
+        let new_root = mobile_storage_contract_root("ios-relocation-symlink-new");
+        std::fs::remove_dir_all(&new_root).unwrap();
+        std::fs::rename(&old_root, &new_root).unwrap();
+        let new_path = storage::project_root_path(&new_root, &project_id)
+            .unwrap()
+            .join("source/source.wav");
+        std::fs::remove_file(&new_path).unwrap();
+        let outside = new_root.with_extension("outside.wav");
+        let _ = std::fs::remove_file(&outside);
+        std::fs::write(&outside, bytes).unwrap();
+        std::os::unix::fs::symlink(&outside, &new_path).unwrap();
+
+        let connection = Connection::open(new_root.join("mobile.sqlite3")).unwrap();
+        assert_eq!(
+            storage::relocate_ios_paths(&connection, &new_root).unwrap_err(),
+            "Relocated iOS artifact is not a regular file."
+        );
+        assert!(std::fs::symlink_metadata(&new_path)
+            .unwrap()
+            .file_type()
+            .is_symlink());
+        std::fs::remove_file(&new_path).unwrap();
+        std::fs::remove_dir(new_path.parent().unwrap()).unwrap();
+        let outside_dir = new_root.with_extension("outside-dir");
+        let _ = std::fs::remove_dir_all(&outside_dir);
+        std::fs::create_dir(&outside_dir).unwrap();
+        std::fs::write(outside_dir.join("source.wav"), b"wrong bytes").unwrap();
+        std::os::unix::fs::symlink(&outside_dir, new_path.parent().unwrap()).unwrap();
+        assert_eq!(
+            storage::relocate_ios_paths(&connection, &new_root).unwrap_err(),
+            "Mobile project directory is not safe."
+        );
+        let stored: String = connection
+            .query_row(
+                "SELECT path FROM artifacts WHERE id = 'art_ios_symlink'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(stored, old_path.to_string_lossy());
+        assert!(std::fs::symlink_metadata(new_path.parent().unwrap())
+            .unwrap()
+            .file_type()
+            .is_symlink());
+        assert_eq!(std::fs::read(&outside).unwrap(), bytes);
+        assert_eq!(std::fs::read(outside_dir.join("source.wav")).unwrap(), b"wrong bytes");
+        drop(connection);
+        let _ = std::fs::remove_dir_all(new_root);
+        let _ = std::fs::remove_file(outside);
+        let _ = std::fs::remove_dir_all(outside_dir);
+    }
+
+    #[cfg(not(target_os = "android"))]
+    #[test]
+    fn mobile_ios_container_relocation_skips_paths_that_must_not_move() {
+        let root = mobile_storage_contract_root("ios-relocation-skips");
+        let connection = storage::db_at_root(&root).unwrap();
+        let current_sha256 = "c".repeat(64);
+        let current_project_id = source_hash_to_project_id(&current_sha256).unwrap();
+        let current_missing = storage::project_root_path(&root, &current_project_id)
+            .unwrap()
+            .join("source/missing.wav");
+        insert_mobile_contract_project(
+            &connection,
+            &current_project_id,
+            &current_sha256,
+            &current_missing,
+        );
+        insert_mobile_contract_artifact(
+            &connection,
+            MobileContractArtifact {
+                artifact_id: "art_ios_current_missing",
+                project_id: &current_project_id,
+                artifact_type: "source_audio",
+                format: "wav",
+                path: &current_missing,
+                content_sha256: &current_sha256,
+                size_bytes: 1,
+                generated_by: "sync",
+                can_delete: false,
+                can_regenerate: false,
+                cache_key: None,
+                metadata: json!({}),
+            },
+        );
+
+        let placeholder_id = source_hash_to_project_id(&"d".repeat(64)).unwrap();
+        connection
+            .execute(
+                "INSERT INTO projects (id, display_name, source_path, imported_path, sync_status, created_at, updated_at) VALUES (?1, 'Placeholder', '', '', 'remote_available', ?2, ?2)",
+                params![placeholder_id, "2026-05-22T12:00:00.000Z"],
+            )
+            .unwrap();
+        let deleted_sha256 = "e".repeat(64);
+        let deleted_project_id = source_hash_to_project_id(&deleted_sha256).unwrap();
+        let deleted_path = std::path::PathBuf::from(format!(
+            "/old/container/projects/{deleted_project_id}/source/deleted.wav"
+        ));
+        insert_mobile_contract_project(
+            &connection,
+            &deleted_project_id,
+            &deleted_sha256,
+            &deleted_path,
+        );
+        connection
+            .execute(
+                "UPDATE projects SET sync_status = 'deleted' WHERE id = ?1",
+                params![deleted_project_id],
+            )
+            .unwrap();
+
+        storage::relocate_ios_paths(&connection, &root).unwrap();
+        let current_stored: String = connection
+            .query_row(
+                "SELECT path FROM artifacts WHERE id = 'art_ios_current_missing'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        let placeholder_paths: (String, String) = connection
+            .query_row(
+                "SELECT source_path, imported_path FROM projects WHERE id = ?1",
+                params![placeholder_id],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .unwrap();
+        let deleted_stored: String = connection
+            .query_row(
+                "SELECT source_path FROM projects WHERE id = ?1",
+                params![deleted_project_id],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(current_stored, current_missing.to_string_lossy());
+        assert_eq!(placeholder_paths, (String::new(), String::new()));
+        assert_eq!(deleted_stored, deleted_path.to_string_lossy());
+        drop(connection);
+        let _ = std::fs::remove_dir_all(root);
     }
 
     #[cfg(not(target_os = "android"))]

--- a/apps/desktop/src-tauri/src/mobile_backend/ios.rs
+++ b/apps/desktop/src-tauri/src/mobile_backend/ios.rs
@@ -1,0 +1,17 @@
+include!("embedded.rs");
+
+fn spawn_playback_proxy_generation(
+    _root: PathBuf,
+    _project_root: PathBuf,
+    _source_path: PathBuf,
+    _artifact_id: String,
+) {
+}
+
+fn ensure_source_playback_proxy_metadata(
+    _connection: &Connection,
+    _root: &Path,
+    _project_id: &str,
+) -> Result<(), String> {
+    Ok(())
+}

--- a/apps/desktop/src-tauri/src/mobile_backend/mod.rs
+++ b/apps/desktop/src-tauri/src/mobile_backend/mod.rs
@@ -18,15 +18,11 @@ use std::{
     fs,
     io::{self, Read},
     path::{Path, PathBuf},
-    str::FromStr,
     thread,
     time::Instant,
 };
 #[cfg(all(test, not(target_os = "android")))]
 use tauri::{AppHandle, Manager};
-#[cfg(all(test, not(target_os = "android")))]
-use tauri_plugin_fs::{FilePath, FsExt, OpenOptions};
-
 include!("constants.rs");
 include!("schemas.rs");
 include!("helpers.rs");
@@ -35,6 +31,19 @@ include!("helpers.rs");
 mod android;
 #[cfg(target_os = "android")]
 pub use android::{
+    mobile_register_sync_staged_reference, mobile_sign_transport_handshake,
+    mobile_sync_transport_artifact_file, mobile_sync_transport_create_pairing_offer_value,
+    mobile_sync_transport_local_identity_value, mobile_sync_transport_metadata_value,
+    mobile_sync_transport_project_manifest_value, mobile_sync_transport_reconciliation_apply_value,
+    mobile_sync_transport_reconciliation_plan_value, mobile_sync_transport_stage_artifact_value,
+    mobile_sync_transport_staged_artifact_value, mobile_sync_transport_trusted_peers_value,
+    mobile_sync_transport_update_trusted_peer_endpoint_hints_value,
+};
+
+#[cfg(target_os = "ios")]
+mod ios;
+#[cfg(target_os = "ios")]
+pub use ios::{
     mobile_register_sync_staged_reference, mobile_sign_transport_handshake,
     mobile_sync_transport_artifact_file, mobile_sync_transport_create_pairing_offer_value,
     mobile_sync_transport_local_identity_value, mobile_sync_transport_metadata_value,
@@ -180,6 +189,16 @@ macro_rules! android_command {
     };
 }
 
+macro_rules! ios_command {
+    ($name:ident, $ret:ty $(, $arg:ident : $ty:ty)*) => {
+        #[cfg(target_os = "ios")]
+        #[tauri::command]
+        pub fn $name($($arg: $ty,)*) -> Result<$ret, String> {
+            ios::$name($($arg,)*)
+        }
+    };
+}
+
 android_command!(mobile_capabilities, MobileCapabilities, app: tauri::AppHandle);
 android_command!(mobile_get_health, HealthResponse, app: tauri::AppHandle);
 android_command!(mobile_list_projects, ProjectsResponse, app: tauri::AppHandle, params: Option<ListProjectsParams>);
@@ -218,3 +237,24 @@ android_command!(mobile_get_sync_staged_artifact, SyncStagedArtifactSchema, app:
 android_command!(mobile_import_sync_project, SyncProjectImportResponse, app: tauri::AppHandle, payload: SyncProjectStagedImportRequest);
 android_command!(mobile_plan_sync_reconciliation, SyncReconciliationPlanResponse, app: tauri::AppHandle, payload: SyncReconciliationPlanRequest);
 android_command!(mobile_apply_sync_reconciliation, SyncReconciliationApplyResponse, app: tauri::AppHandle, payload: SyncReconciliationApplyRequest);
+
+ios_command!(mobile_get_health, HealthResponse, app: tauri::AppHandle);
+ios_command!(mobile_list_projects, ProjectsResponse, app: tauri::AppHandle, params: Option<ListProjectsParams>);
+ios_command!(mobile_get_project, ProjectResponse, app: tauri::AppHandle, project_id: String);
+ios_command!(mobile_list_artifacts, ArtifactsResponse, app: tauri::AppHandle, project_id: String);
+ios_command!(mobile_list_jobs, JobsResponse, app: tauri::AppHandle, params: Option<ListJobsParams>);
+ios_command!(mobile_get_job, JobResponse, app: tauri::AppHandle, job_id: String);
+ios_command!(mobile_get_sync_identity, SyncLocalIdentityResponse, app: tauri::AppHandle);
+ios_command!(mobile_create_sync_pairing_offer, SyncPairingOfferResponse, app: tauri::AppHandle, payload: Option<SyncPairingOfferRequest>);
+ios_command!(mobile_answer_sync_pairing_offer, SyncPairingAnswerResponse, app: tauri::AppHandle, payload: SyncPairingAnswerRequest);
+ios_command!(mobile_list_sync_trusted_peers, SyncTrustedPeersResponse, app: tauri::AppHandle);
+ios_command!(mobile_trust_sync_peer, SyncTrustedPeerResponse, app: tauri::AppHandle, payload: SyncTrustedPeerCreateRequest);
+ios_command!(mobile_revoke_sync_trusted_peer, SyncTrustedPeerResponse, app: tauri::AppHandle, device_id: String);
+ios_command!(mobile_get_sync_metadata, SyncMetadataResponse, app: tauri::AppHandle);
+ios_command!(mobile_get_sync_project_manifest, SyncProjectManifestResponse, app: tauri::AppHandle, project_id: String);
+ios_command!(mobile_update_sync_project_status, SyncProjectStatusUpdateResponse, app: tauri::AppHandle, project_id: String, payload: SyncProjectStatusUpdateRequest);
+ios_command!(mobile_stage_sync_artifact, SyncStagedArtifactSchema, app: tauri::AppHandle, payload: SyncArtifactStagingRequest);
+ios_command!(mobile_get_sync_staged_artifact, SyncStagedArtifactSchema, app: tauri::AppHandle, content_sha256: String);
+ios_command!(mobile_import_sync_project, SyncProjectImportResponse, app: tauri::AppHandle, payload: SyncProjectStagedImportRequest);
+ios_command!(mobile_plan_sync_reconciliation, SyncReconciliationPlanResponse, app: tauri::AppHandle, payload: SyncReconciliationPlanRequest);
+ios_command!(mobile_apply_sync_reconciliation, SyncReconciliationApplyResponse, app: tauri::AppHandle, payload: SyncReconciliationApplyRequest);

--- a/apps/desktop/src-tauri/src/mobile_backend/storage.rs
+++ b/apps/desktop/src-tauri/src/mobile_backend/storage.rs
@@ -365,9 +365,117 @@ pub(super) fn db_at_root(root: &Path) -> Result<Connection, String> {
     let connection =
         Connection::open(root.join("mobile.sqlite3")).map_err(|error| error.to_string())?;
     migrate_mobile_db(&connection)?;
+    #[cfg(target_os = "ios")]
+    relocate_ios_paths(&connection, root)?;
     mark_interrupted_jobs_on_first_open(root, &connection)?;
     ensure_local_identity(&connection)?;
     Ok(connection)
+}
+
+#[cfg(any(target_os = "ios", test))]
+fn ios_relocated_path(root: &Path, project_id: &str, stored_path: &str) -> Result<PathBuf, String> {
+    let stored_path = Path::new(stored_path);
+    let stored_path_text = stored_path
+        .to_str()
+        .ok_or_else(|| "Stored iOS project path is not valid UTF-8.".to_string())?;
+    let separator = std::path::MAIN_SEPARATOR;
+    let marker = format!("{separator}projects{separator}{project_id}{separator}");
+    let mut parts = stored_path_text.split(&marker);
+    let (Some(prefix), Some(relative), None) = (parts.next(), parts.next(), parts.next()) else {
+        return Err("Stored iOS project path cannot be safely relocated.".to_string());
+    };
+    if !stored_path.is_absolute() || prefix.is_empty() || relative.is_empty() {
+        return Err("Stored iOS project path cannot be safely relocated.".to_string());
+    }
+    let project_root = project_root_path(root, project_id)?;
+    Ok(project_root.join(safe_relative_path(relative)?))
+}
+
+#[cfg(any(target_os = "ios", test))]
+pub(super) fn relocate_ios_paths(connection: &Connection, root: &Path) -> Result<(), String> {
+    let _storage_guard = super::storage_cleanup::project_storage_mutation_guard();
+    let transaction =
+        rusqlite::Transaction::new_unchecked(connection, rusqlite::TransactionBehavior::Immediate)
+            .map_err(|error| error.to_string())?;
+    let rows = {
+        let mut statement = transaction
+            .prepare(&format!(
+                "SELECT {ARTIFACT_COLUMNS} FROM artifacts WHERE project_id IN (SELECT id FROM projects WHERE sync_status != 'deleted')"
+            ))
+            .map_err(|error| error.to_string())?;
+        let mapped = statement
+            .query_map([], row_artifact)
+            .map_err(|error| error.to_string())?;
+        mapped
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|error| error.to_string())?
+    };
+    let mut changes = Vec::new();
+    for artifact in rows {
+        if Path::new(&artifact.path).starts_with(root) {
+            continue;
+        }
+        let new_path = ios_relocated_path(root, &artifact.project_id, &artifact.path)?;
+        let expected_sha256 = artifact
+            .content_sha256
+            .as_deref()
+            .ok_or_else(|| "Stored iOS artifact lacks SHA-256 metadata.".to_string())
+            .and_then(|value| normalize_sha256(value, "content_sha256"))?;
+        let metadata = fs::symlink_metadata(&new_path)
+            .map_err(|_| "Relocated iOS artifact is missing.".to_string())?;
+        if !metadata.file_type().is_file() {
+            return Err("Relocated iOS artifact is not a regular file.".to_string());
+        }
+        let project_root = project_root_path(root, &artifact.project_id)?;
+        let owned =
+            super::storage_cleanup::capture_owned_project_file(root, &project_root, &new_path)?;
+        super::storage_cleanup::require_owned_project_file(&owned)?;
+        if metadata.len() as i64 != artifact.size_bytes
+            || file_sha256(&new_path)? != expected_sha256
+        {
+            return Err("Relocated iOS artifact does not match its registration.".to_string());
+        }
+        super::storage_cleanup::require_owned_project_file(&owned)?;
+        changes.push((artifact.id, artifact.project_id, artifact.path, new_path));
+    }
+    for (artifact_id, project_id, old_path, new_path) in &changes {
+        let new_path = new_path.to_string_lossy();
+        transaction
+            .execute(
+                "UPDATE artifacts SET path = ?1 WHERE id = ?2 AND path = ?3",
+                params![new_path.as_ref(), artifact_id, old_path],
+            )
+            .map_err(|error| error.to_string())?;
+        transaction
+                .execute(
+                    "UPDATE projects SET source_path = CASE WHEN source_path = ?1 THEN ?2 ELSE source_path END, imported_path = CASE WHEN imported_path = ?1 THEN ?2 ELSE imported_path END WHERE id = ?3",
+                    params![old_path, new_path.as_ref(), project_id],
+                )
+                .map_err(|error| error.to_string())?;
+    }
+    let paths = {
+        let mut statement = transaction
+            .prepare(
+                "SELECT source_path, imported_path FROM projects WHERE sync_status != 'deleted'",
+            )
+            .map_err(|error| error.to_string())?;
+        let mapped = statement
+            .query_map([], |row| {
+                Ok([row.get::<_, String>(0)?, row.get::<_, String>(1)?])
+            })
+            .map_err(|error| error.to_string())?;
+        mapped
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|error| error.to_string())?
+    };
+    if paths
+        .into_iter()
+        .flatten()
+        .any(|path| !path.is_empty() && !Path::new(&path).starts_with(root))
+    {
+        return Err("Stored iOS project path has no verified artifact registration.".to_string());
+    }
+    transaction.commit().map_err(|error| error.to_string())
 }
 
 fn mark_interrupted_jobs_on_first_open(root: &Path, connection: &Connection) -> Result<(), String> {
@@ -390,6 +498,7 @@ fn mark_interrupted_jobs_on_first_open(root: &Path, connection: &Connection) -> 
             .map_err(|error| error.to_string())?
             .collect::<Result<Vec<_>, _>>()
             .map_err(|error| error.to_string())?;
+        #[cfg(target_os = "android")]
         super::export::fail_interrupted_exports(connection)?;
         fail_interrupted_audio_transforms(connection)?;
         for project_id in project_ids {
@@ -1481,6 +1590,7 @@ pub fn mobile_register_sync_staged_reference(
     )
 }
 
+#[cfg(target_os = "android")]
 pub(super) fn can_upgrade_project_placeholder(
     project: &ProjectSchema,
     project_id: &str,
@@ -1514,6 +1624,7 @@ pub(super) fn delete_project_rows(connection: &Connection, project_id: &str) -> 
     Ok(())
 }
 
+#[cfg(target_os = "android")]
 pub(super) fn discard_deleted_project_placeholders(
     connection: &Connection,
     root: &Path,
@@ -1561,6 +1672,7 @@ pub(super) fn discard_deleted_project_placeholders(
     Ok(())
 }
 
+#[cfg(target_os = "android")]
 pub(super) fn clear_project_delete_tombstones_for_reimport(
     connection: &Connection,
     project_id: &str,
@@ -1573,10 +1685,12 @@ pub(super) fn clear_project_delete_tombstones_for_reimport(
         .map_err(|error| error.to_string())?;
     Ok(())
 }
+#[cfg(target_os = "android")]
 pub(super) fn is_android_file_uri(source_path: &str) -> bool {
     source_path.starts_with("content://") || source_path.starts_with("file://")
 }
 
+#[cfg(target_os = "android")]
 pub(super) fn source_filename(app: &AppHandle, source_path: &str) -> String {
     if is_android_file_uri(source_path) {
         return app
@@ -1594,6 +1708,7 @@ pub(super) fn source_filename(app: &AppHandle, source_path: &str) -> String {
         .to_string()
 }
 
+#[cfg(target_os = "android")]
 pub(super) fn source_stem(file_name: &str) -> String {
     Path::new(file_name)
         .file_stem()
@@ -1635,6 +1750,7 @@ pub(super) fn hex_digest(bytes: &[u8]) -> String {
     output
 }
 
+#[cfg(target_os = "android")]
 pub(super) fn copy_source_into_project(
     app: &AppHandle,
     source_path: &str,
@@ -1750,6 +1866,7 @@ pub fn mobile_list_projects(
     })
 }
 
+#[cfg(target_os = "android")]
 pub fn mobile_import_project(
     app: AppHandle,
     payload: ProjectImportRequest,
@@ -1938,6 +2055,7 @@ pub fn mobile_import_project(
     Ok(ProjectResponse { project })
 }
 
+#[cfg(any(target_os = "android", test))]
 struct ImportAudioProperties {
     duration_seconds: f64,
     sample_rate: u32,

--- a/apps/desktop/src-tauri/src/mobile_backend/stubs.rs
+++ b/apps/desktop/src-tauri/src/mobile_backend/stubs.rs
@@ -43,13 +43,13 @@ macro_rules! mobile_stub {
     };
 }
 
-#[cfg(not(target_os = "android"))]
+#[cfg(not(any(target_os = "android", target_os = "ios")))]
 mobile_stub!(mobile_get_health, HealthResponse, app: AppHandle);
-#[cfg(not(target_os = "android"))]
+#[cfg(not(any(target_os = "android", target_os = "ios")))]
 mobile_stub!(mobile_list_projects, ProjectsResponse, app: AppHandle, params: Option<ListProjectsParams>);
 #[cfg(not(target_os = "android"))]
 mobile_stub!(mobile_import_project, ProjectResponse, app: AppHandle, payload: ProjectImportRequest);
-#[cfg(not(target_os = "android"))]
+#[cfg(not(any(target_os = "android", target_os = "ios")))]
 mobile_stub!(mobile_get_project, ProjectResponse, app: AppHandle, project_id: String);
 #[cfg(not(target_os = "android"))]
 mobile_stub!(mobile_update_project, ProjectResponse, app: AppHandle, project_id: String, payload: ProjectUpdateRequest);
@@ -77,43 +77,43 @@ mobile_stub!(mobile_submit_stems, JobResponse, app: AppHandle, project_id: Strin
 mobile_stub!(mobile_submit_retune, JobResponse, app: AppHandle, project_id: String, payload: EmptyPayload);
 #[cfg(not(target_os = "android"))]
 mobile_stub!(mobile_submit_transpose, JobResponse, app: AppHandle, project_id: String, payload: EmptyPayload);
-#[cfg(not(target_os = "android"))]
+#[cfg(not(any(target_os = "android", target_os = "ios")))]
 mobile_stub!(mobile_list_artifacts, ArtifactsResponse, app: AppHandle, project_id: String);
 #[cfg(not(target_os = "android"))]
 mobile_stub!(mobile_delete_artifact, DeleteResponse, app: AppHandle, project_id: String, artifact_id: String);
 #[cfg(not(target_os = "android"))]
 mobile_stub!(mobile_submit_export, JobResponse, app: AppHandle, project_id: String, payload: EmptyPayload);
-#[cfg(not(target_os = "android"))]
+#[cfg(not(any(target_os = "android", target_os = "ios")))]
 mobile_stub!(mobile_list_jobs, JobsResponse, app: AppHandle, params: Option<ListJobsParams>);
-#[cfg(not(target_os = "android"))]
+#[cfg(not(any(target_os = "android", target_os = "ios")))]
 mobile_stub!(mobile_get_job, JobResponse, app: AppHandle, job_id: String);
 #[cfg(not(target_os = "android"))]
 mobile_stub!(mobile_cancel_job, JobResponse, app: AppHandle, job_id: String);
-#[cfg(not(target_os = "android"))]
+#[cfg(not(any(target_os = "android", target_os = "ios")))]
 mobile_stub!(mobile_get_sync_identity, SyncLocalIdentityResponse, app: AppHandle);
-#[cfg(not(target_os = "android"))]
+#[cfg(not(any(target_os = "android", target_os = "ios")))]
 mobile_stub!(mobile_create_sync_pairing_offer, SyncPairingOfferResponse, app: AppHandle, payload: Option<SyncPairingOfferRequest>);
-#[cfg(not(target_os = "android"))]
+#[cfg(not(any(target_os = "android", target_os = "ios")))]
 mobile_stub!(mobile_answer_sync_pairing_offer, SyncPairingAnswerResponse, app: AppHandle, payload: SyncPairingAnswerRequest);
-#[cfg(not(target_os = "android"))]
+#[cfg(not(any(target_os = "android", target_os = "ios")))]
 mobile_stub!(mobile_list_sync_trusted_peers, SyncTrustedPeersResponse, app: AppHandle);
-#[cfg(not(target_os = "android"))]
+#[cfg(not(any(target_os = "android", target_os = "ios")))]
 mobile_stub!(mobile_trust_sync_peer, SyncTrustedPeerResponse, app: AppHandle, payload: SyncTrustedPeerCreateRequest);
-#[cfg(not(target_os = "android"))]
+#[cfg(not(any(target_os = "android", target_os = "ios")))]
 mobile_stub!(mobile_revoke_sync_trusted_peer, SyncTrustedPeerResponse, app: AppHandle, device_id: String);
-#[cfg(not(target_os = "android"))]
+#[cfg(not(any(target_os = "android", target_os = "ios")))]
 mobile_stub!(mobile_get_sync_metadata, SyncMetadataResponse, app: AppHandle);
-#[cfg(not(target_os = "android"))]
+#[cfg(not(any(target_os = "android", target_os = "ios")))]
 mobile_stub!(mobile_get_sync_project_manifest, SyncProjectManifestResponse, app: AppHandle, project_id: String);
-#[cfg(not(target_os = "android"))]
+#[cfg(not(any(target_os = "android", target_os = "ios")))]
 mobile_stub!(mobile_update_sync_project_status, SyncProjectStatusUpdateResponse, app: AppHandle, project_id: String, payload: SyncProjectStatusUpdateRequest);
-#[cfg(not(target_os = "android"))]
+#[cfg(not(any(target_os = "android", target_os = "ios")))]
 mobile_stub!(mobile_stage_sync_artifact, SyncStagedArtifactSchema, app: AppHandle, payload: SyncArtifactStagingRequest);
-#[cfg(not(target_os = "android"))]
+#[cfg(not(any(target_os = "android", target_os = "ios")))]
 mobile_stub!(mobile_get_sync_staged_artifact, SyncStagedArtifactSchema, app: AppHandle, content_sha256: String);
-#[cfg(not(target_os = "android"))]
+#[cfg(not(any(target_os = "android", target_os = "ios")))]
 mobile_stub!(mobile_import_sync_project, SyncProjectImportResponse, app: AppHandle, payload: SyncProjectStagedImportRequest);
-#[cfg(not(target_os = "android"))]
+#[cfg(not(any(target_os = "android", target_os = "ios")))]
 mobile_stub!(mobile_plan_sync_reconciliation, SyncReconciliationPlanResponse, app: AppHandle, payload: SyncReconciliationPlanRequest);
-#[cfg(not(target_os = "android"))]
+#[cfg(not(any(target_os = "android", target_os = "ios")))]
 mobile_stub!(mobile_apply_sync_reconciliation, SyncReconciliationApplyResponse, app: AppHandle, payload: SyncReconciliationApplyRequest);

--- a/apps/desktop/src-tauri/src/sync_transport.rs
+++ b/apps/desktop/src-tauri/src/sync_transport.rs
@@ -1616,7 +1616,7 @@ mod desktop {
     use snow::{params::NoiseParams, Builder};
     #[cfg(any(test, target_os = "android"))]
     use std::collections::BTreeSet;
-    #[cfg(not(target_os = "android"))]
+    #[cfg(not(mobile))]
     use std::io::{BufRead, BufReader};
     use std::{
         collections::{BTreeMap, HashMap, HashSet, VecDeque},
@@ -1637,7 +1637,7 @@ mod desktop {
         thread::{self, JoinHandle},
         time::{Duration, Instant},
     };
-    #[cfg(target_os = "android")]
+    #[cfg(mobile)]
     use tauri::Manager;
     use tauri::{AppHandle, State};
 
@@ -1690,11 +1690,11 @@ mod desktop {
         "Restore the device state, then retry sync.";
     const LIFECYCLE_INTERRUPTION_NETWORK_GUIDANCE: &str =
         "Restore network connectivity, then retry sync.";
-    #[cfg(not(target_os = "android"))]
+    #[cfg(not(mobile))]
     const HTTP_TIMEOUT: Duration = Duration::from_secs(45);
-    #[cfg(not(target_os = "android"))]
+    #[cfg(not(mobile))]
     const MANIFEST_EXPORT_HTTP_TIMEOUT: Duration = Duration::from_secs(300);
-    #[cfg(not(target_os = "android"))]
+    #[cfg(not(mobile))]
     const BACKEND_PREFLIGHT_TIMEOUT: Duration = Duration::from_secs(3);
 
     trait SyncInhibitionGuard: Send {}
@@ -1943,6 +1943,7 @@ mod desktop {
                 .local_addr()
                 .map_err(|error| format!("Could not inspect sync transport listener: {error}"))?;
             let tcp_endpoint_hints = endpoint_hints_for_port(bind_addr.port(), &identity.device_id);
+            #[cfg(not(target_os = "ios"))]
             let iroh_transport =
                 match create_iroh_transport(&self.backend, &identity.device_id, bind_addr.port()) {
                     Ok(transport) => Some(transport),
@@ -1955,6 +1956,8 @@ mod desktop {
                         None
                     }
                 };
+            #[cfg(target_os = "ios")]
+            let iroh_transport: Option<IrohTransport> = None;
             let mut endpoint_hints = iroh_transport
                 .as_ref()
                 .map(|transport| iroh_endpoint_hints(transport, &identity.device_id))
@@ -1980,6 +1983,7 @@ mod desktop {
                 );
                 tcp_listener_power_inhibition.release();
             });
+            #[cfg(not(target_os = "ios"))]
             let iroh_thread = iroh_transport.as_ref().map(|transport| {
                 let transport = transport.clone();
                 let backend = self.backend.clone();
@@ -1998,7 +2002,11 @@ mod desktop {
                     );
                 })
             });
+            #[cfg(target_os = "ios")]
+            let iroh_thread = None;
+            #[cfg(not(target_os = "ios"))]
             let mut discovery_error = None;
+            #[cfg(not(target_os = "ios"))]
             let discovery_thread = match start_discovery(
                 identity,
                 endpoint_hints.clone(),
@@ -2011,6 +2019,10 @@ mod desktop {
                     None
                 }
             };
+            #[cfg(target_os = "ios")]
+            let discovery_thread = None;
+            #[cfg(target_os = "ios")]
+            let discovery_error: Option<String> = None;
 
             let handle = ListenerHandle {
                 bind_addr,
@@ -2387,10 +2399,13 @@ mod desktop {
                         Vec::new(),
                     )
                 })?;
+            #[cfg(not(target_os = "ios"))]
             let preferred_transport = payload
                 .preferred_transport
                 .as_deref()
                 .and_then(normalized_transport_id);
+            #[cfg(target_os = "ios")]
+            let preferred_transport = Some(TCP_TRANSPORT_ID);
             let local_iroh = self.local_iroh_transport();
             let selection_endpoint_hints = sync_now_selection_endpoint_hints(
                 payload.endpoint_hint.as_deref(),
@@ -3054,7 +3069,7 @@ mod desktop {
     #[derive(Clone)]
     struct BackendAccess {
         base_url: String,
-        #[cfg_attr(not(target_os = "android"), allow(dead_code))]
+        #[cfg_attr(not(mobile), allow(dead_code))]
         app: AppHandle,
     }
 
@@ -3085,7 +3100,7 @@ mod desktop {
     }
 
     impl SyncBackendPreflight {
-        #[cfg(target_os = "android")]
+        #[cfg(mobile)]
         fn ready() -> Self {
             Self {
                 ok: true,
@@ -4715,6 +4730,7 @@ mod desktop {
     }
 
     fn sync_transport_data_dir(_backend: &BackendAccess) -> Result<PathBuf, String> {
+        #[cfg(target_os = "android")]
         let transport_override = env::var("TUNEFORGE_SYNC_TRANSPORT_DATA_DIR").ok();
         #[cfg(target_os = "android")]
         {
@@ -4724,8 +4740,17 @@ mod desktop {
                 })
             });
         }
-        #[cfg(not(target_os = "android"))]
+        #[cfg(target_os = "ios")]
         {
+            return resolve_sync_transport_data_dir(None, None, || {
+                _backend.app.path().app_data_dir().map_err(|error| {
+                    format!("Could not resolve iOS sync transport data directory: {error}")
+                })
+            });
+        }
+        #[cfg(not(mobile))]
+        {
+            let transport_override = env::var("TUNEFORGE_SYNC_TRANSPORT_DATA_DIR").ok();
             let data_root_override = env::var("TUNEFORGE_DATA_DIR").ok();
             resolve_sync_transport_data_dir(
                 transport_override.as_deref(),
@@ -9581,7 +9606,7 @@ mod desktop {
         results
     }
 
-    #[cfg(target_os = "android")]
+    #[cfg(mobile)]
     fn already_staged_artifact_result(
         client: &BackendClient,
         artifact: &RemoteArtifact,
@@ -9589,7 +9614,7 @@ mod desktop {
         client.register_staged_artifact_reference(artifact)
     }
 
-    #[cfg(not(target_os = "android"))]
+    #[cfg(not(mobile))]
     fn already_staged_artifact_result(
         client: &BackendClient,
         artifact: &RemoteArtifact,
@@ -12350,13 +12375,13 @@ mod desktop {
 
     #[derive(Clone)]
     struct BackendClient {
-        #[cfg(not(target_os = "android"))]
+        #[cfg(not(mobile))]
         host: String,
-        #[cfg(not(target_os = "android"))]
+        #[cfg(not(mobile))]
         port: u16,
-        #[cfg(not(target_os = "android"))]
+        #[cfg(not(mobile))]
         sync_transport_temp_root: Arc<Mutex<Option<PathBuf>>>,
-        #[cfg(target_os = "android")]
+        #[cfg(mobile)]
         app: AppHandle,
     }
 
@@ -12365,7 +12390,7 @@ mod desktop {
             &self,
             artifact: &RemoteArtifact,
         ) -> Result<bool, String> {
-            #[cfg(target_os = "android")]
+            #[cfg(mobile)]
             {
                 return crate::mobile_backend::mobile_register_sync_staged_reference(
                     self.app.clone(),
@@ -12376,7 +12401,7 @@ mod desktop {
                 );
             }
 
-            #[cfg(not(target_os = "android"))]
+            #[cfg(not(mobile))]
             {
                 let _ = artifact;
                 Ok(true)
@@ -12384,11 +12409,11 @@ mod desktop {
         }
 
         fn new(access: &BackendAccess) -> Result<Self, String> {
-            #[cfg(target_os = "android")]
+            #[cfg(mobile)]
             {
                 if access.base_url != "mobile://embedded" {
                     return Err(
-                        "Android sync transport requires the embedded mobile backend.".to_string(),
+                        "Mobile sync transport requires the embedded mobile backend.".to_string(),
                     );
                 }
                 return Ok(Self {
@@ -12396,7 +12421,7 @@ mod desktop {
                 });
             }
 
-            #[cfg(not(target_os = "android"))]
+            #[cfg(not(mobile))]
             {
                 let base_url = &access.base_url;
                 let without_scheme = base_url.strip_prefix("http://").ok_or_else(|| {
@@ -12427,28 +12452,28 @@ mod desktop {
         }
 
         fn sync_preflight(&self) -> Result<SyncBackendPreflight, BackendError> {
-            #[cfg(target_os = "android")]
+            #[cfg(mobile)]
             {
                 return Ok(SyncBackendPreflight::ready());
             }
 
-            #[cfg(not(target_os = "android"))]
+            #[cfg(not(mobile))]
             self.get_json_with_timeout("/api/v1/sync/preflight", BACKEND_PREFLIGHT_TIMEOUT)
         }
 
         fn sync_metadata_preflight_probe(&self) -> Result<(), BackendError> {
-            #[cfg(target_os = "android")]
+            #[cfg(mobile)]
             {
                 return Ok(());
             }
 
-            #[cfg(not(target_os = "android"))]
+            #[cfg(not(mobile))]
             self.get_json_with_timeout::<Value>("/api/v1/sync/metadata", BACKEND_PREFLIGHT_TIMEOUT)
                 .map(|_| ())
         }
 
         fn local_identity(&self) -> Result<SyncLocalIdentity, BackendError> {
-            #[cfg(target_os = "android")]
+            #[cfg(mobile)]
             {
                 let value = crate::mobile_backend::mobile_sync_transport_local_identity_value(
                     self.app.clone(),
@@ -12459,13 +12484,13 @@ mod desktop {
                     .map_err(|error| BackendError::local(error.to_string()));
             }
 
-            #[cfg(not(target_os = "android"))]
+            #[cfg(not(mobile))]
             self.get_json::<SyncLocalIdentityResponse>("/api/v1/sync/identity")
                 .map(|response| response.identity)
         }
 
         fn trusted_peer(&self, device_id: &str) -> Result<Option<SyncTrustedPeer>, BackendError> {
-            #[cfg(target_os = "android")]
+            #[cfg(mobile)]
             {
                 let response = crate::mobile_backend::mobile_sync_transport_trusted_peers_value(
                     self.app.clone(),
@@ -12479,7 +12504,7 @@ mod desktop {
                     .find(|peer| peer.device_id == device_id && peer.revoked_at.is_none()));
             }
 
-            #[cfg(not(target_os = "android"))]
+            #[cfg(not(mobile))]
             {
                 let response =
                     self.get_json::<SyncTrustedPeersResponse>("/api/v1/sync/trusted-peers")?;
@@ -12495,7 +12520,7 @@ mod desktop {
             endpoint_hints: Vec<String>,
             ttl_seconds: u32,
         ) -> Result<Value, BackendError> {
-            #[cfg(target_os = "android")]
+            #[cfg(mobile)]
             {
                 return crate::mobile_backend::mobile_sync_transport_create_pairing_offer_value(
                     self.app.clone(),
@@ -12505,7 +12530,7 @@ mod desktop {
                 .map_err(BackendError::local);
             }
 
-            #[cfg(not(target_os = "android"))]
+            #[cfg(not(mobile))]
             {
                 let body = json!({
                     "endpoint_hints": endpoint_hints,
@@ -12526,7 +12551,7 @@ mod desktop {
                 return Ok(());
             }
 
-            #[cfg(target_os = "android")]
+            #[cfg(mobile)]
             {
                 crate::mobile_backend::mobile_sync_transport_update_trusted_peer_endpoint_hints_value(
                     self.app.clone(),
@@ -12537,7 +12562,7 @@ mod desktop {
                 .map_err(BackendError::local)
             }
 
-            #[cfg(not(target_os = "android"))]
+            #[cfg(not(mobile))]
             {
                 let body = json!({ "endpoint_hints": endpoint_hints });
                 let path = format!(
@@ -12557,7 +12582,7 @@ mod desktop {
             peer_device_id: &str,
             challenge: &Value,
         ) -> Result<Value, BackendError> {
-            #[cfg(target_os = "android")]
+            #[cfg(mobile)]
             {
                 return crate::mobile_backend::mobile_sign_transport_handshake(
                     self.app.clone(),
@@ -12567,7 +12592,7 @@ mod desktop {
                 .map_err(BackendError::local);
             }
 
-            #[cfg(not(target_os = "android"))]
+            #[cfg(not(mobile))]
             {
                 let body = json!({
                     "peer_device_id": peer_device_id,
@@ -12578,7 +12603,7 @@ mod desktop {
         }
 
         fn temp_artifact_root(&self) -> Result<PathBuf, String> {
-            #[cfg(target_os = "android")]
+            #[cfg(mobile)]
             {
                 if let Ok(path) = self.app.path().app_cache_dir() {
                     return Ok(path);
@@ -12587,11 +12612,11 @@ mod desktop {
                     return Ok(path);
                 }
                 return Err(
-                    "Could not resolve Android sync transport artifact temp directory.".to_string(),
+                    "Could not resolve mobile sync transport artifact temp directory.".to_string(),
                 );
             }
 
-            #[cfg(not(target_os = "android"))]
+            #[cfg(not(mobile))]
             {
                 let mut cached = self
                     .sync_transport_temp_root
@@ -12610,13 +12635,13 @@ mod desktop {
             }
         }
 
-        #[cfg(not(target_os = "android"))]
+        #[cfg(not(mobile))]
         fn get_json<T: for<'de> Deserialize<'de>>(&self, path: &str) -> Result<T, BackendError> {
             let value = self.request_json_value("GET", path, None)?;
             serde_json::from_value(value).map_err(|error| BackendError::local(error.to_string()))
         }
 
-        #[cfg(not(target_os = "android"))]
+        #[cfg(not(mobile))]
         fn get_json_with_timeout<T: for<'de> Deserialize<'de>>(
             &self,
             path: &str,
@@ -12627,7 +12652,7 @@ mod desktop {
         }
 
         fn get_json_value(&self, path: &str) -> Result<Value, BackendError> {
-            #[cfg(target_os = "android")]
+            #[cfg(mobile)]
             {
                 if path == "/api/v1/sync/metadata" {
                     return crate::mobile_backend::mobile_sync_transport_metadata_value(
@@ -12662,16 +12687,16 @@ mod desktop {
                     });
                 }
                 return Err(BackendError::local(format!(
-                    "Android mobile backend does not implement GET {path}."
+                    "Mobile embedded backend does not implement GET {path}."
                 )));
             }
 
-            #[cfg(not(target_os = "android"))]
+            #[cfg(not(mobile))]
             self.request_json_value("GET", path, None)
         }
 
         fn get_project_manifest_json_value(&self, project_id: &str) -> Result<Value, BackendError> {
-            #[cfg(target_os = "android")]
+            #[cfg(mobile)]
             {
                 return crate::mobile_backend::mobile_sync_transport_project_manifest_value(
                     self.app.clone(),
@@ -12680,7 +12705,7 @@ mod desktop {
                 .map_err(BackendError::local);
             }
 
-            #[cfg(not(target_os = "android"))]
+            #[cfg(not(mobile))]
             {
                 let path = format!(
                     "/api/v1/sync/projects/{}/manifest",
@@ -12696,7 +12721,7 @@ mod desktop {
         }
 
         fn post_json_value(&self, path: &str, body: &Value) -> Result<Value, BackendError> {
-            #[cfg(target_os = "android")]
+            #[cfg(mobile)]
             {
                 return match path {
                     "/api/v1/sync/artifacts/staging" => {
@@ -12712,13 +12737,13 @@ mod desktop {
                         )
                     }
                     _ => Err(format!(
-                        "Android mobile backend does not implement POST {path}."
+                        "Mobile embedded backend does not implement POST {path}."
                     )),
                 }
                 .map_err(BackendError::local);
             }
 
-            #[cfg(not(target_os = "android"))]
+            #[cfg(not(mobile))]
             self.request_json_value("POST", path, Some(body))
         }
 
@@ -12727,7 +12752,7 @@ mod desktop {
             body: Value,
             compact_staged_references: Vec<CompactStagedReference>,
         ) -> Result<Value, BackendError> {
-            #[cfg(target_os = "android")]
+            #[cfg(mobile)]
             {
                 return crate::mobile_backend::mobile_sync_transport_reconciliation_apply_value(
                     self.app.clone(),
@@ -12737,7 +12762,7 @@ mod desktop {
                 .map_err(BackendError::local);
             }
 
-            #[cfg(not(target_os = "android"))]
+            #[cfg(not(mobile))]
             {
                 let _ = compact_staged_references;
                 self.request_json_value("POST", "/api/v1/sync/reconciliation/apply", Some(&body))
@@ -12745,15 +12770,15 @@ mod desktop {
         }
 
         fn post_manifest_batch_json_value(&self, body: &Value) -> Result<Value, BackendError> {
-            #[cfg(target_os = "android")]
+            #[cfg(mobile)]
             {
                 Err(BackendError::local(
-                    "Android mobile backend does not implement POST /api/v1/sync/projects/manifests."
+                    "Mobile embedded backend does not implement POST /api/v1/sync/projects/manifests."
                         .to_string(),
                 ))
             }
 
-            #[cfg(not(target_os = "android"))]
+            #[cfg(not(mobile))]
             self.request_json_value_with_timeout(
                 "POST",
                 "/api/v1/sync/projects/manifests",
@@ -12766,20 +12791,20 @@ mod desktop {
             if matches!(error.status, Some(404 | 405)) {
                 return true;
             }
-            #[cfg(target_os = "android")]
+            #[cfg(mobile)]
             {
                 error.status.is_none()
                     && error
                         .message
                         .contains("does not implement POST /api/v1/sync/projects/manifests")
             }
-            #[cfg(not(target_os = "android"))]
+            #[cfg(not(mobile))]
             {
                 false
             }
         }
 
-        #[cfg(not(target_os = "android"))]
+        #[cfg(not(mobile))]
         fn request_json_value(
             &self,
             method: &str,
@@ -12789,7 +12814,7 @@ mod desktop {
             self.request_json_value_with_timeout(method, path, body, HTTP_TIMEOUT)
         }
 
-        #[cfg(not(target_os = "android"))]
+        #[cfg(not(mobile))]
         fn request_json_value_with_timeout(
             &self,
             method: &str,
@@ -12814,7 +12839,7 @@ mod desktop {
             &self,
             artifacts: &[RemoteArtifact],
         ) -> Result<ArtifactFileResolveResult, BackendError> {
-            #[cfg(target_os = "android")]
+            #[cfg(mobile)]
             {
                 let mut files = HashMap::new();
                 for artifact in artifacts {
@@ -12840,7 +12865,7 @@ mod desktop {
                 });
             }
 
-            #[cfg(not(target_os = "android"))]
+            #[cfg(not(mobile))]
             {
                 let artifact_ids: Vec<_> = artifacts
                     .iter()
@@ -12853,7 +12878,7 @@ mod desktop {
             }
         }
 
-        #[cfg(not(target_os = "android"))]
+        #[cfg(not(mobile))]
         fn request_body_with_timeout(
             &self,
             method: &str,
@@ -12927,7 +12952,7 @@ mod desktop {
             })
         }
 
-        #[cfg(not(target_os = "android"))]
+        #[cfg(not(mobile))]
         fn connect_with_timeout(&self, timeout: Duration) -> Result<TcpStream, BackendError> {
             let host = self
                 .host
@@ -12960,7 +12985,7 @@ mod desktop {
         }
     }
 
-    #[cfg(not(target_os = "android"))]
+    #[cfg(not(mobile))]
     fn backend_http_io_error(error: io::Error, timeout: Duration) -> BackendError {
         if matches!(
             error.kind(),
@@ -13342,6 +13367,16 @@ mod desktop {
                 resolved,
                 PathBuf::from("platform-data").join("sync-transport")
             );
+        }
+
+        #[test]
+        fn sync_transport_data_dir_propagates_platform_fallback_failure() {
+            let error = resolve_sync_transport_data_dir(None, None, || {
+                Err("app data directory unavailable".to_string())
+            })
+            .expect_err("missing app-private root must fail closed");
+
+            assert_eq!(error, "app data directory unavailable");
         }
 
         #[test]
@@ -15312,6 +15347,19 @@ mod desktop {
                     attempted_transports: vec![TCP_TRANSPORT_ID.to_string()],
                 }
             );
+
+            let iroh_only_hints = vec![format!(
+                "{IROH_ENDPOINT_SCHEME}iroh_peer?device_id=dev_peer&v=1&addr=127.0.0.1%3A47620"
+            )];
+            let error = select_sync_transport(
+                Some(TCP_TRANSPORT_ID),
+                None,
+                &iroh_only_hints,
+                &request.peer_device_id,
+                true,
+            )
+            .expect_err("explicit TCP must reject an Iroh-only peer");
+            assert!(error.contains("does not have a TuneForge TCP endpoint hint"));
         }
 
         #[test]

--- a/apps/desktop/src-tauri/tauri.ios.conf.json
+++ b/apps/desktop/src-tauri/tauri.ios.conf.json
@@ -7,6 +7,7 @@
     "resources": [],
     "iOS": {
       "frameworks": ["SystemConfiguration"],
+      "infoPlist": "Info.ios.plist",
       "minimumSystemVersion": "14.0"
     }
   }

--- a/apps/desktop/src/App.mobile.test.tsx
+++ b/apps/desktop/src/App.mobile.test.tsx
@@ -1,6 +1,6 @@
 import { act, fireEvent, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { LyricsResponse } from "./lib/api";
 import { markPlaybackStarting } from "./lib/playbackDiagnostics";
 import { updateBrowserWakeLockStatus } from "./lib/powerInhibition";
@@ -9,14 +9,22 @@ import {
   markAudioReady,
   mockCreateStems,
   mockGetChords,
+  mockGetProject,
   mockGetLyrics,
+  mockInvoke,
+  mockListArtifacts,
   mockGetMobileCapabilities,
+  mockStartSyncListener,
   resetAppTestHarness,
   renderApp,
   setProjectAnalysis,
   setProjectChords,
   setProjectLyrics,
 } from "./test/appTestHarness";
+
+const originalUserAgent = navigator.userAgent;
+const originalPlatform = navigator.platform;
+const originalMaxTouchPoints = navigator.maxTouchPoints;
 
 function enableAndroidRuntime() {
   mockGetMobileCapabilities.mockResolvedValue({
@@ -29,6 +37,38 @@ function enableAndroidRuntime() {
     whisperAvailable: false,
     stemSeparationAvailable: false,
     generationTestingAvailable: true,
+    maxRecommendedModel: null,
+    cpuFallbackAllowed: false,
+  });
+}
+
+function setIOSUserAgent() {
+  Object.defineProperty(window.navigator, "userAgent", {
+    configurable: true,
+    value: "Mozilla/5.0 (iPhone; CPU iPhone OS 26_5 like Mac OS X)",
+  });
+}
+
+function setIPadDesktopUserAgent() {
+  Object.defineProperties(window.navigator, {
+    userAgent: { configurable: true, value: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)" },
+    platform: { configurable: true, value: "MacIntel" },
+    maxTouchPoints: { configurable: true, value: 5 },
+  });
+}
+
+function enableIOSRuntime() {
+  setIOSUserAgent();
+  mockGetMobileCapabilities.mockResolvedValue({
+    platform: "ios",
+    mediaBackend: "cpal_coreaudio",
+    isEmulator: true,
+    gpuBackend: null,
+    analysisAvailable: false,
+    basicChordsAvailable: false,
+    whisperAvailable: false,
+    stemSeparationAvailable: false,
+    generationTestingAvailable: false,
     maxRecommendedModel: null,
     cpuFallbackAllowed: false,
   });
@@ -107,6 +147,104 @@ function setTempoAnalysis(tempoBpm = 120) {
 
 describe("Desktop app mobile capability gates", () => {
   beforeEach(resetAppTestHarness);
+  afterEach(() => {
+    Object.defineProperties(window.navigator, {
+      userAgent: { configurable: true, value: originalUserAgent },
+      platform: { configurable: true, value: originalPlatform },
+      maxTouchPoints: { configurable: true, value: originalMaxTouchPoints },
+    });
+  });
+
+  it("keeps the iOS library sync-directed", async () => {
+    enableIOSRuntime();
+    renderApp(["/"]);
+
+    expect(await screen.findByRole("heading", { name: "Practice Projects" })).toBeInTheDocument();
+    await waitFor(() =>
+      expect(screen.queryByRole("button", { name: "Import Track(s)" })).not.toBeInTheDocument(),
+    );
+    expect(screen.queryByRole("link", { name: "Open Demo Song project" })).not.toBeInTheDocument();
+    expect(screen.queryByText("Show file details")).not.toBeInTheDocument();
+  });
+
+  it.each(["pending", "failed"])("keeps the iOS library closed when capabilities are %s", async (state) => {
+    setIOSUserAgent();
+    if (state === "pending") mockGetMobileCapabilities.mockReturnValue(new Promise(() => {}));
+    else mockGetMobileCapabilities.mockRejectedValue(new Error("capabilities unavailable"));
+    renderApp(["/"]);
+
+    expect(await screen.findByRole("heading", { name: "Practice Projects" })).toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: "Open Demo Song project" })).not.toBeInTheDocument();
+    expect(screen.queryByText("Show file details")).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Import Track(s)" })).not.toBeInTheDocument();
+  });
+
+  it("gates iOS project routes before the full project model mounts", async () => {
+    enableIOSRuntime();
+    renderApp(["/projects/proj_123"]);
+
+    expect(await screen.findByRole("heading", { name: "Project playback unavailable" })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Back to Library" })).toBeInTheDocument();
+    expect(screen.queryByRole("heading", { name: "Processing" })).not.toBeInTheDocument();
+    expect(mockGetProject).not.toHaveBeenCalled();
+    expect(mockListArtifacts).not.toHaveBeenCalled();
+    expect(mockInvoke).not.toHaveBeenCalledWith("audio_prepare_session", expect.anything());
+  });
+
+  it("fails a project route closed when runtime capabilities fail", async () => {
+    setIPadDesktopUserAgent();
+    mockGetMobileCapabilities.mockRejectedValue(new Error("capabilities unavailable"));
+    renderApp(["/projects/proj_123"]);
+
+    expect(await screen.findByRole("alert")).toHaveTextContent("Could not verify project support");
+    expect(screen.getByRole("button", { name: "Retry" })).toBeInTheDocument();
+    expect(mockGetProject).not.toHaveBeenCalled();
+    expect(mockListArtifacts).not.toHaveBeenCalled();
+    expect(mockInvoke).not.toHaveBeenCalledWith("audio_prepare_session", expect.anything());
+  });
+
+  it("keeps an iOS project route closed while runtime capabilities are pending", () => {
+    setIOSUserAgent();
+    mockGetMobileCapabilities.mockReturnValue(new Promise(() => {}));
+    renderApp(["/projects/proj_123"]);
+
+    expect(screen.getByRole("status")).toHaveTextContent("Loading project runtime");
+    expect(mockGetProject).not.toHaveBeenCalled();
+    expect(mockListArtifacts).not.toHaveBeenCalled();
+    expect(mockInvoke).not.toHaveBeenCalledWith("audio_prepare_session", expect.anything());
+  });
+
+  it("shows only manual sync controls in iOS Activity", async () => {
+    enableIOSRuntime();
+    renderApp(["/activity"]);
+
+    expect(await screen.findByRole("heading", { name: "Sync" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Answer Offer" })).toBeInTheDocument();
+    expect(screen.queryByRole("tab", { name: "Jobs" })).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Create Pairing Offer" })).toBeDisabled();
+    expect(screen.queryByRole("heading", { name: "Nearby Devices" })).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Copy Evidence" })).toBeDisabled();
+    expect(screen.queryByRole("button", { name: "Export Evidence" })).not.toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Local Readiness" })).toBeInTheDocument();
+  });
+
+  it("keeps iOS pairing available when the listener cannot start", async () => {
+    const user = userEvent.setup();
+    enableIOSRuntime();
+    mockStartSyncListener.mockRejectedValueOnce(new Error("raw native listener detail"));
+    renderApp(["/activity"]);
+
+    const startListener = await screen.findByRole("button", { name: "Start Listener" });
+    await user.click(startListener);
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      "Sync listener could not start. Pairing with a listening peer and Sync Now remain available.",
+    );
+    expect(startListener).toBeEnabled();
+    expect(screen.getByLabelText("Peer pairing code")).toBeEnabled();
+    expect(screen.getByRole("button", { name: "Answer Offer" })).toBeInTheDocument();
+    expect(screen.queryByText("raw native listener detail")).not.toBeInTheDocument();
+  });
 
   it("disables generation actions when mobile acceleration is unavailable", async () => {
     mockGetMobileCapabilities.mockResolvedValue({

--- a/apps/desktop/src/features/activity/ActivitySyncPanel.tsx
+++ b/apps/desktop/src/features/activity/ActivitySyncPanel.tsx
@@ -2251,6 +2251,7 @@ export function ActivitySyncPanel() {
   }, [pairingInputValue]);
 	  const qrScanSupported = mobileCapabilitiesQuery.data?.platform === "android";
 	  const isAndroidRuntime = mobileCapabilitiesQuery.data?.platform === "android";
+    const isIOSRuntime = mobileCapabilitiesQuery.data?.platform === "ios";
     const pairingPrerequisitesUnavailable = identityQuery.isError || peersQuery.isError;
 
   const refreshSyncQueries = useCallback(async () => {
@@ -2797,6 +2798,11 @@ export function ActivitySyncPanel() {
   }
 
   const listenerMutationPending = startListenerMutation.isPending || stopListenerMutation.isPending;
+  const listenerMutationErrorMessage = startListenerMutation.isError
+    ? "Sync listener could not start. Pairing with a listening peer and Sync Now remain available."
+    : stopListenerMutation.isError
+      ? "Sync listener could not stop. Try again."
+      : null;
   const pairingPayloadPending = answerPairingOfferMutation.isPending || trustPeerMutation.isPending;
   const pairingInputInvalid = Boolean(pairingInputValue && decodedPairingInput.error);
   const trustedPeers = peersQuery.data ?? [];
@@ -2854,7 +2860,7 @@ export function ActivitySyncPanel() {
       <div className="panel-heading activity-sync-panel__heading">
         <div>
           <h2 id="activity-sync-heading">Sync</h2>
-          <p className="subpanel__copy">Native LAN transport lab for trusted desktop peers.</p>
+          <p className="subpanel__copy">Native LAN sync for trusted desktop peers.</p>
         </div>
         <button
           className="button button--ghost button--small"
@@ -2865,6 +2871,12 @@ export function ActivitySyncPanel() {
           {listenerMutationPending ? "Updating..." : listenerActive ? "Stop Listener" : "Start Listener"}
         </button>
       </div>
+
+      {listenerMutationErrorMessage ? (
+        <p className="activity-sync-alert activity-sync-alert--error" role="alert">
+          {listenerMutationErrorMessage}
+        </p>
+      ) : null}
 
       <div className="activity-sync-grid">
         <section className="activity-sync-section" aria-labelledby="activity-sync-listener-heading">
@@ -2897,14 +2909,16 @@ export function ActivitySyncPanel() {
               >
                 Copy Evidence
               </button>
-              <button
-                className="button button--ghost button--small"
-                disabled={!visibleSyncResult || evidenceActionPending !== null}
-                onClick={handleExportSyncEvidence}
-                type="button"
-              >
-                {evidenceActionPending === "export" ? "Exporting…" : "Export Evidence"}
-              </button>
+              {!isIOSRuntime ? (
+                  <button
+                    className="button button--ghost button--small"
+                    disabled={!visibleSyncResult || evidenceActionPending !== null}
+                    onClick={handleExportSyncEvidence}
+                    type="button"
+                  >
+                    {evidenceActionPending === "export" ? "Exporting…" : "Export Evidence"}
+                  </button>
+              ) : null}
             </div>
           </div>
           <dl className="activity-sync-facts">
@@ -2976,11 +2990,6 @@ export function ActivitySyncPanel() {
               {retryableInterruptionText(retryableInterruption)}
             </p>
           ) : null}
-          {startListenerMutation.isError || stopListenerMutation.isError ? (
-            <p className="activity-sync-alert activity-sync-alert--error" role="alert">
-              Could not update the sync listener.
-            </p>
-          ) : null}
           {lastSyncMessage ? (
             <p className="activity-sync-alert" role="status">
               {lastSyncMessage}
@@ -3039,7 +3048,7 @@ export function ActivitySyncPanel() {
                     value={pairingOutput.code}
                   />
                 </label>
-                <div
+                {!isIOSRuntime ? <div
                   aria-label={
                     pairingOutput.kind === "response"
                       ? "Pairing response QR code"
@@ -3056,7 +3065,7 @@ export function ActivitySyncPanel() {
                     size={288}
                     value={pairingOutput.code}
                   />
-                </div>
+                </div> : null}
               </div>
               <button
                 className="button button--ghost button--small"
@@ -3268,7 +3277,7 @@ export function ActivitySyncPanel() {
         ))}
       </section>
 
-      <section className="activity-sync-section activity-sync-section--nearby" aria-labelledby="activity-sync-nearby-heading">
+      {!isIOSRuntime ? <section className="activity-sync-section activity-sync-section--nearby" aria-labelledby="activity-sync-nearby-heading">
         <div className="activity-sync-section__header">
           <h3 id="activity-sync-nearby-heading">Nearby Devices</h3>
           <span className="metric-label">{nearbyPeers.length} nearby</span>
@@ -3352,7 +3361,7 @@ export function ActivitySyncPanel() {
             })}
           </ul>
         ) : null}
-      </section>
+      </section> : null}
 
       <section className="activity-sync-section activity-sync-section--peers" aria-labelledby="activity-sync-peers-heading">
         <div className="activity-sync-section__header">

--- a/apps/desktop/src/features/activity/ActivityView.tsx
+++ b/apps/desktop/src/features/activity/ActivityView.tsx
@@ -1,5 +1,5 @@
 import { useDeferredValue, useEffect, useMemo, useRef, useState } from "react";
-import { useInfiniteQuery, useMutation, useQueries, useQueryClient } from "@tanstack/react-query";
+import { useInfiniteQuery, useMutation, useQueries, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Activity, Layers, Mic, RefreshCw } from "lucide-react";
 import { Link } from "react-router-dom";
 import { confirm } from "@tauri-apps/plugin-dialog";
@@ -384,7 +384,7 @@ function JobRow({
 }
 
 export function ActivityView() {
-  const [activeTab, setActiveTab] = useState<ActivityTab>("jobs");
+  const [selectedTab, setActiveTab] = useState<ActivityTab>("jobs");
   const [searchDraft, setSearchDraft] = useState("");
   const [bulkJobResult, setBulkJobResult] = useState<{
     action: BulkJobAction;
@@ -397,6 +397,15 @@ export function ActivityView() {
   const { defaultDurableAudioFormat, defaultStemModel } = usePreferences();
   const { beatBackendForAction } = useBeatBackendActionSelection();
   const { chordBackendForAction } = useChordBackendActionSelection();
+  const mobileCapabilitiesQuery = useQuery({
+    queryKey: ["runtime", "mobile-capabilities"],
+    queryFn: () => api.getMobileCapabilities(),
+  });
+  const isIOSHost = /\b(iPhone|iPad|iPod)\b/i.test(navigator.userAgent)
+    || (navigator.platform === "MacIntel" && navigator.maxTouchPoints > 1);
+  const isIOSRuntime = mobileCapabilitiesQuery.data?.platform === "ios";
+  const activeTab = isIOSRuntime ? "sync" : selectedTab;
+  const jobsEnabled = (!isIOSHost || mobileCapabilitiesQuery.isSuccess) && !isIOSRuntime;
   const activeJobsQueryKey = useMemo(
     () => [...ACTIVE_JOBS_QUERY_KEY, deferredSearch] as const,
     [deferredSearch],
@@ -406,6 +415,7 @@ export function ActivityView() {
     [deferredSearch],
   );
   const activeJobsQuery = useInfiniteQuery({
+    enabled: jobsEnabled,
     queryKey: activeJobsQueryKey,
     initialPageParam: 0,
     queryFn: async ({ pageParam }) => {
@@ -432,6 +442,7 @@ export function ActivityView() {
     isSuccess: isActiveJobsSuccess,
   } = activeJobsQuery;
   const terminalJobsQuery = useInfiniteQuery({
+    enabled: jobsEnabled,
     queryKey: terminalJobsQueryKey,
     initialPageParam: 0,
     queryFn: async ({ pageParam }) => {
@@ -624,18 +635,32 @@ export function ActivityView() {
     bulkJobsMutation.mutate({ ...action, durableFormat });
   }
 
+  if (isIOSHost && mobileCapabilitiesQuery.isPending) {
+    return <div className="panel" role="status">Loading Activity...</div>;
+  }
+  if (isIOSHost && mobileCapabilitiesQuery.isError) {
+    return (
+      <div className="panel panel--error" role="alert">
+        Could not verify Activity support.
+        <button onClick={() => void mobileCapabilitiesQuery.refetch()} type="button">Retry</button>
+      </div>
+    );
+  }
+
   return (
     <section className="screen activity-screen">
       <div className="screen__header">
         <div className="screen__title-block">
           <p className="eyebrow">Activity</p>
           <h1>Activity</h1>
-          <p className="screen__subtitle">Review local processing and sync lab activity.</p>
+          <p className="screen__subtitle">
+            {isIOSRuntime ? "Pair with a trusted desktop and sync projects." : "Review local processing and sync lab activity."}
+          </p>
         </div>
       </div>
 
       <div className="project-workspace-tabs" role="tablist" aria-label="Activity">
-        {ACTIVITY_TABS.map((tab) => (
+        {ACTIVITY_TABS.filter((tab) => !isIOSRuntime || tab.id === "sync").map((tab) => (
           <button
             aria-controls={`activity-${tab.id}-panel`}
             aria-selected={activeTab === tab.id}

--- a/apps/desktop/src/features/projects/LibraryView.tsx
+++ b/apps/desktop/src/features/projects/LibraryView.tsx
@@ -1,5 +1,5 @@
-import { startTransition, useDeferredValue, useState } from "react";
-import { useInfiniteQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { startTransition, useDeferredValue, useState, type PropsWithChildren } from "react";
+import { useInfiniteQuery, useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { open } from "@tauri-apps/plugin-dialog";
 import { Music2, Upload } from "lucide-react";
 import { Link, useNavigate } from "react-router-dom";
@@ -46,7 +46,26 @@ function formatUpdatedAt(value: string | null) {
   };
 }
 
-function ProjectCard({ project }: { project: ProjectSchema }) {
+function ProjectSummaryLink({
+  children,
+  isIOSRuntime,
+  project,
+}: PropsWithChildren<{ isIOSRuntime: boolean; project: ProjectSchema }>) {
+  if (isIOSRuntime) {
+    return <div className="project-card__link">{children}</div>;
+  }
+  return (
+    <Link
+      aria-label={`Open ${project.display_name} project`}
+      className="project-card__link"
+      to={`/projects/${project.id}`}
+    >
+      {children}
+    </Link>
+  );
+}
+
+function ProjectCard({ project, isIOSRuntime }: { project: ProjectSchema; isIOSRuntime: boolean }) {
   const { informationDensity } = usePreferences();
   const updatedAt = formatUpdatedAt(project.updated_at);
   const fileType = project.source_path.split(".").pop()?.toUpperCase() ?? "Audio";
@@ -55,11 +74,7 @@ function ProjectCard({ project }: { project: ProjectSchema }) {
 
   return (
     <article className="project-card project-library-row">
-      <Link
-        aria-label={`Open ${project.display_name} project`}
-        className="project-card__link"
-        to={`/projects/${project.id}`}
-      >
+      <ProjectSummaryLink isIOSRuntime={isIOSRuntime} project={project}>
         <span className="project-library-row__icon" aria-hidden="true">
           <Music2 />
         </span>
@@ -109,21 +124,23 @@ function ProjectCard({ project }: { project: ProjectSchema }) {
           ) : null}
         </div>
 
-      </Link>
+      </ProjectSummaryLink>
 
-      <details className="card-details">
-        <summary>Show file details</summary>
-        <dl className="details-grid details-grid--single-column">
-          <div>
-            <dt>Original Source</dt>
-            <dd className="path">{project.source_path}</dd>
-          </div>
-          <div>
-            <dt>Imported Audio</dt>
-            <dd className="path">{project.imported_path}</dd>
-          </div>
-        </dl>
-      </details>
+      {!isIOSRuntime ? (
+        <details className="card-details">
+          <summary>Show file details</summary>
+          <dl className="details-grid details-grid--single-column">
+            <div>
+              <dt>Original Source</dt>
+              <dd className="path">{project.source_path}</dd>
+            </div>
+            <div>
+              <dt>Imported Audio</dt>
+              <dd className="path">{project.imported_path}</dd>
+            </div>
+          </dl>
+        </details>
+      ) : null}
     </article>
   );
 }
@@ -285,6 +302,13 @@ export function LibraryView() {
   const [importPendingPhase, setImportPendingPhase] = useState<ImportPendingPhase | null>(null);
   const deferredSearch = useDeferredValue(searchDraft.trim());
   const showSubtitle = informationDensity !== "minimal";
+  const mobileCapabilitiesQuery = useQuery({
+    queryKey: ["runtime", "mobile-capabilities"],
+    queryFn: () => api.getMobileCapabilities(),
+  });
+  const isIOSHost = /\b(iPhone|iPad|iPod)\b/i.test(navigator.userAgent)
+    || (navigator.platform === "MacIntel" && navigator.maxTouchPoints > 1);
+  const isIOSRuntime = mobileCapabilitiesQuery.data?.platform === "ios";
 
   const projectsQuery = useInfiniteQuery({
     queryKey: ["projects", deferredSearch],
@@ -308,6 +332,7 @@ export function LibraryView() {
     isFetchingNextPage,
     isLoading: isProjectsLoading,
     isRefetchError,
+    refetch: refetchProjects,
   } = projectsQuery;
 
   const importMutation = useMutation({
@@ -459,11 +484,13 @@ export function LibraryView() {
           <h1>Practice Projects</h1>
           {showSubtitle ? (
             <p className="screen__subtitle">
-              Keep songs, saved mixes, and stem-ready practice sessions close to playback.
+              {isIOSRuntime
+                ? "Browse projects synced from a trusted desktop."
+                : "Keep songs, saved mixes, and stem-ready practice sessions close to playback."}
             </p>
           ) : null}
         </div>
-        <div className="screen__title-block">
+        {(!isIOSHost || mobileCapabilitiesQuery.isSuccess) && !isIOSRuntime ? <div className="screen__title-block">
           <button
             className="button button--primary"
             onClick={() => importMutation.mutate()}
@@ -477,7 +504,7 @@ export function LibraryView() {
               {pendingImportCopy.guidance}
             </p>
           ) : null}
-        </div>
+        </div> : null}
       </div>
 
       {importNotice ? (
@@ -547,7 +574,8 @@ export function LibraryView() {
       ) : null}
       {showInitialError ? (
         <div className="panel panel--error" role="alert">
-          Could not load projects.
+          Could not load projects.{" "}
+          <button onClick={() => void refetchProjects()} type="button">Retry</button>
         </div>
       ) : null}
       {showRefetchError ? (
@@ -565,7 +593,9 @@ export function LibraryView() {
               <span>Updated</span>
               <span>Format / Duration</span>
             </div>
-            {projects.map((project) => <ProjectCard key={project.id} project={project} />)}
+            {projects.map((project) => (
+              <ProjectCard isIOSRuntime={isIOSHost || isIOSRuntime} key={project.id} project={project} />
+            ))}
           </>
         ) : showEmptyState ? (
           <div className="panel panel--empty">
@@ -573,7 +603,9 @@ export function LibraryView() {
             <p>
               {deferredSearch
                 ? "Try a different name or clear the search."
-                : "Import audio or video to create a local project. Processing stays on this device, and Activity shows queue progress."}
+                : isIOSRuntime
+                  ? "Pair with TuneForge on your desktop, then use Activity to sync projects here."
+                  : "Import audio or video to create a local project. Processing stays on this device, and Activity shows queue progress."}
             </p>
           </div>
         ) : null}

--- a/apps/desktop/src/features/projects/ProjectView.tsx
+++ b/apps/desktop/src/features/projects/ProjectView.tsx
@@ -1,10 +1,46 @@
 import { useEffect } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { Link } from "react-router-dom";
+import { api } from "../../lib/api";
 import { ProjectShell } from "./components/ProjectShell";
 import { ProjectViewModelProvider } from "./components/ProjectViewModelContext";
 import { useProjectViewModel } from "./hooks/useProjectViewModel";
 import { useMetronome } from "../tools/metronome-context";
 
 export function ProjectView() {
+  const mobileCapabilitiesQuery = useQuery({
+    queryKey: ["runtime", "mobile-capabilities"],
+    queryFn: () => api.getMobileCapabilities(),
+  });
+  const isIOSHost = /\b(iPhone|iPad|iPod)\b/i.test(navigator.userAgent)
+    || (navigator.platform === "MacIntel" && navigator.maxTouchPoints > 1);
+
+  if (isIOSHost && mobileCapabilitiesQuery.isPending) {
+    return <div className="panel" role="status">Loading project runtime...</div>;
+  }
+  if (isIOSHost && mobileCapabilitiesQuery.isError) {
+    return (
+      <div className="panel panel--error" role="alert">
+        Could not verify project support.
+        <button className="button button--ghost" onClick={() => void mobileCapabilitiesQuery.refetch()} type="button">
+          Retry
+        </button>
+      </div>
+    );
+  }
+  if (mobileCapabilitiesQuery.data?.platform === "ios") {
+    return (
+      <div className="panel">
+        <h1>Project playback unavailable</h1>
+        <p>Browse synced project and artifact details from Library.</p>
+        <Link className="button button--ghost" to="/">Back to Library</Link>
+      </div>
+    );
+  }
+  return <FullProjectView />;
+}
+
+function FullProjectView() {
   const model = useProjectViewModel();
   const { followPlayback, seedBpm } = useMetronome();
   const tempoBpm = model.analysisQuery.data?.tempo_bpm;

--- a/docs/MOBILE.md
+++ b/docs/MOBILE.md
@@ -156,12 +156,23 @@ transfer, recovery, or conflict states rather than where the data originated.
 | Sync revisions | `entity_revisions` with revision identity, entity type, source artifact, content hash, state, author device, payload, metadata, and timestamps. | Reconcile by identity and content hash. Apply tombstones before accepting older revisions. | Healthy accepted revisions have no badge. `Missing` if referenced payload is absent. `Unreadable` if hash or schema validation fails. Conflicts use sync conflict state. |
 | Tombstones | `delete_tombstones` for deleted projects, artifacts, and entity revisions, with author, target, group/project context, and prior metadata. | Persist delete markers and suppress resurrected records from offline peers. | Deleted records stay deleted or hidden, not `Missing`. Invalid tombstones are `Unreadable`; accepted tombstones have no status badge. |
 
-## iOS Simulator Foundation
+## iOS Simulator
 
-The iOS target currently provides a simulator-only runtime foundation. It bundles the normal React
-frontend, reports iOS capabilities through Tauri IPC, and fails closed when the embedded API is not
-available. It never falls back to the desktop HTTP backend at `127.0.0.1:8765`. Project persistence,
-LAN sync, and playback are not available in this foundation.
+The iOS target currently provides a simulator-only runtime. It bundles the normal React frontend,
+reports iOS capabilities through Tauri IPC, and fails closed when the embedded API is not available.
+It never falls back to the desktop HTTP backend at `127.0.0.1:8765`.
+
+iOS stores synced projects and their artifacts in its Tauri app-private data directory. Activity
+supports manual pairing and TCP sync with a trusted desktop peer; it does not start Iroh or nearby
+device discovery. Library shows synced project metadata. Import, processing, rich project readers,
+playback, evidence export, and QR pairing remain unavailable. Local-network permission copy comes
+from the source `Info.ios.plist`; no Bonjour or
+multicast entitlement is required for manual TCP endpoints.
+
+For same-Mac simulator validation, start only the desktop listener, pair the simulator, then initiate
+Sync Now from iOS. The simulator shares the host network, so simultaneous desktop and simulator
+listeners need separate ports. Physical devices use separate network stacks, and Sync Now keeps its
+normal bidirectional semantics.
 
 The debug startup smoke verifies an in-memory SQLite query, synthetic WAV decode, Signalsmith
 construction and processing, and CPAL/CoreAudio output initialization. The app uses the isolated


### PR DESCRIPTION
## Summary

- Enable manual desktop pairing and TCP project sync on iOS through the existing shared mobile persistence and transport implementation. Keep Library cards limited to project metadata.
- Preserve app-private artifact registration, canonical confinement, transactional staging, size checks, and SHA-256 validation. Repair registered paths transactionally when iOS relocates an app container, validating confinement before reading files.
- Layer 3 of #531, based on #533; native playback remains layer 4. Refs #531.

## Changes

- Add minimal iOS module wiring; keep Android import/conversion Android-only. Disable iOS Iroh and UDP discovery; retain existing bidirectional transfer semantics and manual pairing controls.
- Ignore desktop storage overrides on iOS, add Local Network purpose text, and block unsupported project routes and controls. No HTTP/OpenAPI, schema, or sync-wire changes.
- Fail closed on corrupt or unverified relocated artifacts, preserving existing records and files. Update mobile documentation and Unreleased changelog.

## Testing

- Final frontend: 49 files / 906 tests passed; desktop lint and typecheck passed. Commands used pinned pnpm 11.22.0 and fresh data/transport roots:
  ```sh
  TUNEFORGE_DATA_DIR="$(mktemp -d)" TUNEFORGE_SYNC_TRANSPORT_DATA_DIR="$(mktemp -d)" npm exec --yes --package=pnpm@11.22.0 -- pnpm --filter @tuneforge/desktop test -- --run src/App.mobile.test.tsx
  npm exec --yes --package=pnpm@11.22.0 -- pnpm --filter @tuneforge/desktop lint
  npm exec --yes --package=pnpm@11.22.0 -- pnpm --filter @tuneforge/desktop typecheck
  ```
  The forwarded test arguments ran the complete desktop suite. Full workspace `pnpm lint`, `pnpm typecheck`, and `pnpm test` passed before the final narrow relocation/UI fixes; affected lanes were rerun afterward.
- Final shared Rust: 99 tests passed, including 4 container-relocation regressions covering rollback and symlink confinement. Matching stable Rust tools were selected:
  ```sh
  stable_cargo="$(rustup which cargo --toolchain stable)"
  stable_rustc="$(rustup which rustc --toolchain stable)"
  stable_rustdoc="$(rustup which rustdoc --toolchain stable)"
  RUSTC="$stable_rustc" RUSTDOC="$stable_rustdoc" "$stable_cargo" test --manifest-path apps/desktop/src-tauri/Cargo.toml mobile_backend:: -- --nocapture
  cargo fmt --manifest-path apps/desktop/src-tauri/Cargo.toml --all -- --check
  git diff --check
  ```
- Android arm64 compilation passed with the audited FFmpeg runtime; documented iOS debug build passed:
  ```sh
  ANDROID_NDK_HOME="${ANDROID_NDK_HOME:?}" TUNEFORGE_ANDROID_FFMPEG_ROOT="$PWD/packaging/ffmpeg/generated/android-arm64-v8a" bash scripts/android-arm64-env.sh cargo check --manifest-path apps/desktop/src-tauri/Cargo.toml --target aarch64-linux-android
  npm exec --yes --package=pnpm@11.22.0 -- pnpm --filter @tuneforge/desktop ios:build:debug
  ```
  iOS used a per-command `DEVELOPER_DIR` pointing to Xcode, preserving global configuration.
- Live isolated desktop-to-simulator TCP sync transferred all 4 synthetic artifacts (7,056,312 bytes). Source, drums, vocals, and practice mix matched registered sizes and SHA-256 hashes. Identity, trust, metadata, private paths, and files survived in-place app update and a separate plain restart. Final simulator Library visual QA passed.
- Existing deterministic shared tests cover cancellation/interruption and rollback; live evidence covers healthy transfer and persistence. Unavailable command wiring was source/compile checked, not exercised through iOS IPC. Physical-device permissions, playback, and distribution remain unverified and excluded.

## Review size

| Category | Added | Deleted |
| --- | ---: | ---: |
| Production (14 files) | 483 | 147 |
| Tests | 437 | 1 |
| Docs | 19 | 6 |

Layer 3: 1,093 handwritten changed lines; no generated or lockfile churn. Aggregate stack: 29 production files, 2,208 handwritten changed lines, plus 1 generated lockfile line; within approved limits.
