### PR TITLE
feat: Add native iOS playback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ download, installation, verification, signature, and publication instructions.
 
 - Added simulator-only iOS project persistence and manual TCP sync with trusted desktop peers,
   including synced project metadata in Library.
+- Added simulator-only iOS playback for synced registered WAV sources, practice mixes, and stems,
+  with native play, pause, stop, seek, loop, mute, and solo controls at 1.0x speed.
 - Added owned, offline LGPL FFmpeg conversion for macOS arm64 and Android arm64, API 26+, with
   durable WAV, FLAC, MP3, and M4A import, preview, retune, transpose, and Android export support.
 

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -174,19 +174,19 @@ This file is the source of truth for dependency and model-weight distribution po
 
 - **License:** Apache-2.0 / MIT (dual)
 - **Source:** <https://github.com/RustAudio/cpal>
-- **Notes:** Used by the desktop shell for local microphone device enumeration and tuner input capture, and by macOS, Linux, and Android project playback. Android playback uses CPAL's AAudio backend and requires API 26 or newer. The iOS simulator foundation initializes CPAL's CoreAudio output backend during its debug startup smoke; product playback remains unavailable there.
+- **Notes:** Used by the desktop shell for local microphone device enumeration and tuner input capture, and by macOS, Linux, Android, and iOS simulator project playback. Android playback uses CPAL's AAudio backend and requires API 26 or newer. iOS simulator playback uses CPAL's CoreAudio output backend.
 
 ### signalsmith-stretch
 
 - **License:** MIT
 - **Source:** <https://github.com/colinmarc/signalsmith-stretch-rs>
-- **Notes:** Used by the native macOS, Linux, and Android playback engine for tempo changes with pitch preservation. The iOS simulator foundation constructs and processes a synthetic buffer during its debug startup smoke. Its resolved Rust transitive stack is permissively licensed.
+- **Notes:** Used by the shared native macOS, Linux, Android, and iOS simulator playback engine. iOS playback is limited to 1.0x speed. Its resolved Rust transitive stack is permissively licensed.
 
 ### Symphonia
 
 - **License:** MPL-2.0
 - **Source:** <https://github.com/pdeljanov/Symphonia>
-- **Notes:** Used by the native macOS, Linux, and Android playback engine and by Android durable-artifact validation. The iOS simulator foundation decodes a generated WAV during its debug startup smoke. FFmpeg conversion remains separate from realtime playback and is not included on iOS.
+- **Notes:** Used by the native macOS, Linux, and Android playback engine and by Android durable-artifact validation. The iOS simulator startup smoke decodes a generated WAV, while product playback uses the strict WAV decoder without a Symphonia fallback. FFmpeg conversion remains separate from realtime playback and is not included on iOS.
 
 ### ndk-context
 
@@ -198,7 +198,7 @@ This file is the source of truth for dependency and model-weight distribution po
 
 - **License:** MIT for rusqlite; SQLite is public domain
 - **Source:** <https://github.com/rusqlite/rusqlite> and <https://sqlite.org/>
-- **Notes:** Used by the embedded Android backend. The iOS simulator foundation exercises an in-memory database during debug startup; durable iOS persistence is not yet available. Desktop persistence remains in the Python backend.
+- **Notes:** Used by the embedded Android and iOS simulator backends for durable app-private persistence. The iOS simulator startup smoke also exercises an in-memory database. Desktop persistence remains in the Python backend.
 
 ### rustls
 

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -4075,6 +4075,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6948501a91121d6399b79abaa33a8aa4ea7857fe019f341b8c23ad6e81b79b08"
 dependencies = [
  "bitflags 2.13.1",
+ "block2",
  "libc",
  "objc2",
  "objc2-core-audio",
@@ -4090,7 +4091,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13a380031deed8e99db00065c45937da434ca987c034e13b87e4441f9e4090be"
 dependencies = [
  "bitflags 2.13.1",
+ "block2",
  "objc2",
+ "objc2-audio-toolbox",
+ "objc2-core-audio-types",
  "objc2-foundation",
 ]
 
@@ -7131,7 +7135,9 @@ dependencies = [
  "ndk-context",
  "ndk-sys",
  "objc2",
+ "objc2-avf-audio",
  "objc2-foundation",
+ "objc2-ui-kit",
  "rand",
  "rusqlite",
  "rustls",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -45,6 +45,9 @@ symphonia = { version = "0.6.1", default-features = false, features = ["all"] }
 rusqlite = { version = "0.40.2", features = ["bundled"] }
 
 [target.'cfg(target_os = "ios")'.dependencies]
+objc2 = "0.6.4"
+objc2-avf-audio = { version = "0.3.2", features = ["AVAudioSession", "AVAudioSessionTypes"] }
+objc2-ui-kit = { version = "0.3.2", features = ["UIApplication"] }
 rustls = { version = "0.23.43", default-features = false, features = ["ring", "std"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]

--- a/apps/desktop/src-tauri/src/ios_dependency_smoke.rs
+++ b/apps/desktop/src-tauri/src/ios_dependency_smoke.rs
@@ -68,6 +68,7 @@ fn smoke_signalsmith() {
 }
 
 fn smoke_output() -> Result<(), String> {
+    let _audio_session = crate::native_audio::ios_session::PlaybackAudioSession::activate()?;
     let host = cpal::default_host();
     let device = host
         .default_output_device()

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -678,7 +678,7 @@ pub fn run() {
         .expect("error while building tuneforge");
 
     app.run(|app_handle, event| {
-        #[cfg(target_os = "android")]
+        #[cfg(any(target_os = "android", target_os = "ios"))]
         if matches!(
             event,
             tauri::RunEvent::WindowEvent {
@@ -687,7 +687,10 @@ pub fn run() {
             }
         ) {
             let native_audio = app_handle.state::<native_audio::NativeAudioState>();
+            #[cfg(target_os = "android")]
             native_audio::stop_input_for_lifecycle(app_handle, native_audio.inner());
+            #[cfg(target_os = "ios")]
+            native_audio::pause_output_for_lifecycle(app_handle, native_audio.inner());
         }
         if let tauri::RunEvent::Exit = event {
             let mobile_media =

--- a/apps/desktop/src-tauri/src/native_audio/ios_session.rs
+++ b/apps/desktop/src-tauri/src/native_audio/ios_session.rs
@@ -1,0 +1,56 @@
+use objc2::MainThreadMarker;
+use objc2_avf_audio::{
+    AVAudioSession, AVAudioSessionCategoryOptions, AVAudioSessionCategoryPlayback,
+    AVAudioSessionModeDefault,
+};
+use objc2_ui_kit::{UIApplication, UIApplicationState};
+use std::sync::mpsc;
+use tauri::AppHandle;
+
+pub(super) async fn application_is_active(app: &AppHandle) -> Result<bool, String> {
+    let (sender, receiver) = mpsc::channel();
+    app.run_on_main_thread(move || {
+        let active = MainThreadMarker::new()
+            .map(|marker| {
+                UIApplication::sharedApplication(marker).applicationState()
+                    == UIApplicationState::Active
+            })
+            .unwrap_or(false);
+        let _ = sender.send(active);
+    })
+    .map_err(|_| "Native audio app state is unavailable.".to_string())?;
+    tauri::async_runtime::spawn_blocking(move || receiver.recv())
+        .await
+        .map_err(|_| "Native audio app state is unavailable.".to_string())?
+        .map_err(|_| "Native audio app state is unavailable.".to_string())
+}
+
+pub(crate) struct PlaybackAudioSession;
+
+impl PlaybackAudioSession {
+    pub(crate) fn activate() -> Result<Self, String> {
+        let session = unsafe { AVAudioSession::sharedInstance() };
+        let category = unsafe { AVAudioSessionCategoryPlayback }
+            .ok_or_else(|| "Native playback audio session is unavailable.".to_string())?;
+        let mode = unsafe { AVAudioSessionModeDefault }
+            .ok_or_else(|| "Native playback audio session is unavailable.".to_string())?;
+        unsafe {
+            session.setCategory_mode_options_error(
+                category,
+                mode,
+                AVAudioSessionCategoryOptions::empty(),
+            )
+        }
+        .map_err(|_| "Native playback audio session could not be configured.".to_string())?;
+        unsafe { session.setActive_error(true) }
+            .map_err(|_| "Native playback audio session could not be activated.".to_string())?;
+        Ok(Self)
+    }
+}
+
+impl Drop for PlaybackAudioSession {
+    fn drop(&mut self) {
+        let session = unsafe { AVAudioSession::sharedInstance() };
+        let _ = unsafe { session.setActive_error(false) };
+    }
+}

--- a/apps/desktop/src-tauri/src/native_audio/mod.rs
+++ b/apps/desktop/src-tauri/src/native_audio/mod.rs
@@ -6,6 +6,8 @@ pub mod android_media;
 pub mod capture;
 pub mod decode;
 pub mod diagnostics;
+#[cfg(target_os = "ios")]
+pub(crate) mod ios_session;
 pub mod mixer;
 pub mod platform;
 pub mod session;
@@ -36,6 +38,14 @@ pub const AUDIO_EVENT_TERMINAL: &str = "audio://terminal";
 pub struct NativeAudioState {
     capabilities: AudioCapabilities,
     engine: Arc<Mutex<NativeAudioEngine>>,
+    #[cfg(target_os = "ios")]
+    lifecycle: Arc<IosAudioLifecycle>,
+}
+
+#[cfg(target_os = "ios")]
+struct IosAudioLifecycle {
+    epoch: std::sync::atomic::AtomicU64,
+    inhibited: Arc<std::sync::atomic::AtomicBool>,
 }
 
 struct NativeAudioEngine {
@@ -55,11 +65,26 @@ impl NativeAudioState {
         diagnostics::initialize();
         let capabilities = AudioCapabilities::detect();
         let (report_sender, report_receiver) = mpsc::sync_channel(32);
+        #[cfg(target_os = "ios")]
+        let lifecycle = Arc::new(IosAudioLifecycle {
+            epoch: std::sync::atomic::AtomicU64::new(0),
+            inhibited: Arc::new(std::sync::atomic::AtomicBool::new(true)),
+        });
+        #[cfg(target_os = "ios")]
+        let transport = {
+            let mut transport = transport::TransportState::default();
+            transport.bind_runtime_inhibitor(lifecycle.inhibited.clone());
+            transport
+        };
+        #[cfg(not(target_os = "ios"))]
+        let transport = transport::TransportState::default();
         Self {
             capabilities: capabilities.clone(),
+            #[cfg(target_os = "ios")]
+            lifecycle,
             engine: Arc::new(Mutex::new(NativeAudioEngine {
                 mixer: mixer::MixerState::default(),
-                transport: transport::TransportState::default(),
+                transport,
                 capture: capture::CaptureState::default(),
                 output_session: session::SessionCoordinator::new_for_resource(
                     session::AudioResource::Output,
@@ -89,6 +114,13 @@ impl NativeAudioState {
         self.engine
             .lock()
             .map_err(|_| "Native audio engine is unavailable.".to_string())
+    }
+
+    #[cfg(target_os = "ios")]
+    fn lifecycle_epoch(&self) -> u64 {
+        self.lifecycle
+            .epoch
+            .load(std::sync::atomic::Ordering::Acquire)
     }
 }
 
@@ -320,13 +352,23 @@ pub async fn audio_prepare_session(
     if !state.capabilities.native_playback_supported {
         return Err("native_audio_unavailable".to_string());
     }
+    #[cfg(target_os = "ios")]
+    validate_ios_playback_rate(payload.playback_rate)?;
+    #[cfg(target_os = "ios")]
+    let lifecycle_epoch = state.lifecycle_epoch();
     let state = state.inner().clone();
     tauri::async_runtime::spawn_blocking(move || {
         let diagnostic_generation = diagnostics::begin_operation(
             diagnostics::DiagnosticOperationKind::Prepare,
             payload.lanes.len(),
         );
+        #[cfg(target_os = "ios")]
+        source_scope::validate_playback_lanes(&app, &payload.lanes)?;
         let mut engine = state.engine()?;
+        #[cfg(target_os = "ios")]
+        if state.lifecycle_epoch() != lifecycle_epoch {
+            return Err("native_audio_lifecycle_changed".to_string());
+        }
         payload
             .control
             .validate_acquisition()
@@ -376,7 +418,7 @@ pub async fn audio_prepare_session(
 }
 
 #[tauri::command]
-pub fn audio_play(
+pub async fn audio_play(
     app: AppHandle,
     state: State<'_, NativeAudioState>,
     payload: transport::AudioPlayRequest,
@@ -385,7 +427,16 @@ pub fn audio_play(
         return Err("Native audio playback is not available yet.".to_string());
     }
 
+    #[cfg(target_os = "ios")]
+    let lifecycle_epoch = state.lifecycle_epoch();
+    #[cfg(target_os = "ios")]
+    let app_active = ios_session::application_is_active(&app).await?;
+    let state = state.inner().clone();
     let mut engine = state.engine()?;
+    #[cfg(target_os = "ios")]
+    if !app_active || state.lifecycle_epoch() != lifecycle_epoch {
+        return Err("native_audio_inactive".to_string());
+    }
     engine.drain_reports();
     let previous_generation = engine.output_session.snapshot().generation;
     if !engine
@@ -439,6 +490,11 @@ pub fn audio_play(
     }) {
         return Err("invalid_cue_schedule".to_string());
     }
+    #[cfg(target_os = "ios")]
+    state
+        .lifecycle
+        .inhibited
+        .store(false, std::sync::atomic::Ordering::Release);
     if let Err(error) = engine.transport.play(payload) {
         if let Some(event) = engine
             .output_session
@@ -576,6 +632,10 @@ pub fn audio_set_lanes(
     payload: mixer::AudioLaneUpdate,
     control: session::SessionCommand,
 ) -> Result<transport::AudioSnapshot, String> {
+    #[cfg(target_os = "ios")]
+    validate_ios_playback_rate(payload.playback_rate)?;
+    #[cfg(target_os = "ios")]
+    source_scope::validate_playback_lanes(&app, &payload.lanes)?;
     let mut engine = state.engine()?;
     if !engine.authorize(session::SessionOwner::Playback, &control, false)? {
         return Ok(engine.output_snapshot());
@@ -622,6 +682,14 @@ pub fn audio_set_standalone_metronome(
 ) -> Result<transport::StandaloneMetronomeState, String> {
     if !state.capabilities.native_playback_supported {
         return Err("Native audio output is unavailable.".to_string());
+    }
+    #[cfg(target_os = "ios")]
+    if state
+        .lifecycle
+        .inhibited
+        .load(std::sync::atomic::Ordering::Acquire)
+    {
+        return Err("native_audio_inactive".to_string());
     }
     let mut engine = state.engine()?;
     engine.drain_reports();
@@ -694,6 +762,51 @@ pub fn audio_request_input_permission() -> capture::AudioInputPermissionStatus {
 pub fn stop_input_for_lifecycle(app: &AppHandle, state: &NativeAudioState) {
     if let Ok(mut engine) = state.engine() {
         engine.capture.stop_for_background(app);
+    }
+}
+
+#[cfg(target_os = "ios")]
+pub fn pause_output_for_lifecycle(app: &AppHandle, state: &NativeAudioState) {
+    let Ok(mut engine) = state.engine() else {
+        return;
+    };
+    state
+        .lifecycle
+        .inhibited
+        .store(true, std::sync::atomic::Ordering::Release);
+    state
+        .lifecycle
+        .epoch
+        .fetch_add(1, std::sync::atomic::Ordering::AcqRel);
+    let snapshot = engine.transport.pause_for_lifecycle();
+    if let Ok(mut timeline) = engine.output_session.timeline().lock() {
+        let revision = timeline.revision();
+        let _ = timeline.seek(revision, snapshot.position_seconds);
+        timeline.pause();
+    }
+    engine.emit_session(app, session::AudioResource::Output);
+    let snapshot = engine.output_snapshot();
+    let _ = app.emit(AUDIO_EVENT_STATE, snapshot.clone());
+    let _ = app.emit(
+        AUDIO_EVENT_POSITION,
+        transport::AudioPositionEvent {
+            session_id: snapshot.session_id,
+            position_seconds: snapshot.position_seconds,
+            duration_seconds: snapshot.duration_seconds,
+            state: snapshot.state,
+            generation: snapshot.generation,
+            timeline_revision: snapshot.timeline_revision,
+            native_time_us: snapshot.native_time_us,
+        },
+    );
+}
+
+#[cfg(any(target_os = "ios", test))]
+fn validate_ios_playback_rate(rate: Option<f64>) -> Result<(), String> {
+    if rate.is_none_or(|value| value.is_finite() && (value - 1.0).abs() <= 0.0001) {
+        Ok(())
+    } else {
+        Err("ios_playback_rate_unsupported".to_string())
     }
 }
 
@@ -1302,4 +1415,13 @@ mod tests {
         assert_eq!(prepared.lease_id, "project-playback");
         assert!(engine.transport.has_auxiliary_runtime());
     }
+}
+#[test]
+fn ios_playback_rate_accepts_only_native_speed() {
+    assert!(validate_ios_playback_rate(None).is_ok());
+    assert!(validate_ios_playback_rate(Some(1.0)).is_ok());
+    assert_eq!(
+        validate_ios_playback_rate(Some(1.25)).unwrap_err(),
+        "ios_playback_rate_unsupported"
+    );
 }

--- a/apps/desktop/src-tauri/src/native_audio/platform/mod.rs
+++ b/apps/desktop/src-tauri/src/native_audio/platform/mod.rs
@@ -1,11 +1,32 @@
 #[cfg(target_os = "android")]
 mod android;
+#[cfg(target_os = "ios")]
+mod ios {
+    use super::AudioPlatform;
+
+    pub fn current_platform() -> AudioPlatform {
+        AudioPlatform {
+            name: "ios",
+            backend: "ios-coreaudio",
+            native_playback_supported: true,
+            availability_reason: None,
+            mic_capture_supported: false,
+            mic_monitoring_supported: false,
+            system_input_volume_supported: false,
+        }
+    }
+}
 #[cfg(all(
-    not(target_os = "android"),
+    not(any(target_os = "android", target_os = "ios")),
     any(target_os = "linux", target_os = "macos")
 ))]
 mod desktop;
-#[cfg(not(any(target_os = "android", target_os = "linux", target_os = "macos")))]
+#[cfg(not(any(
+    target_os = "android",
+    target_os = "ios",
+    target_os = "linux",
+    target_os = "macos"
+)))]
 mod null;
 
 #[derive(Clone, Copy)]
@@ -24,15 +45,25 @@ pub fn current_platform() -> AudioPlatform {
     android::current_platform()
 }
 
+#[cfg(target_os = "ios")]
+pub fn current_platform() -> AudioPlatform {
+    ios::current_platform()
+}
+
 #[cfg(all(
-    not(target_os = "android"),
+    not(any(target_os = "android", target_os = "ios")),
     any(target_os = "linux", target_os = "macos")
 ))]
 pub fn current_platform() -> AudioPlatform {
     desktop::current_platform()
 }
 
-#[cfg(not(any(target_os = "android", target_os = "linux", target_os = "macos")))]
+#[cfg(not(any(
+    target_os = "android",
+    target_os = "ios",
+    target_os = "linux",
+    target_os = "macos"
+)))]
 pub fn current_platform() -> AudioPlatform {
     null::current_platform()
 }

--- a/apps/desktop/src-tauri/src/native_audio/source_scope.rs
+++ b/apps/desktop/src-tauri/src/native_audio/source_scope.rs
@@ -7,6 +7,8 @@ use std::{
 #[cfg(any(target_os = "linux", target_os = "macos", test))]
 use std::{env, ffi::OsStr};
 
+#[cfg(target_os = "ios")]
+use super::mixer::AudioLaneRequest;
 use rusqlite::{params, Connection, Error as SqliteError, OpenFlags, OptionalExtension};
 use serde_json::Value;
 #[cfg(not(any(target_os = "android", target_os = "ios")))]
@@ -89,8 +91,11 @@ impl PlaybackSourceScope {
             .ok_or(PlaybackSourceError::Unavailable)?;
         let canonical_path = validate_playback_source_path(source_path, &self.projects_root)?;
         let artifact_paths = artifact_paths_for_id(&self.database_path, artifact_id)?;
-        let matches_registered_path = artifact_paths.iter().any(|artifact_path| {
-            validate_artifact_record_path(artifact_path, &self.projects_root)
+        let matches_registered_path = artifact_paths.iter().any(|artifact| {
+            if !registered_path_is_playable(artifact.format.as_deref(), cfg!(target_os = "ios")) {
+                return false;
+            }
+            validate_artifact_record_path(&artifact.path, &self.projects_root)
                 .is_ok_and(|registered_path| registered_path == canonical_path)
         });
         if !matches_registered_path {
@@ -98,6 +103,22 @@ impl PlaybackSourceScope {
         }
         Ok(canonical_path)
     }
+}
+
+#[cfg(target_os = "ios")]
+pub(super) fn validate_playback_lanes(
+    app: &AppHandle,
+    lanes: &[AudioLaneRequest],
+) -> Result<(), String> {
+    let scope = PlaybackSourceScope::from_app(app)?;
+    for lane in lanes {
+        if let Some(source_path) = lane.source_path.as_deref() {
+            scope
+                .validate(lane.artifact_id.as_deref(), source_path)
+                .map_err(|error| error.message().to_string())?;
+        }
+    }
+    Ok(())
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -211,7 +232,7 @@ fn validate_playback_source_path(
 fn artifact_paths_for_id(
     database_path: &Path,
     artifact_id: &str,
-) -> Result<Vec<PathBuf>, PlaybackSourceError> {
+) -> Result<Vec<RegisteredPlaybackPath>, PlaybackSourceError> {
     let connection = Connection::open_with_flags(
         database_path,
         OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_NO_MUTEX,
@@ -222,38 +243,56 @@ fn artifact_paths_for_id(
         .map_err(|_| PlaybackSourceError::Unavailable)?;
     let artifact = connection
         .query_row(
-            "SELECT path, metadata_json FROM artifacts WHERE id = ?1",
+            "SELECT path, format, metadata_json FROM artifacts WHERE id = ?1",
             params![artifact_id],
-            |row| Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?)),
+            |row| {
+                Ok((
+                    row.get::<_, String>(0)?,
+                    row.get::<_, String>(1)?,
+                    row.get::<_, String>(2)?,
+                ))
+            },
         )
         .optional()
         .map_err(|error| match error {
             SqliteError::QueryReturnedNoRows => PlaybackSourceError::Unavailable,
             _ => PlaybackSourceError::Unavailable,
         })?;
-    let (artifact_path, metadata_json) = artifact.ok_or(PlaybackSourceError::Unavailable)?;
+    let (artifact_path, artifact_format, metadata_json) =
+        artifact.ok_or(PlaybackSourceError::Unavailable)?;
     let mut paths = Vec::with_capacity(2);
     if !artifact_path.trim().is_empty() {
-        paths.push(PathBuf::from(artifact_path));
+        paths.push(RegisteredPlaybackPath {
+            path: PathBuf::from(artifact_path),
+            format: Some(artifact_format),
+        });
     }
-    if let Some(playback_path) =
-        serde_json::from_str::<Value>(&metadata_json)
-            .ok()
-            .and_then(|metadata| {
-                metadata
-                    .get("playback_path")
-                    .and_then(Value::as_str)
-                    .map(str::trim)
-                    .filter(|value| !value.is_empty())
-                    .map(PathBuf::from)
-            })
-    {
-        paths.push(playback_path);
+    if let Ok(metadata) = serde_json::from_str::<Value>(&metadata_json) {
+        if let Some(playback_path) = metadata.get("playback_path").and_then(Value::as_str) {
+            if !playback_path.trim().is_empty() {
+                paths.push(RegisteredPlaybackPath {
+                    path: PathBuf::from(playback_path),
+                    format: metadata
+                        .get("playback_format")
+                        .and_then(Value::as_str)
+                        .map(str::to_string),
+                });
+            }
+        }
     }
     if paths.is_empty() {
         return Err(PlaybackSourceError::Unavailable);
     }
     Ok(paths)
+}
+
+struct RegisteredPlaybackPath {
+    path: PathBuf,
+    format: Option<String>,
+}
+
+fn registered_path_is_playable(format: Option<&str>, require_wav: bool) -> bool {
+    !require_wav || format.is_some_and(|value| value.eq_ignore_ascii_case("wav"))
 }
 
 fn validate_artifact_record_path(
@@ -350,7 +389,7 @@ mod tests {
             Connection::open(data_root.join(BACKEND_DATABASE_NAME)).expect("open test database");
         connection
             .execute(
-                "CREATE TABLE artifacts (id TEXT PRIMARY KEY, path TEXT NOT NULL, metadata_json TEXT NOT NULL)",
+                "CREATE TABLE artifacts (id TEXT PRIMARY KEY, path TEXT NOT NULL, format TEXT NOT NULL, metadata_json TEXT NOT NULL)",
                 [],
             )
             .expect("create artifacts table");
@@ -361,7 +400,7 @@ mod tests {
             Connection::open(data_root.join(BACKEND_DATABASE_NAME)).expect("open test database");
         connection
             .execute(
-                "INSERT INTO artifacts (id, path, metadata_json) VALUES (?1, ?2, '{}')",
+                "INSERT INTO artifacts (id, path, format, metadata_json) VALUES (?1, ?2, 'wav', '{}')",
                 params![artifact_id, source_path_string(path)],
             )
             .expect("insert artifact");
@@ -378,7 +417,7 @@ mod tests {
         let metadata = serde_json::json!({"playback_path": source_path_string(playback_path)});
         connection
             .execute(
-                "INSERT INTO artifacts (id, path, metadata_json) VALUES (?1, ?2, ?3)",
+                "INSERT INTO artifacts (id, path, format, metadata_json) VALUES (?1, ?2, 'flac', ?3)",
                 params![artifact_id, source_path_string(path), metadata.to_string()],
             )
             .expect("insert artifact");
@@ -494,6 +533,14 @@ mod tests {
             validated,
             playback_path.canonicalize().expect("canonical file")
         );
+    }
+
+    #[test]
+    fn ios_requires_an_explicit_wav_format_for_registered_paths() {
+        assert!(registered_path_is_playable(Some("WAV"), true));
+        assert!(!registered_path_is_playable(Some("mp3"), true));
+        assert!(!registered_path_is_playable(None, true));
+        assert!(registered_path_is_playable(None, false));
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/native_audio/transport.rs
+++ b/apps/desktop/src-tauri/src/native_audio/transport.rs
@@ -690,6 +690,8 @@ pub struct TransportState {
     app: Option<AppHandle>,
     #[cfg(any(mobile, target_os = "linux", target_os = "macos"))]
     runtime: Option<PlaybackRuntime>,
+    #[cfg(any(target_os = "ios", test))]
+    runtime_inhibited: Option<Arc<AtomicBool>>,
     #[cfg(test)]
     fail_next_runtime_start: bool,
     #[cfg(test)]
@@ -720,6 +722,8 @@ impl Default for TransportState {
             app: None,
             #[cfg(any(mobile, target_os = "linux", target_os = "macos"))]
             runtime: None,
+            #[cfg(any(target_os = "ios", test))]
+            runtime_inhibited: None,
             #[cfg(test)]
             fail_next_runtime_start: false,
             #[cfg(test)]
@@ -729,6 +733,11 @@ impl Default for TransportState {
 }
 
 impl TransportState {
+    #[cfg(any(target_os = "ios", test))]
+    pub(crate) fn bind_runtime_inhibitor(&mut self, inhibited: Arc<AtomicBool>) {
+        self.runtime_inhibited = Some(inhibited);
+    }
+
     pub fn bind_session(
         &mut self,
         generation: u64,
@@ -1376,6 +1385,13 @@ impl TransportState {
         self.snapshot()
     }
 
+    #[cfg(any(target_os = "ios", test))]
+    pub fn pause_for_lifecycle(&mut self) -> AudioSnapshot {
+        let snapshot = self.pause();
+        self.stop_runtime();
+        snapshot
+    }
+
     pub fn stop(&mut self) -> AudioSnapshot {
         #[cfg(any(mobile, target_os = "linux", target_os = "macos"))]
         let failed_runtime = self.runtime.as_ref().and_then(|runtime| {
@@ -1513,6 +1529,14 @@ impl TransportState {
 
     #[cfg(any(mobile, target_os = "linux", target_os = "macos"))]
     fn ensure_runtime(&mut self, require_project_runtime: bool) -> Result<bool, String> {
+        #[cfg(any(target_os = "ios", test))]
+        if self
+            .runtime_inhibited
+            .as_ref()
+            .is_some_and(|inhibited| inhibited.load(Ordering::Acquire))
+        {
+            return Err("native_audio_inactive".to_string());
+        }
         #[cfg(test)]
         if std::mem::take(&mut self.fail_next_runtime_start) {
             return Err("injected_runtime_start_failure".to_string());
@@ -2438,6 +2462,14 @@ fn start_output_stream_thread(
     stop_receiver: mpsc::Receiver<RuntimeControl>,
     ready_sender: mpsc::Sender<Result<(), String>>,
 ) {
+    #[cfg(target_os = "ios")]
+    let _audio_session = match super::ios_session::PlaybackAudioSession::activate() {
+        Ok(session) => session,
+        Err(error) => {
+            let _ = ready_sender.send(Err(error));
+            return;
+        }
+    };
     let host = cpal::default_host();
     let result = (|| {
         let device = host
@@ -3044,22 +3076,40 @@ impl StreamingDecoder {
         start_seconds: f64,
         diagnostics_context: Option<(u64, usize)>,
     ) -> Result<Self, String> {
+        #[cfg(target_os = "ios")]
+        let _ = diagnostics_context;
         let is_wav = path
             .extension()
             .and_then(|value| value.to_str())
             .map(|value| value.eq_ignore_ascii_case("wav"))
             .unwrap_or(false);
-        if is_wav {
-            match WavStreamDecoder::open(
+        #[cfg(target_os = "ios")]
+        {
+            if !is_wav {
+                return Err("iOS native playback requires a registered WAV source.".to_string());
+            }
+            return WavStreamDecoder::open(
                 &path,
                 target_sample_rate,
                 target_channels,
                 playback_rate,
                 start_seconds,
-            ) {
-                Ok(decoder) => return Ok(Self::Wav(decoder)),
-                Err(wav_error) => {
-                    return SymphoniaStreamDecoder::open(
+            )
+            .map(Self::Wav);
+        }
+        #[cfg(not(target_os = "ios"))]
+        {
+            if is_wav {
+                match WavStreamDecoder::open(
+                    &path,
+                    target_sample_rate,
+                    target_channels,
+                    playback_rate,
+                    start_seconds,
+                ) {
+                    Ok(decoder) => return Ok(Self::Wav(decoder)),
+                    Err(wav_error) => {
+                        return SymphoniaStreamDecoder::open(
                         path,
                         target_sample_rate,
                         target_channels,
@@ -3073,19 +3123,20 @@ impl StreamingDecoder {
                             "Native playback could not decode WAV source. Fast path failed: {wav_error}. Symphonia failed: {symphonia_error}"
                         )
                     });
+                    }
                 }
             }
-        }
 
-        SymphoniaStreamDecoder::open(
-            path,
-            target_sample_rate,
-            target_channels,
-            playback_rate,
-            start_seconds,
-            diagnostics_context,
-        )
-        .map(Self::Symphonia)
+            SymphoniaStreamDecoder::open(
+                path,
+                target_sample_rate,
+                target_channels,
+                playback_rate,
+                start_seconds,
+                diagnostics_context,
+            )
+            .map(Self::Symphonia)
+        }
     }
 
     fn next_chunk(&mut self) -> Result<Option<Vec<f32>>, String> {
@@ -4383,6 +4434,49 @@ mod tests {
         for receiver in exited_receivers {
             assert!(receiver.try_recv().is_ok());
         }
+    }
+
+    #[test]
+    #[cfg(any(mobile, target_os = "linux", target_os = "macos"))]
+    fn lifecycle_pause_releases_click_runtime_and_preserves_controls() {
+        let mut shared =
+            shared_with_lane(Arc::new(Mutex::new(RingBuffer::new(1_000))), 1_000, 1, 1.0);
+        shared.position_seconds = 6.5;
+        shared.click.enabled = true;
+        let (runtime, exited_receivers) = stoppable_runtime(shared);
+        let mut state = TransportState::default();
+        state.session_id = Some("session".to_string());
+        state.duration_seconds = 30.0;
+        state.native_playback_supported = true;
+        state.status = TransportStatus::Playing;
+        state.click.enabled = true;
+        state.runtime = Some(runtime);
+
+        let snapshot = state.pause_for_lifecycle();
+
+        assert!(state.runtime.is_none());
+        assert!(state.click.enabled);
+        assert_eq!(snapshot.state, "paused");
+        assert_seconds_close(snapshot.position_seconds, 6.5);
+        for receiver in exited_receivers {
+            assert!(receiver.try_recv().is_ok());
+        }
+    }
+
+    #[test]
+    #[cfg(any(mobile, target_os = "linux", target_os = "macos"))]
+    fn inhibited_output_blocks_the_common_runtime_creation_sink() {
+        let mut state = TransportState::default();
+        let inhibited = Arc::new(AtomicBool::new(true));
+        state.bind_runtime_inhibitor(inhibited.clone());
+
+        assert_eq!(
+            state.ensure_runtime(false).unwrap_err(),
+            "native_audio_inactive"
+        );
+
+        inhibited.store(false, Ordering::Release);
+        assert!(!state.ensure_runtime(false).expect("runtime is authorized"));
     }
 
     #[test]

--- a/apps/desktop/src/App.mobile.test.tsx
+++ b/apps/desktop/src/App.mobile.test.tsx
@@ -6,13 +6,16 @@ import { markPlaybackStarting } from "./lib/playbackDiagnostics";
 import { updateBrowserWakeLockStatus } from "./lib/powerInhibition";
 import {
   findAudioByArtifactId,
+  emitMockNativePlaybackPosition,
   markAudioReady,
   mockCreateStems,
   mockGetChords,
+  mockGetAnalysis,
   mockGetProject,
   mockGetLyrics,
   mockInvoke,
   mockListArtifacts,
+  mockListJobs,
   mockGetMobileCapabilities,
   mockStartSyncListener,
   resetAppTestHarness,
@@ -20,6 +23,8 @@ import {
   setProjectAnalysis,
   setProjectChords,
   setProjectLyrics,
+  setProjectArtifacts,
+  setMockNativeAudioState,
 } from "./test/appTestHarness";
 
 const originalUserAgent = navigator.userAgent;
@@ -148,6 +153,7 @@ function setTempoAnalysis(tempoBpm = 120) {
 describe("Desktop app mobile capability gates", () => {
   beforeEach(resetAppTestHarness);
   afterEach(() => {
+    delete (window as Window & { __TAURI_INTERNALS__?: unknown }).__TAURI_INTERNALS__;
     Object.defineProperties(window.navigator, {
       userAgent: { configurable: true, value: originalUserAgent },
       platform: { configurable: true, value: originalPlatform },
@@ -163,7 +169,7 @@ describe("Desktop app mobile capability gates", () => {
     await waitFor(() =>
       expect(screen.queryByRole("button", { name: "Import Track(s)" })).not.toBeInTheDocument(),
     );
-    expect(screen.queryByRole("link", { name: "Open Demo Song project" })).not.toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Open Demo Song project" })).toBeInTheDocument();
     expect(screen.queryByText("Show file details")).not.toBeInTheDocument();
   });
 
@@ -179,16 +185,195 @@ describe("Desktop app mobile capability gates", () => {
     expect(screen.queryByRole("button", { name: "Import Track(s)" })).not.toBeInTheDocument();
   });
 
-  it("gates iOS project routes before the full project model mounts", async () => {
+  it("opens an iOS project directly in the constrained playback workspace", async () => {
     enableIOSRuntime();
     renderApp(["/projects/proj_123"]);
 
-    expect(await screen.findByRole("heading", { name: "Project playback unavailable" })).toBeInTheDocument();
+    expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
     expect(screen.getByRole("link", { name: "Back to Library" })).toBeInTheDocument();
     expect(screen.queryByRole("heading", { name: "Processing" })).not.toBeInTheDocument();
-    expect(mockGetProject).not.toHaveBeenCalled();
-    expect(mockListArtifacts).not.toHaveBeenCalled();
-    expect(mockInvoke).not.toHaveBeenCalledWith("audio_prepare_session", expect.anything());
+    expect(screen.queryByRole("tablist", { name: "Project workspace" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "More playback actions" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("heading", { name: "Lyrics + chords" })).not.toBeInTheDocument();
+    expect(mockGetProject).toHaveBeenCalledWith("proj_123");
+    expect(mockListArtifacts).toHaveBeenCalledWith("proj_123");
+    expect(mockGetAnalysis).not.toHaveBeenCalled();
+    expect(mockGetChords).not.toHaveBeenCalled();
+    expect(mockGetLyrics).not.toHaveBeenCalled();
+    expect(mockListJobs).not.toHaveBeenCalled();
+
+    await userEvent.click(screen.getByRole("button", { name: "Open Practice Controls" }));
+    const dialog = screen.getByRole("dialog", { name: "Practice Controls" });
+    expect(within(dialog).getByRole("button", { name: /Source Track/i })).toBeInTheDocument();
+    expect(within(dialog).queryByText("Transpose / Capo")).not.toBeInTheDocument();
+    expect(within(dialog).queryByText("Count-in")).not.toBeInTheDocument();
+    expect(within(dialog).queryByText("Playback BPM")).not.toBeInTheDocument();
+  });
+
+  it("uses registered WAV proxies and omits unsupported iOS playback rows", async () => {
+    enableIOSRuntime();
+    Object.defineProperty(window, "__TAURI_INTERNALS__", {
+      configurable: true,
+      value: { invoke: mockInvoke },
+    });
+    setMockNativeAudioState({ capabilities: {
+      platform: "ios", backend: "ios-coreaudio", nativePlaybackSupported: true,
+    } });
+    setProjectArtifacts("proj_123", [
+      { id: "proxy", project_id: "proj_123", type: "preview_mix", format: "mp3", path: "/private/mix.mp3", metadata: { playback_path: "/private/mix.wav", playback_format: "wav" }, created_at: "2026-04-18T13:16:00.000Z" },
+      { id: "unsupported", project_id: "proj_123", type: "source_audio", format: "mp3", path: "/private/source.mp3", metadata: {}, created_at: "2026-04-18T13:16:00.000Z" },
+    ]);
+    renderApp(["/projects/proj_123"]);
+
+    expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
+    await userEvent.click(screen.getByRole("button", { name: "Open Practice Controls" }));
+    const dialog = screen.getByRole("dialog", { name: "Practice Controls" });
+    expect(within(dialog).getByRole("button", { name: /Practice Mix/i })).toBeInTheDocument();
+    expect(within(dialog).queryByRole("button", { name: /Source Track/i })).not.toBeInTheDocument();
+    await userEvent.click(within(dialog).getByRole("button", { name: "Close Practice Controls" }));
+    await userEvent.click(screen.getByRole("button", { name: "Play playback" }));
+    await waitFor(() => expect(mockInvoke).toHaveBeenCalledWith(
+      "audio_prepare_session",
+      expect.objectContaining({ payload: expect.objectContaining({ lanes: [expect.objectContaining({ sourcePath: "/private/mix.wav" })] }) }),
+    ));
+  });
+
+  it("resumes iOS playback with one Play after a lifecycle pause", async () => {
+    enableIOSRuntime();
+    Object.defineProperty(window, "__TAURI_INTERNALS__", {
+      configurable: true,
+      value: { invoke: mockInvoke },
+    });
+    setMockNativeAudioState({ capabilities: {
+      platform: "ios", backend: "ios-coreaudio", nativePlaybackSupported: true,
+    } });
+    renderApp(["/projects/proj_123"]);
+
+    await userEvent.click(await screen.findByRole("button", { name: "Play playback" }));
+    expect(await screen.findByRole("button", { name: "Pause playback" })).toBeInTheDocument();
+    act(() => emitMockNativePlaybackPosition({
+      sessionId: "proj_123:native:art_source",
+      state: "paused",
+      positionSeconds: 4,
+      durationSeconds: 16,
+      timelineRevision: 0,
+    }));
+    act(() => emitMockNativePlaybackPosition({
+      sessionId: "other-session",
+      state: "paused",
+      positionSeconds: 5,
+      durationSeconds: 16,
+      timelineRevision: 2,
+    }));
+    expect(screen.getByRole("button", { name: "Pause playback" })).toBeInTheDocument();
+    act(() => emitMockNativePlaybackPosition({
+      sessionId: "proj_123:native:art_source",
+      state: "paused",
+      positionSeconds: 6.5,
+      durationSeconds: 16,
+      timelineRevision: 2,
+    }));
+    const playButton = await screen.findByRole("button", { name: "Play playback" });
+    const playCallsBeforeResume = mockInvoke.mock.calls.filter(([command]) => command === "audio_play").length;
+
+    await userEvent.click(playButton);
+
+    await waitFor(() => expect(
+      mockInvoke.mock.calls.filter(([command]) => command === "audio_play"),
+    ).toHaveLength(playCallsBeforeResume + 1));
+    const playCalls = mockInvoke.mock.calls.filter(([command]) => command === "audio_play");
+    const resumeCall = playCalls[playCalls.length - 1];
+    expect(resumeCall?.[1]).toEqual(expect.objectContaining({
+      payload: expect.objectContaining({ timelineRevision: 2 }),
+    }));
+    expect(screen.getByRole("button", { name: "Pause playback" })).toBeInTheDocument();
+  });
+
+  it.each([
+    ["desktop", "macos", "desktop-cpal"],
+    ["Android", "android", "android-aaudio"],
+  ])("does not treat a newer %s pause as an iOS lifecycle event", async (_label, platform, backend) => {
+    enableIOSRuntime();
+    Object.defineProperty(window, "__TAURI_INTERNALS__", {
+      configurable: true,
+      value: { invoke: mockInvoke },
+    });
+    setMockNativeAudioState({ capabilities: {
+      platform, backend, nativePlaybackSupported: true,
+    } });
+    renderApp(["/projects/proj_123"]);
+
+    await userEvent.click(await screen.findByRole("button", { name: "Play playback" }));
+    expect(await screen.findByRole("button", { name: "Pause playback" })).toBeInTheDocument();
+    act(() => emitMockNativePlaybackPosition({
+      sessionId: "proj_123:native:art_source",
+      state: "paused",
+      positionSeconds: 6.5,
+      durationSeconds: 16,
+      timelineRevision: 2,
+    }));
+
+    expect(screen.getByRole("button", { name: "Pause playback" })).toBeInTheDocument();
+    await userEvent.click(screen.getByRole("button", { name: "Pause playback" }));
+    await userEvent.click(await screen.findByRole("button", { name: "Play playback" }));
+    expect(await screen.findByRole("button", { name: "Pause playback" })).toBeInTheDocument();
+  });
+
+  it("keeps iOS stems in one source group and exposes mute, solo, and reset", async () => {
+    enableIOSRuntime();
+    setProjectArtifacts("proj_123", [
+      {
+        id: "group-a",
+        project_id: "proj_123",
+        type: "preview_mix",
+        format: "wav",
+        path: "/private/group-a.wav",
+        metadata: {},
+        created_at: "2026-04-18T13:16:00.000Z",
+      },
+      ...["vocals", "drums"].map((stem) => ({
+        id: `group-a-${stem}`,
+        project_id: "proj_123",
+        type: `${stem === "vocals" ? "vocal" : stem}_stem`,
+        format: "wav",
+        path: `/private/group-a-${stem}.wav`,
+        metadata: { source_artifact_id: "group-a", stem_source: stem },
+        created_at: "2026-04-18T13:16:00.000Z",
+      })),
+      ...["bass", "guitar"].map((stem) => ({
+        id: `group-b-${stem}`,
+        project_id: "proj_123",
+        type: `${stem}_stem`,
+        format: "wav",
+        path: `/private/group-b-${stem}.wav`,
+        metadata: { source_artifact_id: "group-b", stem_source: stem },
+        created_at: "2026-04-18T13:16:00.000Z",
+      })),
+    ]);
+    window.localStorage.setItem("tuneforge.project-playback-state", JSON.stringify({
+      proj_123: {
+        activeWorkspace: "playback",
+        selectedArtifactId: "group-b-bass",
+        selectedPrimaryArtifactId: "group-a",
+      },
+    }));
+    renderApp(["/projects/proj_123"]);
+
+    await userEvent.click(await screen.findByRole("button", { name: "Open Practice Controls" }));
+    const dialog = screen.getByRole("dialog", { name: "Practice Controls" });
+    const stemList = within(dialog).getByRole("group", { name: "Playback stem list" });
+    expect(within(stemList).getByRole("button", { name: "Mute Guitar" })).toBeInTheDocument();
+    expect(within(stemList).queryByRole("button", { name: "Mute Drums" })).not.toBeInTheDocument();
+    expect(within(dialog).getByRole("button", { name: "Full Mix" })).toBeDisabled();
+
+    await userEvent.click(within(stemList).getByRole("button", { name: "Mute Guitar" }));
+    await userEvent.click(within(stemList).getByRole("button", { name: "Solo Bass" }));
+    const reset = within(dialog).getByRole("button", { name: "Reset stem mute and solo" });
+    expect(reset).toBeEnabled();
+    await userEvent.click(reset);
+    expect(within(stemList).getByRole("button", { name: "Mute Guitar" })).toHaveAttribute(
+      "aria-pressed", "false",
+    );
   });
 
   it("fails a project route closed when runtime capabilities fail", async () => {

--- a/apps/desktop/src/features/projects/LibraryView.tsx
+++ b/apps/desktop/src/features/projects/LibraryView.tsx
@@ -48,12 +48,8 @@ function formatUpdatedAt(value: string | null) {
 
 function ProjectSummaryLink({
   children,
-  isIOSRuntime,
   project,
 }: PropsWithChildren<{ isIOSRuntime: boolean; project: ProjectSchema }>) {
-  if (isIOSRuntime) {
-    return <div className="project-card__link">{children}</div>;
-  }
   return (
     <Link
       aria-label={`Open ${project.display_name} project`}

--- a/apps/desktop/src/features/projects/ProjectView.tsx
+++ b/apps/desktop/src/features/projects/ProjectView.tsx
@@ -1,6 +1,5 @@
 import { useEffect } from "react";
 import { useQuery } from "@tanstack/react-query";
-import { Link } from "react-router-dom";
 import { api } from "../../lib/api";
 import { ProjectShell } from "./components/ProjectShell";
 import { ProjectViewModelProvider } from "./components/ProjectViewModelContext";
@@ -25,15 +24,6 @@ export function ProjectView() {
         <button className="button button--ghost" onClick={() => void mobileCapabilitiesQuery.refetch()} type="button">
           Retry
         </button>
-      </div>
-    );
-  }
-  if (mobileCapabilitiesQuery.data?.platform === "ios") {
-    return (
-      <div className="panel">
-        <h1>Project playback unavailable</h1>
-        <p>Browse synced project and artifact details from Library.</p>
-        <Link className="button button--ghost" to="/">Back to Library</Link>
       </div>
     );
   }

--- a/apps/desktop/src/features/projects/components/PlaybackPracticeRail.tsx
+++ b/apps/desktop/src/features/projects/components/PlaybackPracticeRail.tsx
@@ -59,6 +59,7 @@ export const PlaybackPracticeRail = forwardRef<
     informationDensity,
     hasActiveStemControls,
     isMobileRuntime,
+    isIOSRuntime,
     isStemPlayback,
     lowerCapoPreview,
     lowerCapoShiftOptions,
@@ -243,15 +244,15 @@ export const PlaybackPracticeRail = forwardRef<
         className="playback-practice-rail__focus-icons"
         tabIndex={0}
       >
-        <span title="Transpose / Capo">
+        {!isIOSRuntime ? <span title="Transpose / Capo">
           <ArrowUpDown aria-hidden="true" />
-        </span>
-        <span title="Pre-count">
+        </span> : null}
+        {!isIOSRuntime ? <span title="Pre-count">
           <Drumstick aria-hidden="true" />
-        </span>
-        <span title="Tempo">
+        </span> : null}
+        {!isIOSRuntime ? <span title="Tempo">
           <Gauge aria-hidden="true" />
-        </span>
+        </span> : null}
         <span title="Source and Mixes">
           <Layers aria-hidden="true" />
         </span>
@@ -278,6 +279,7 @@ export const PlaybackPracticeRail = forwardRef<
         ) : null}
       </div>
 
+      {!isIOSRuntime ? <>
       <section className="playback-capo-control">
         <TargetKeySelector
           currentKey={capoKey}
@@ -449,6 +451,7 @@ export const PlaybackPracticeRail = forwardRef<
         </div>
         <p className="artifact-meta playback-tempo-control__summary">{tempoSummary}</p>
       </section>
+      </> : null}
 
       <section className="playback-picker-group playback-picker-group--compact">
         <div className="playback-picker-group__header">
@@ -502,6 +505,7 @@ export const PlaybackPracticeRail = forwardRef<
               <button
                 aria-pressed={!isStemPlayback}
                 className={`chip${!isStemPlayback ? " chip--active" : ""}`}
+                disabled={!selectedPrimaryArtifact}
                 onClick={() => {
                   if (selectedPrimaryArtifact) {
                     handleSelectPrimaryArtifact(selectedPrimaryArtifact);

--- a/apps/desktop/src/features/projects/components/PlaybackWorkspace.tsx
+++ b/apps/desktop/src/features/projects/components/PlaybackWorkspace.tsx
@@ -17,6 +17,7 @@ export function PlaybackWorkspace({
     handleResetPlaybackTempo,
     handleTogglePlaybackLoop,
     isMobileRuntime,
+    isIOSRuntime,
     isPlaying,
     loopRange,
     loopStatusMessage,
@@ -36,7 +37,7 @@ export function PlaybackWorkspace({
   return (
     <div className={`playback-workspace playback-workspace--practice${isPlaying ? " playback-workspace--focus" : ""}`}>
       {!isMobileRuntime ? <PlaybackPracticeRail /> : null}
-      <PlaybackPracticeSurface />
+      {!isIOSRuntime ? <PlaybackPracticeSurface /> : null}
       <div className="panel playback-transport-dock" ref={playbackTransportRef}>
         <PlaybackTransport
           compact

--- a/apps/desktop/src/features/projects/components/ProjectHeader.tsx
+++ b/apps/desktop/src/features/projects/components/ProjectHeader.tsx
@@ -19,6 +19,7 @@ export function ProjectHeader({
     handleSelectWorkspace,
     hasLyricsTranscript,
     isLyricsRunning,
+    isIOSRuntime,
     isMobileRuntime,
     isRenaming,
     lyricsMutation,
@@ -163,7 +164,7 @@ export function ProjectHeader({
             <SlidersHorizontal aria-hidden="true" />
             <span>Practice Controls</span>
           </button>
-          <div className="mobile-playback-overflow" ref={overflowRef}>
+          {!isIOSRuntime ? <div className="mobile-playback-overflow" ref={overflowRef}>
             <button
               aria-expanded={overflowOpen}
               aria-haspopup="menu"
@@ -230,7 +231,7 @@ export function ProjectHeader({
                 </button>
               </div>
             ) : null}
-          </div>
+          </div> : null}
         </div>
       </header>
     );

--- a/apps/desktop/src/features/projects/components/ProjectShell.tsx
+++ b/apps/desktop/src/features/projects/components/ProjectShell.tsx
@@ -7,11 +7,15 @@ import { ProjectWorkspace } from "./ProjectWorkspace";
 export function ProjectShell() {
   const {
     activeWorkspace,
+    artifactsQuery,
     exportRecoveryNoticeId,
     exportRecoveryNoticeProjectId,
     handleSelectWorkspace,
+    isIOSRuntime,
     isMobileRuntime,
     projectId,
+    projectQuery,
+    selectedPlaybackArtifact,
   } = useProjectViewModelContext();
   const [practiceControlsOpen, setPracticeControlsOpen] = useState(false);
   const [showExportRecoveryNotice, setShowExportRecoveryNotice] = useState(false);
@@ -53,6 +57,31 @@ export function ProjectShell() {
     const timeoutId = window.setTimeout(() => setShowExportRecoveryNotice(false), 4000);
     return () => window.clearTimeout(timeoutId);
   }, [exportRecoveryNoticeId, exportRecoveryNoticeProjectId, projectId]);
+
+  if (isIOSRuntime && (projectQuery.isPending || artifactsQuery.isPending)) {
+    return <div className="panel" role="status">Loading synced playback...</div>;
+  }
+  if (isIOSRuntime && (projectQuery.isError || artifactsQuery.isError)) {
+    return (
+      <div className="panel panel--error" role="alert">
+        Could not load synced playback.
+        <button
+          className="button button--ghost"
+          onClick={() => void Promise.all([projectQuery.refetch(), artifactsQuery.refetch()])}
+          type="button"
+        >
+          Retry
+        </button>
+      </div>
+    );
+  }
+  if (isIOSRuntime && !selectedPlaybackArtifact) {
+    return (
+      <div className="panel" role="status">
+        No registered WAV source or playback proxy is available. Sync WAV playback artifacts from desktop.
+      </div>
+    );
+  }
 
   return (
     <section

--- a/apps/desktop/src/features/projects/hooks/useProjectViewModel.ts
+++ b/apps/desktop/src/features/projects/hooks/useProjectViewModel.ts
@@ -173,6 +173,17 @@ function formatLyricsLanguageMetadata(lyrics: LyricsResponse | undefined) {
   return effectiveLabel ? `Language: ${effectiveLabel}` : null;
 }
 
+function iosPlaybackSource(artifact: ArtifactSchema) {
+  if (artifact.format.toLowerCase() === "wav") {
+    return { format: "wav", path: artifact.path };
+  }
+  const path = artifact.metadata?.playback_path;
+  const format = artifact.metadata?.playback_format;
+  return typeof path === "string" && typeof format === "string" && format.toLowerCase() === "wav"
+    ? { format: "wav", path }
+    : null;
+}
+
 function resolveDefaultPlaybackDisplayMode(
   defaultMode: DefaultPlaybackDisplayMode,
   hasLyricsTranscript: boolean,
@@ -392,6 +403,12 @@ export function useProjectViewModel() {
   const [chordsFollowEnabled, setChordsFollowEnabled] = useState(defaultChordsFollowEnabled);
   const showSupportingCopy = informationDensity !== "minimal";
 
+  const mobileCapabilitiesQuery = useQuery({
+    queryKey: ["runtime", "mobile-capabilities"],
+    queryFn: async () => api.getMobileCapabilities(),
+    staleTime: Infinity,
+  });
+  const isIOSRuntime = mobileCapabilitiesQuery.data?.platform === "ios";
   const projectQuery = useQuery({
     queryKey: ["project", projectId],
     queryFn: async () => (await api.getProject(projectId)).project,
@@ -402,22 +419,22 @@ export function useProjectViewModel() {
   const analysisQuery = useQuery({
     queryKey: ["analysis", projectId],
     queryFn: async () => (await api.getAnalysis(projectId)).analysis,
-    enabled: Boolean(projectId),
+    enabled: Boolean(projectId) && !isIOSRuntime,
   });
   const chordsQuery = useQuery({
     queryKey: ["chords", projectId],
     queryFn: async () => api.getChords(projectId),
-    enabled: Boolean(projectId),
+    enabled: Boolean(projectId) && !isIOSRuntime,
   });
   const lyricsQuery = useQuery({
     queryKey: ["lyrics", projectId],
     queryFn: async () => api.getLyrics(projectId),
-    enabled: Boolean(projectId),
+    enabled: Boolean(projectId) && !isIOSRuntime,
   });
   const sectionsQuery = useQuery({
     queryKey: ["sections", projectId],
     queryFn: async () => api.listSections(projectId),
-    enabled: Boolean(projectId),
+    enabled: Boolean(projectId) && !isIOSRuntime,
   });
   const artifactsQuery = useQuery({
     queryKey: ["artifacts", projectId],
@@ -434,7 +451,7 @@ export function useProjectViewModel() {
         limit: ACTIVE_PROJECT_JOBS_LIMIT,
         offset: pageParam,
       }),
-    enabled: Boolean(projectId),
+    enabled: Boolean(projectId) && !isIOSRuntime,
     getNextPageParam: getNextJobsPageOffset,
   });
   const terminalProjectJobsQuery = useInfiniteQuery({
@@ -447,13 +464,8 @@ export function useProjectViewModel() {
         limit: PROJECT_HISTORY_JOBS_PAGE_SIZE,
         offset: pageParam,
       }),
-    enabled: Boolean(projectId),
+    enabled: Boolean(projectId) && !isIOSRuntime,
     getNextPageParam: getNextJobsPageOffset,
-  });
-  const mobileCapabilitiesQuery = useQuery({
-    queryKey: ["mobile-capabilities"],
-    queryFn: async () => api.getMobileCapabilities(),
-    staleTime: Infinity,
   });
   const projectSyncSummary = useMemo(
     () => getProjectSyncSummary(projectQuery.data),
@@ -788,9 +800,11 @@ export function useProjectViewModel() {
   const primaryArtifacts = useMemo(
     () =>
       displayArtifacts.filter(
-        (artifact) => artifact.type === "preview_mix" || artifact.type === "source_audio",
+        (artifact) =>
+          (artifact.type === "preview_mix" || artifact.type === "source_audio")
+          && (!isIOSRuntime || iosPlaybackSource(artifact) !== null),
       ),
-    [displayArtifacts],
+    [displayArtifacts, isIOSRuntime],
   );
   const sourceArtifact = useMemo(
     () => primaryArtifacts.find((artifact) => artifact.type === "source_audio") ?? null,
@@ -802,10 +816,9 @@ export function useProjectViewModel() {
   );
   const stemArtifacts = useMemo(
     () =>
-      displayArtifacts.filter(
-        (artifact) => isStemArtifact(artifact),
-      ),
-    [displayArtifacts],
+      displayArtifacts.filter((artifact) =>
+        isStemArtifact(artifact) && (!isIOSRuntime || iosPlaybackSource(artifact) !== null)),
+    [displayArtifacts, isIOSRuntime],
   );
   const selectableArtifacts = useMemo(
     () => [...primaryArtifacts, ...stemArtifacts].filter((artifact) => isPlayableArtifact(artifact)),
@@ -816,20 +829,31 @@ export function useProjectViewModel() {
 
   const selectedArtifact =
     selectableArtifacts.find((artifact) => artifact.id === selectedArtifactId) ?? null;
-  const selectedPrimaryArtifact =
-    primaryArtifacts.find((artifact) => artifact.id === selectedPrimaryArtifactId) ??
-    artifactById(primaryArtifacts, sourceArtifactIdForStems(selectedArtifact)) ??
-    defaultPrimaryArtifact;
+  const selectedStemPrimaryArtifact = artifactById(
+    primaryArtifacts,
+    sourceArtifactIdForStems(selectedArtifact),
+  );
+  const selectedPrimaryArtifact = isIOSRuntime && isStemArtifact(selectedArtifact)
+    ? selectedStemPrimaryArtifact
+    : primaryArtifacts.find((artifact) => artifact.id === selectedPrimaryArtifactId) ??
+      selectedStemPrimaryArtifact ??
+      defaultPrimaryArtifact;
+  const visibleStemSourceArtifactId = sourceArtifactIdForStems(selectedArtifact)
+    ?? sourceArtifactIdForStems(stemArtifacts[0]);
   const visibleStemArtifacts = useMemo(
     () =>
       stemArtifacts.filter((artifact) => {
         const sourceArtifactId = artifact.metadata?.source_artifact_id;
         return (
-          typeof sourceArtifactId === "string" &&
-          sourceArtifactId === selectedPrimaryArtifact?.id
+          (!selectedPrimaryArtifact && isIOSRuntime
+            && (visibleStemSourceArtifactId
+              ? sourceArtifactId === visibleStemSourceArtifactId
+              : artifact.id === (selectedArtifact?.id ?? stemArtifacts[0]?.id))) ||
+          (typeof sourceArtifactId === "string" &&
+            sourceArtifactId === selectedPrimaryArtifact?.id)
         );
       }),
-    [selectedPrimaryArtifact?.id, stemArtifacts],
+    [isIOSRuntime, selectedArtifact, selectedPrimaryArtifact, stemArtifacts, visibleStemSourceArtifactId],
   );
   const stemJob = useMemo(() => {
     const selectedPrimaryId = selectedPrimaryArtifact?.id;
@@ -885,6 +909,7 @@ export function useProjectViewModel() {
   const precountDisabledReason = canUsePrecount ? null : "Waiting for BPM analysis";
   const mobileCapabilities = mobileCapabilitiesQuery.data ?? null;
   const isMobileRuntime = mobileCapabilities !== null;
+  const effectiveActiveWorkspace = isIOSRuntime ? "playback" : activeWorkspace;
   const sourceKeyOverride = useMemo(
     () => parseStoredKey(projectQuery.data?.source_key_override),
     [projectQuery.data?.source_key_override],
@@ -1246,6 +1271,9 @@ export function useProjectViewModel() {
   }
 
   function handleSelectWorkspace(workspace: "project" | "playback") {
+    if (isIOSRuntime) {
+      return;
+    }
     setActiveWorkspace(workspace);
   }
 
@@ -2036,7 +2064,7 @@ export function useProjectViewModel() {
 
     if (!defaultPrimaryArtifact) {
       setSelectedPrimaryArtifactId(null);
-      setSelectedArtifactId(null);
+      setSelectedArtifactId(isIOSRuntime ? stemArtifacts[0]?.id ?? null : null);
       return;
     }
 
@@ -2086,6 +2114,8 @@ export function useProjectViewModel() {
     selectableArtifacts,
     selectedArtifactId,
     selectedPrimaryArtifactId,
+    isIOSRuntime,
+    stemArtifacts,
   ]);
 
   useEffect(() => {
@@ -2409,22 +2439,24 @@ export function useProjectViewModel() {
       selectedPlaybackArtifactId: selectedPlaybackArtifact.id,
       isStemPlayback,
       playbackArtifactIds: nativePlaybackArtifacts.map((artifact) => artifact.id),
-      artifactPathsById: Object.fromEntries(
-        nativePlaybackArtifacts.map((artifact) => [artifact.id, artifact.path]),
-      ),
-      artifactFormatsById: Object.fromEntries(
-        nativePlaybackArtifacts.map((artifact) => [artifact.id, artifact.format]),
-      ),
+      artifactPathsById: Object.fromEntries(nativePlaybackArtifacts.map((artifact) => [
+        artifact.id,
+        isIOSRuntime ? iosPlaybackSource(artifact)?.path ?? "" : artifact.path,
+      ])),
+      artifactFormatsById: Object.fromEntries(nativePlaybackArtifacts.map((artifact) => [
+        artifact.id,
+        isIOSRuntime ? "wav" : artifact.format,
+      ])),
       visibleStemArtifactIds: visibleStemArtifacts.map((artifact) => artifact.id),
       stemControls,
       durationHintSeconds: projectQuery.data?.duration_seconds ?? 0,
-      precountEnabled,
-      precountLoopEnabled,
+      precountEnabled: isIOSRuntime ? false : precountEnabled,
+      precountLoopEnabled: isIOSRuntime ? false : precountLoopEnabled,
       precountClickCount,
-      precountTempoBpm,
-      tempoOriginalBpm,
-      tempoTargetBpm: tempoTargetBpmForPlayback,
-      timingGrid: analysisTimingGrid,
+      precountTempoBpm: isIOSRuntime ? null : precountTempoBpm,
+      tempoOriginalBpm: isIOSRuntime ? null : tempoOriginalBpm,
+      tempoTargetBpm: isIOSRuntime ? null : tempoTargetBpmForPlayback,
+      timingGrid: isIOSRuntime ? null : analysisTimingGrid,
       loopRange,
       chordDictionaryFollowProject,
     });
@@ -2433,6 +2465,7 @@ export function useProjectViewModel() {
     chordDictionaryFollowProject,
     hydratedProjectId,
     isStemPlayback,
+    isIOSRuntime,
     projectId,
     projectQuery.data?.duration_seconds,
     projectPlaybackName,
@@ -2454,7 +2487,7 @@ export function useProjectViewModel() {
 
 
   return {
-    activeWorkspace,
+    activeWorkspace: effectiveActiveWorkspace,
     activeProjectPanel,
     activeChordIndex,
     activeEnharmonicKeyContext,
@@ -2576,6 +2609,7 @@ export function useProjectViewModel() {
     isTabImportOpen,
     isLyricsRunning,
     isMobileRuntime,
+    isIOSRuntime,
     isPlaying,
     isFetchingNextProjectHistoryJobsPage: terminalProjectJobsQuery.isFetchingNextPage,
     isFetchNextProjectHistoryJobsPageError: terminalProjectJobsQuery.isFetchNextPageError,

--- a/apps/desktop/src/features/projects/playback.tsx
+++ b/apps/desktop/src/features/projects/playback.tsx
@@ -3921,15 +3921,40 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
     const unlisteners = Promise.all([
       listenNativeAudioPositions((position) => {
         const activeSession = sessionRef.current;
+        const sessionSignature = nativePlaybackRef.current.sessionSignature;
+        const currentRevision = nativePlaybackRef.current.timelineRevision;
+        const newerLifecyclePause =
+          nativeBackendRef.current === "ios-coreaudio" &&
+          position.state === "paused" &&
+          currentRevision !== null &&
+          position.timelineRevision > currentRevision;
         if (
           !activeSession ||
           !nativePlaybackRef.current.active ||
           nativePrecountRef.current !== null ||
-          position.sessionId !== nativePlaybackRef.current.sessionSignature ||
+          sessionSignature === null ||
+          position.sessionId !== sessionSignature ||
           position.generation !== nativePlaybackRef.current.generation ||
-          position.timelineRevision !== nativePlaybackRef.current.timelineRevision
+          (position.timelineRevision !== currentRevision && !newerLifecyclePause)
         ) {
           return;
+        }
+        if (newerLifecyclePause) {
+          loopEpochRef.current += 1;
+          playbackIntentEpochRef.current += 1;
+          nativeControlGenerationRef.current += 1;
+          invalidateNativeOutputMutations();
+          precountSequenceRef.current += 1;
+          allowFreshPlaybackRef.current = true;
+          clearPendingTransition();
+          pendingNativePlayRef.current = null;
+          pendingNativePauseRef.current = null;
+          nativePlaybackRef.current.timelineRevision = position.timelineRevision;
+          nativeOutputAuthorityRef.current = {
+            generation: position.generation,
+            sessionSignature,
+            timelineRevision: position.timelineRevision,
+          };
         }
         if (position.state === "playing" && restartLoopIfNeeded(activeSession, position.positionSeconds)) {
           setPlaybackDurationSeconds(position.durationSeconds || activeSession.durationHintSeconds || 0);

--- a/docs/MOBILE.md
+++ b/docs/MOBILE.md
@@ -164,9 +164,14 @@ It never falls back to the desktop HTTP backend at `127.0.0.1:8765`.
 
 iOS stores synced projects and their artifacts in its Tauri app-private data directory. Activity
 supports manual pairing and TCP sync with a trusted desktop peer; it does not start Iroh or nearby
-device discovery. Library shows synced project metadata. Import, processing, rich project readers,
-playback, evidence export, and QR pairing remain unavailable. Local-network permission copy comes
-from the source `Info.ios.plist`; no Bonjour or
+device discovery. Library shows synced project metadata and opens a constrained playback workspace
+for registered WAV source audio, practice mixes, and stems. Playback uses the shared native mixer at
+1.0x speed with play, pause, stop, seek, loop, mute, solo, and reset controls. Non-WAV artifacts stay
+stored unchanged and remain unavailable unless sync registered an existing WAV playback proxy.
+Suspending the app pauses playback, tears down output, retains the confirmed position, and requires
+an explicit Play after the app becomes active again. Import, processing, rich project readers,
+evidence export, and QR pairing remain unavailable. Local-network permission copy comes from the
+source `Info.ios.plist`; no Bonjour or
 multicast entitlement is required for manual TCP endpoints.
 
 For same-Mac simulator validation, start only the desktop listener, pair the simulator, then initiate


### PR DESCRIPTION
## Summary

- Enable native iOS simulator playback for registered WAV sources, practice mixes, and stems at 1.0x through the existing Android project UI and shared native mixer.
- Pause and destroy output on suspension, retain position, and require explicit Play on return. Reconcile the paused UI state so one tap resumes; this revision-handling exception applies only to iOS.

## Motivation

Final layer of #531, based on #535 (`feat/ios-project-sync`). Stack: #532 → #533 → #535 → this PR. Follows [#401's reviewed evidence](https://github.com/grazzolini/tuneforge/issues/401#issuecomment-5620176932).

Closes #531.

## Changes

- Reuse CPAL output, mixer, workers, session ownership, WAV decoding, seek, and loop behavior. Add narrow AVAudioSession lifecycle integration and validate registered app-private WAV/proxy paths and 1.0x rates before mutation.
- Reuse Library navigation, source/mix selection, stem Mute/Solo/Reset, and transport controls. Keep unsupported operations and formats unavailable without conversion or web-audio fallback; preserve desktop preferences.
- Preserve Android background playback and existing event handling. No HTTP/OpenAPI, schema, shared-type, or sync-wire changes. Update mobile docs, dependency notices, and changelog.
- Layer 4: production +547/-110 across 16 files; tests +191/-6; docs +14/-7; lockfile +6; no other generated churn. Handwritten total: 875 lines. Aggregate stack: 37 production files, 3,029 handwritten lines, 3,036 tracked-text lines, within revised approved limits.

## Testing

Commands used pinned pnpm 11.22.0, matching stable Rust tools, the configured Xcode developer directory, and the audited Android NDK/FFmpeg environment.

- `npm exec --yes --package=pnpm@11.22.0 -- pnpm lint` — pass.
- `npm exec --yes --package=pnpm@11.22.0 -- pnpm typecheck` — pass.
- Full workspace gate below passed before the final lifecycle repair: 908 frontend, 440 Rust, 824 backend tests, plus tooling suites. Final repair received focused reruns rather than another full workspace run.

```sh
fixture_root="$(mktemp -d)"
TUNEFORGE_DATA_DIR="$fixture_root/data" \
TUNEFORGE_SYNC_TRANSPORT_DATA_DIR="$fixture_root/sync" \
npm exec --yes --package=pnpm@11.22.0 -- pnpm test
```

- `npm exec --yes --package=pnpm@11.22.0 -- pnpm --dir apps/desktop exec vitest run src/App.mobile.test.tsx` — 35 passed, including one-tap iOS resume, stale/session rejection, and Android/desktop exclusion.
- `cargo test --manifest-path apps/desktop/src-tauri/Cargo.toml native_audio` — 135 passed before the lifecycle repair; final focused `native_audio::transport::tests::lifecycle_pause_releases_click_runtime_and_preserves_controls` rerun passed.
- `cargo check --manifest-path apps/desktop/src-tauri/Cargo.toml` and simulator-target check with `--target aarch64-apple-ios-sim` — pass.
- `TUNEFORGE_ANDROID_FFMPEG_ROOT="$PWD/packaging/ffmpeg/generated/android-arm64-v8a" bash scripts/android-arm64-env.sh rustup run stable cargo check --manifest-path apps/desktop/src-tauri/Cargo.toml --target aarch64-linux-android` — final Android regression compile passed.
- `npm exec --yes --package=pnpm@11.22.0 -- pnpm --filter @tuneforge/desktop ios:build:debug` — build/link/install/launch passed.
- Live simulator acceptance: audible playback, pause, seek, loop, source/mix/stems, Mute/Solo, suspension with retained position and no automatic resume, corrected one-tap resume, and restart persistence passed. Update preserved pairing, two projects, and all 12 artifact files; hashes, sizes, and canonical private paths verified.
- Correctness, contract, and UI reviews passed; `git diff --check` passed.

Proof limits: no physical-device, Bluetooth/hardware-route, distribution, background-audio, or real interruption guarantees. Actual AVAudioSession activation failure was not injected; failure cleanup used existing synthetic seams, with teardown ordering reviewed and valid output exercised live. Generic power-protection warning remains unchanged by request.

## Checklist

- [x] Conventional Commit title; one signed layer commit.
- [x] Lint, typecheck, workspace baseline, and final focused checks pass as detailed above.
- [x] Changelog, mobile docs, and dependency notices updated.
- [x] No backend contract changes requiring regeneration.
- [x] No secrets, personal media, generated build artifacts, or copyrighted audio added.
